### PR TITLE
Verify hashes on both gets and puts.

### DIFF
--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -41,7 +41,7 @@ public class NetworkAccess {
 
     public NetworkAccess(CoreNode coreNode, ContentAddressedStorage dhtClient, MutablePointers mutable, Btree btree, List<String> usernames, boolean isJavascript) {
         this.coreNode = coreNode;
-        this.dhtClient = dhtClient;
+        this.dhtClient = new HashVerifyingStorage(dhtClient);
         this.mutable = mutable;
         this.btree = btree;
         this.usernames = usernames;


### PR DESCRIPTION
This means we don't need to trust IPFS and our client doesn't need to
trust our server (except in the case of a web page, to deliver
the original JS).