### PR TITLE
Make leaf nodes (file fragments) use raw format rather than cbor.

### DIFF
--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -70,7 +70,9 @@ public class DHTHandler implements HttpHandler
                             .findAny()
                             .get();
                     List<byte[]> data = MultipartReceiver.extractFiles(httpExchange.getRequestBody(), boundary);
-                    dht.put(writer, data).thenAccept(hashes -> {
+                    boolean isRaw = last.apply("format").equals("raw");
+
+                    (isRaw ? dht.putRaw(writer, data) : dht.put(writer, data)).thenAccept(hashes -> {
                         List<Object> json = hashes.stream().map(h -> wrapHash(h)).collect(Collectors.toList());
                         // make stream of JSON objects
                         String jsonStream = json.stream().map(m -> JSONParser.toString(m)).reduce("", (a, b) -> a + b);

--- a/src/peergos/server/storage/IpfsDHT.java
+++ b/src/peergos/server/storage/IpfsDHT.java
@@ -30,8 +30,17 @@ public class IpfsDHT implements ContentAddressedStorage {
 
     @Override
     public CompletableFuture<List<Multihash>> put(PublicSigningKey writer, List<byte[]> blocks) {
+        return put(writer, blocks, "cbor");
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> putRaw(PublicSigningKey writer, List<byte[]> blocks) {
+        return put(writer, blocks, "raw");
+    }
+
+    private CompletableFuture<List<Multihash>> put(PublicSigningKey writer, List<byte[]> blocks, String format) {
         try {
-            return CompletableFuture.completedFuture(ipfs.block.put(blocks, Optional.of("cbor")))
+            return CompletableFuture.completedFuture(ipfs.block.put(blocks, Optional.of(format)))
                     .thenApply(nodes -> nodes.stream().map(n -> n.hash).collect(Collectors.toList()));
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -43,6 +52,16 @@ public class IpfsDHT implements ContentAddressedStorage {
         try {
             byte[] raw = ipfs.block.get(hash);
             return CompletableFuture.completedFuture(Optional.of(CborObject.fromByteArray(raw)));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Multihash hash) {
+        try {
+            byte[] raw = ipfs.block.get(hash);
+            return CompletableFuture.completedFuture(Optional.of(raw));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -34,6 +34,16 @@ public class RAMStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<List<Multihash>> putRaw(PublicSigningKey writer, List<byte[]> blocks) {
+        return put(writer, blocks);
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Multihash object) {
+        return CompletableFuture.completedFuture(Optional.of(storage.getOrDefault(object, new byte[0])));
+    }
+
+    @Override
     public CompletableFuture<Optional<CborObject>> get(Multihash object) {
         return CompletableFuture.completedFuture(Optional.of(getAndParseObject(object)));
     }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -255,6 +255,19 @@ public abstract class UserTests {
     }
 
     @Test
+    public void smallFileWrite() throws Exception {
+        String username = generateUsername();
+        String password = "test01";
+        UserContext context = ensureSignedUp(username, password, network, crypto);
+        FileTreeNode userRoot = context.getUserRoot().get();
+
+        String filename = "small.txt";
+        byte[] data = new byte[10];
+        userRoot.uploadFile(filename, new AsyncReader.ArrayBacked(data), data.length, context.network,
+                context.crypto.random, l -> {}, context.fragmenter()).get();
+    }
+
+    @Test
     public void mediumFileWrite() throws Exception {
         String username = generateUsername();
         String password = "test01";
@@ -264,7 +277,7 @@ public abstract class UserTests {
         String filename = "mediumfile.bin";
         byte[] data = new byte[0];
         userRoot.uploadFile(filename, new AsyncReader.ArrayBacked(data), data.length, context.network,
-                context.crypto.random, l -> {}, context.fragmenter());
+                context.crypto.random, l -> {}, context.fragmenter()).get();
 
         //overwrite with 2 chunk file
         byte[] data5 = new byte[10*1024*1024];

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -147,13 +147,13 @@ public class NetworkAccess {
     }
 
     private CompletableFuture<Multihash> uploadFragment(Fragment f, PublicSigningKey targetUser) {
-        return dhtClient.put(targetUser, new CborObject.CborByteArray(f.data).toByteArray());
+        return dhtClient.putRaw(targetUser, f.data);
     }
 
     private CompletableFuture<List<Multihash>> bulkUploadFragments(List<Fragment> fragments, PublicSigningKey targetUser) {
-        return dhtClient.put(targetUser, fragments
+        return dhtClient.putRaw(targetUser, fragments
                 .stream()
-                .map(f -> new CborObject.CborByteArray(f.data).toByteArray())
+                .map(f -> f.data)
                 .collect(Collectors.toList()));
     }
 
@@ -204,9 +204,9 @@ public class NetworkAccess {
 
     public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes, ProgressConsumer<Long> monitor, double spaceIncreaseFactor) {
         List<CompletableFuture<Optional<FragmentWithHash>>> futures = hashes.stream().parallel()
-                .map(h -> dhtClient.get(h)
+                .map(h -> dhtClient.getRaw(h)
                         .thenApply(dataOpt -> {
-                            Optional<byte[]> bytes = dataOpt.map(cbor -> ((CborObject.CborByteArray) cbor).value);
+                            Optional<byte[]> bytes = dataOpt;
                             bytes.ifPresent(arr -> monitor.accept((long)(arr.length / spaceIncreaseFactor)));
                             return bytes.map(data -> new FragmentWithHash(new Fragment(data), h));
                         }))


### PR DESCRIPTION
This means that pins will be MUCH faster, and we also save a few bytes.

This is a breaking change. So I won't merge/deploy this until I can batch it with a few other breaking changes.