### PR TITLE
Keep track of expired username claims in tofu keystore.

### DIFF
--- a/src/peergos/server/RenewUsernameClaim.java
+++ b/src/peergos/server/RenewUsernameClaim.java
@@ -1,0 +1,31 @@
+package peergos.server;
+
+import peergos.shared.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.random.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+public class RenewUsernameClaim {
+
+    public static void main(String[] args) throws Exception {
+        Crypto crypto = Crypto.initJava();
+        NetworkAccess network = NetworkAccess.buildJava(new URL("https://demo.peergos.net")).get();
+        String username = args[0];
+        String password = args[1];
+
+        LocalDate expiry = LocalDate.now().plusMonths(2);
+        UserContext context = UserContext.signIn(username, password, network, crypto).get();
+        boolean isExpired = context.usernameIsExpired().get();
+        if (isExpired)
+            System.out.println(context.renewUsernameClaim(expiry).get() ? "Renewed username" : "Failed to renew username");
+    }
+}

--- a/src/peergos/server/corenode/JDBCCoreNode.java
+++ b/src/peergos/server/corenode/JDBCCoreNode.java
@@ -415,6 +415,8 @@ public class JDBCCoreNode implements CoreNode, MutablePointers {
     @Override
     public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> tail) {
         UserPublicKeyLink.validChain(tail, username);
+        if (UserPublicKeyLink.isExpiredClaim(tail.get(tail.size() - 1)))
+            return CompletableFuture.completedFuture(false);
 
         if (tail.size() > 2)
             return CompletableFuture.completedFuture(false);

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -212,12 +212,15 @@ public class UserPublicKeyLink implements Cborable{
         return result;
     }
 
-    public static void validChain(List<UserPublicKeyLink> chain, String username) {
+    public static boolean validChain(List<UserPublicKeyLink> chain, String username) {
         for (int i=0; i < chain.size()-1; i++)
             if (!validLink(chain.get(i), chain.get(i+1).owner, username))
-                throw new IllegalStateException("Invalid public key chain link!");
-        if (!validClaim(chain.get(chain.size()-1), username))
-            throw new IllegalStateException("Invalid username claim!");
+                return false;
+        UserPublicKeyLink last = chain.get(chain.size() - 1);
+        if (!validClaim(last, username)) {
+            return false;
+        }
+        return true;
     }
 
     static boolean validLink(UserPublicKeyLink from, PublicSigningKey target, String username) {
@@ -239,9 +242,12 @@ public class UserPublicKeyLink implements Cborable{
             return false;
         if (username.length() > MAX_USERNAME_SIZE)
             return false;
-        if (!from.claim.username.equals(username) || from.claim.expiry.isBefore(LocalDate.now()))
+        if (!from.claim.username.equals(username))
             return false;
         return true;
     }
 
+    public static boolean isExpiredClaim(UserPublicKeyLink from) {
+        return from.claim.expiry.isBefore(LocalDate.now());
+    }
 }

--- a/src/peergos/shared/user/TofuKeyStore.java
+++ b/src/peergos/shared/user/TofuKeyStore.java
@@ -5,20 +5,23 @@ import peergos.shared.corenode.*;
 import peergos.shared.crypto.asymmetric.*;
 
 import java.util.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class TofuKeyStore implements Cborable {
 
     private final Map<String, List<UserPublicKeyLink>> chains;
+    private final Map<String, List<UserPublicKeyLink>> expired;
     private final Map<PublicSigningKey, String> reverseLookup = new HashMap<>();
 
-    public TofuKeyStore(Map<String, List<UserPublicKeyLink>> chains) {
+    public TofuKeyStore(Map<String, List<UserPublicKeyLink>> chains, Map<String, List<UserPublicKeyLink>> expired) {
         this.chains = chains;
+        this.expired = expired;
         updateReverseLookup();
     }
 
     public TofuKeyStore() {
-        this(new HashMap<>());
+        this(new HashMap<>(), new HashMap<>());
     }
 
     public Optional<PublicSigningKey> getPublicKey(String username) {
@@ -34,17 +37,35 @@ public class TofuKeyStore implements Cborable {
     }
 
     public List<UserPublicKeyLink> getChain(String username) {
-        return chains.getOrDefault(username, Collections.emptyList());
+        return chains.getOrDefault(username, expired.getOrDefault(username, Collections.emptyList()));
     }
 
     public void updateChain(String username, List<UserPublicKeyLink> tail) {
         UserPublicKeyLink.validChain(tail, username);
+        UserPublicKeyLink last = tail.get(tail.size() - 1);
+        // we are allowing expired chains to be stored
 
         List<UserPublicKeyLink> existing = getChain(username);
-        List<UserPublicKeyLink> merged = UserPublicKeyLink.merge(existing, tail);
-        chains.put(username, merged);
-        PublicSigningKey owner = tail.get(tail.size() - 1).owner;
-        reverseLookup.put(owner, username);
+        boolean existingExpired =
+                (existing.size() > 0 && UserPublicKeyLink.isExpiredClaim(existing.get(existing.size() - 1))) ||
+                        expired.containsKey(username);
+        if (existingExpired) {
+            List<UserPublicKeyLink> expiredChain = expired.getOrDefault(username, existing);
+            List<UserPublicKeyLink> withoutExpiredClaim = expiredChain.subList(0, expiredChain.size() - 1);
+            if (withoutExpiredClaim.size() == 0 && ! expiredChain.get(0).owner.equals(tail.get(0).owner))
+                throw new IllegalStateException("Trying to update a username claim with a different key!");
+
+            List<UserPublicKeyLink> merged = UserPublicKeyLink.merge(withoutExpiredClaim, tail);
+            chains.put(username, merged);
+            expired.remove(username);
+            PublicSigningKey owner = last.owner;
+            reverseLookup.put(owner, username);
+        } else {
+            List<UserPublicKeyLink> merged = UserPublicKeyLink.merge(existing, tail);
+            chains.put(username, merged);
+            PublicSigningKey owner = last.owner;
+            reverseLookup.put(owner, username);
+        }
     }
 
     private void updateReverseLookup() {
@@ -58,10 +79,12 @@ public class TofuKeyStore implements Cborable {
     @Override
     public CborObject toCbor() {
         SortedMap<CborObject, CborObject> state = new TreeMap<>();
-        chains.forEach((name, chain) -> state.put(new CborObject.CborString(name),
+        Consumer<Map<String, List<UserPublicKeyLink>>> serialise = map -> map.forEach((name, chain) -> state.put(new CborObject.CborString(name),
                 new CborObject.CborList(chain.stream()
                         .map(link -> link.toCbor())
                         .collect(Collectors.toList()))));
+        serialise.accept(chains);
+        serialise.accept(expired);
         return new CborObject.CborMap(state);
     }
 
@@ -70,6 +93,7 @@ public class TofuKeyStore implements Cborable {
             throw new IllegalStateException("Invalid cbor for Tofu key store: " + cbor);
 
         Map<String, List<UserPublicKeyLink>> chains = new HashMap<>();
+        Map<String, List<UserPublicKeyLink>> expired = new HashMap<>();
         SortedMap<CborObject, CborObject> values = ((CborObject.CborMap) cbor).values;
         for (CborObject key: values.keySet()) {
             if (key instanceof CborObject.CborString) {
@@ -79,11 +103,15 @@ public class TofuKeyStore implements Cborable {
                     List<UserPublicKeyLink> chain = ((CborObject.CborList) value).value.stream()
                             .map(UserPublicKeyLink::fromCbor)
                             .collect(Collectors.toList());
-                    UserPublicKeyLink.validChain(chain, name);
-                    chains.put(name, chain);
+                    if (UserPublicKeyLink.validChain(chain, name)) {
+                        if (UserPublicKeyLink.isExpiredClaim(chain.get(chain.size() - 1)))
+                            expired.put(name, chain);
+                        else
+                            chains.put(name, chain);
+                    }
                 } else throw new IllegalStateException("Invalid value in Tofu key store map: " + value);
             } else throw new IllegalStateException("Invalid key in Tofu key store map: " + key);
         }
-        return new TofuKeyStore(chains);
+        return new TofuKeyStore(chains, expired);
     }
 }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -87,8 +87,14 @@ public class UserContext {
                                                                 CompletableFuture.completedFuture(new CommittedWriterData(MaybeMultihash.of(pair.left), userData)),
                                                                 root);
                                                         tofu.setContext(result);
-                                                        System.out.println("Initializing context..");
-                                                        return result.init();
+                                                        return result.usernameIsExpired()
+                                                                .thenCompose(expired -> expired ?
+                                                                        result.renewUsernameClaim(LocalDate.now().plusMonths(2)) :
+                                                                        CompletableFuture.completedFuture(true))
+                                                                .thenCompose(x -> {
+                                                                    System.out.println("Initializing context..");
+                                                                    return result.init();
+                                                                });
                                                     }));
                                 } catch (Throwable t) {
                                     throw new IllegalStateException("Incorrect password");
@@ -102,7 +108,11 @@ public class UserContext {
         return signUpGeneral(username, password, network, crypto, UserGenerationAlgorithm.getDefault());
     }
 
-    public static CompletableFuture<UserContext> signUpGeneral(String username, String password, NetworkAccess network, Crypto crypto, UserGenerationAlgorithm algorithm) {
+    public static CompletableFuture<UserContext> signUpGeneral(String username,
+                                                               String password,
+                                                               NetworkAccess network,
+                                                               Crypto crypto,
+                                                               UserGenerationAlgorithm algorithm) {
         return UserUtil.generateUser(username, password, crypto.hasher, crypto.symmetricProvider, crypto.random, crypto.signer, crypto.boxer, algorithm)
                 .thenCompose(userWithRoot -> {
                     WriterData newUserData = WriterData.createEmpty(Optional.of(userWithRoot.getBoxingPair().publicBoxingKey), userWithRoot.getRoot());
@@ -234,6 +244,21 @@ public class UserContext {
             List<UserPublicKeyLink> claimChain = UserPublicKeyLink.createInitial(signer, this.username, expiry);
             return network.coreNode.updateChain(this.username, claimChain);
         });
+    }
+
+    public CompletableFuture<Boolean> usernameIsExpired() {
+        return network.coreNode.getChain(username)
+                .thenApply(chain -> UserPublicKeyLink.isExpiredClaim(chain.get(chain.size() - 1)));
+    }
+
+    public CompletableFuture<Boolean> renewUsernameClaim(LocalDate expiry) {
+        return renewUsernameClaim(username, signer, expiry, network);
+    }
+
+    public static CompletableFuture<Boolean> renewUsernameClaim(String username, SigningKeyPair signer, LocalDate expiry, NetworkAccess network) {
+        System.out.println("renewing username: " + username + " with expiry " + expiry);
+        List<UserPublicKeyLink> claimChain = UserPublicKeyLink.createInitial(signer, username, expiry);
+        return network.coreNode.updateChain(username, claimChain);
     }
 
     @JsMethod


### PR DESCRIPTION
Auto renew username on login if it has expired (this need more testing)
Separate keychain validity from expiry.

This needs a solid review. Particularly for the security implications. 