### PR TITLE
Store and client-side-verify signatures

### DIFF
--- a/src/peergos/server/corenode/JDBCCoreNode.java
+++ b/src/peergos/server/corenode/JDBCCoreNode.java
@@ -587,19 +587,18 @@ public class JDBCCoreNode {
         }
     }
 
-    public CompletableFuture<Boolean> setPointer(PublicKeyHash owner, PublicKeyHash writerHash, byte[] bothHashes) {
-        MetadataBlob blob = new MetadataBlob(writerHash.serialize(), bothHashes);
+    public CompletableFuture<Boolean> setPointer(PublicKeyHash owner, PublicKeyHash writerHash, byte[] writingKeySignedHash) {
+        MetadataBlob blob = new MetadataBlob(writerHash.serialize(), writingKeySignedHash);
         return CompletableFuture.completedFuture(blob.insert());
     }
 
-    public CompletableFuture<MaybeMultihash> getPointer(PublicKeyHash writingKey) {
+    public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writingKey) {
         byte[] dummy = null;
         MetadataBlob blob = new MetadataBlob(writingKey.serialize(), dummy);
         MetadataBlob users = blob.selectOne();
         if (users == null)
-            return CompletableFuture.completedFuture(MaybeMultihash.EMPTY());
-        HashCasPair cas = HashCasPair.fromCbor(CborObject.fromByteArray(users.hash));
-        return CompletableFuture.completedFuture(cas.updated);
+            return CompletableFuture.completedFuture(Optional.empty());
+        return CompletableFuture.completedFuture(Optional.of(users.hash));
     }
 
     public synchronized void close()
@@ -637,5 +636,4 @@ public class JDBCCoreNode {
                 }
         }
     }
-
 }

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -98,7 +98,11 @@ public class UserRepository implements CoreNode, MutablePointers {
                                 HashCasPair cas = HashCasPair.fromCbor(CborObject.fromByteArray(bothHashes));
                                 MaybeMultihash claimedCurrentHash = cas.original;
                                 Multihash newHash = cas.updated.get();
-                                if (!current.equals(claimedCurrentHash))
+
+                                MaybeMultihash existing = current
+                                        .map(signed -> HashCasPair.fromCbor(CborObject.fromByteArray(writerKey.unsignMessage(signed))).updated)
+                                        .orElse(MaybeMultihash.EMPTY());
+                                if (! existing.equals(claimedCurrentHash))
                                     return CompletableFuture.completedFuture(false);
                                 if (LOGGING)
                                     System.out.println("Core::setMetadata for " + writer + " from " + current + " to " + newHash);

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -82,7 +82,7 @@ public class UserRepository implements CoreNode, MutablePointers {
     }
 
     @Override
-    public CompletableFuture<MaybeMultihash> getPointer(PublicKeyHash writer) {
+    public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writer) {
         return store.getPointer(writer);
     }
 
@@ -102,7 +102,7 @@ public class UserRepository implements CoreNode, MutablePointers {
                                     return CompletableFuture.completedFuture(false);
                                 if (LOGGING)
                                     System.out.println("Core::setMetadata for " + writer + " from " + current + " to " + newHash);
-                                return store.setPointer(owner, writer, bothHashes);
+                                return store.setPointer(owner, writer, writerSignedBtreeRootHash);
                             } catch (TweetNaCl.InvalidSignatureException e) {
                                 System.err.println("Invalid signature during setMetadataBlob for sharer: " + writer);
                                 return CompletableFuture.completedFuture(false);

--- a/src/peergos/server/mutable/HttpMutablePointerServer.java
+++ b/src/peergos/server/mutable/HttpMutablePointerServer.java
@@ -3,11 +3,8 @@ package peergos.server.mutable;
 import com.sun.net.httpserver.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.merklebtree.*;
 import peergos.shared.mutable.*;
-import peergos.shared.util.*;
 
 import java.io.*;
 import java.net.*;
@@ -93,9 +90,9 @@ public class HttpMutablePointerServer
         void getPointer(DataInputStream din, DataOutputStream dout) throws Exception
         {
             PublicKeyHash encodedSharingKey = PublicKeyHash.fromCbor(CborObject.deserialize(new CborDecoder(din)));
-            MaybeMultihash metadataBlob = mutable.getPointer(encodedSharingKey).get();
+            byte[] metadataBlob = mutable.getPointer(encodedSharingKey).get().orElse(new byte[0]);
 
-            dout.write(metadataBlob.serialize());
+            dout.write(metadataBlob);
         }
     }
 

--- a/src/peergos/server/mutable/PinningMutablePointers.java
+++ b/src/peergos/server/mutable/PinningMutablePointers.java
@@ -1,7 +1,6 @@
 package peergos.server.mutable;
 
 import peergos.shared.cbor.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multiaddr.*;
@@ -73,7 +72,7 @@ public class PinningMutablePointers implements MutablePointers {
     }
 
     @Override
-    public CompletableFuture<MaybeMultihash> getPointer(PublicKeyHash encodedSharingKey) {
-        return target.getPointer(encodedSharingKey);
+    public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writer) {
+        return target.getPointer(writer);
     }
 }

--- a/src/peergos/shared/mutable/CachingPointers.java
+++ b/src/peergos/shared/mutable/CachingPointers.java
@@ -15,7 +15,7 @@ public class CachingPointers implements MutablePointers {
 
     private final MutablePointers target;
     private final int cacheTTL;
-    private final Map<PublicKeyHash, Pair<MaybeMultihash, Long>> cache = new HashMap<>();
+    private final Map<PublicKeyHash, Pair<Optional<byte[]>, Long>> cache = new HashMap<>();
 
     public CachingPointers(MutablePointers target, int cacheTTL) {
         this.target = target;
@@ -23,9 +23,9 @@ public class CachingPointers implements MutablePointers {
     }
 
     @Override
-    public CompletableFuture<MaybeMultihash> getPointer(PublicKeyHash writer) {
+    public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writer) {
         synchronized (cache) {
-            Pair<MaybeMultihash, Long> cached = cache.get(writer);
+            Pair<Optional<byte[]>, Long> cached = cache.get(writer);
             if (cached != null && System.currentTimeMillis() - cached.right < cacheTTL)
                 return CompletableFuture.completedFuture(cached.left);
         }

--- a/src/peergos/shared/mutable/HttpMutablePointers.java
+++ b/src/peergos/shared/mutable/HttpMutablePointers.java
@@ -1,12 +1,7 @@
 
 package peergos.shared.mutable;
 
-import peergos.shared.cbor.*;
-import peergos.shared.corenode.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.io.ipfs.api.*;
-import peergos.shared.merklebtree.*;
 import peergos.shared.user.*;
 import peergos.shared.util.*;
 
@@ -63,15 +58,15 @@ public class HttpMutablePointers implements MutablePointers
     }
 
     @Override
-    public CompletableFuture<MaybeMultihash> getPointer(PublicKeyHash encodedSharingKey)
+    public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writer)
     {
         long t1 = System.currentTimeMillis();
         try {
-            return poster.postUnzip("mutable/getPointer", encodedSharingKey.serialize())
-                    .thenApply(meta -> MaybeMultihash.fromCbor(CborObject.fromByteArray(meta)));
+            return poster.postUnzip("mutable/getPointer", writer.serialize())
+                    .thenApply(meta -> meta.length == 0 ? Optional.empty() : Optional.of(meta));
         } catch (Exception ioe) {
             ioe.printStackTrace();
-            return CompletableFuture.completedFuture(MaybeMultihash.EMPTY());
+            return CompletableFuture.completedFuture(Optional.empty());
         } finally {
             long t2 = System.currentTimeMillis();
             if (LOGGING)

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -1,8 +1,9 @@
 package peergos.shared.mutable;
 
 import peergos.shared.crypto.hash.*;
-import peergos.shared.merklebtree.*;
+import peergos.shared.crypto.asymmetric.*;
 
+import java.util.*;
 import java.util.concurrent.*;
 
 public interface MutablePointers {
@@ -18,8 +19,8 @@ public interface MutablePointers {
 
     /** Get the current hash a public key maps to
      *
-     * @param encodedSharingKey
+     * @param writer
      * @return
      */
-    CompletableFuture<MaybeMultihash> getPointer(PublicKeyHash encodedSharingKey);
+    CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writer);
 }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1046,12 +1046,16 @@ public class UserContext {
                 });
     }
 
-    private static CompletableFuture<Pair<Multihash, CborObject>> getWriterDataCbor(NetworkAccess network, PublicKeyHash signer) {
-        return network.mutable.getPointer(signer)
-                .thenCompose(key -> network.dhtClient.get(key.get())
-                        .thenApply(Optional::get)
-                        .thenApply(cbor -> new Pair<>(key.get(), cbor))
-                );
+    private static CompletableFuture<Pair<Multihash, CborObject>> getWriterDataCbor(NetworkAccess network, PublicKeyHash signerHash) {
+        return network.mutable.getPointer(signerHash)
+                .thenCompose(casOpt -> network.dhtClient.getSigningKey(signerHash)
+                        .thenApply(signer -> casOpt.map(raw -> HashCasPair.fromCbor(CborObject.fromByteArray(
+                                signer.get().unsignMessage(raw))).updated)
+                                .orElse(MaybeMultihash.EMPTY())))
+                        .thenCompose(key -> network.dhtClient.get(key.get())
+                                .thenApply(Optional::get)
+                                .thenApply(cbor -> new Pair<>(key.get(), cbor))
+                        );
     }
 
     @JsMethod


### PR DESCRIPTION
This stores the signatures of MutablePointer writes, and verifies them client side.

This removes any trust in IPNS/ the corenode.

This is a breaking change