### PR TITLE
Rename privacy for unshared files

### DIFF
--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -178,7 +178,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
                 Optional<FileTreeNode> renamedOriginal = context.getByPath(renamedInPlacePath.toString()).get();;
                 if (!renamedOriginal.isPresent())
                     return 1;
-                renamedOriginal.get().copyTo(newParent.get(), context.network, context.crypto.random).get();
+                renamedOriginal.get().copyTo(newParent.get(), context.network, context.crypto.random, context.fragmenter()).get();
                 boolean removed = source.treeNode.remove(context.network, parent).get();
                 if (!removed)
                     return 1;

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -11,6 +11,7 @@ import peergos.shared.crypto.symmetric.*;
 import peergos.server.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.*;
 
 import java.io.*;
@@ -273,7 +274,7 @@ public class MultiUserTests {
         String friendsPathToFile = u1.username + "/" + filename;
         Optional<FileTreeNode> priorUnsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         FilePointer priorPointer = priorUnsharedView.get().getPointer().filePointer;
-        FileAccess priorFileAccess = network.getMetadata(priorPointer.getLocation()).get().get();
+        CryptreeNode priorFileAccess = network.getMetadata(priorPointer.getLocation()).get().get();
         SymmetricKey priorMetaKey = priorFileAccess.getMetaKey(priorPointer.baseKey);
 
         // unshare with a single user
@@ -287,7 +288,7 @@ public class MultiUserTests {
         Optional<FileTreeNode> unsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         String friendsNewPathToFile = u1.username + "/" + newname;
         Optional<FileTreeNode> unsharedView2 = userToUnshareWith.getByPath(friendsNewPathToFile).get();
-        FileAccess fileAccess = network.getMetadata(priorPointer.getLocation()).get().get();
+        CryptreeNode fileAccess = network.getMetadata(priorPointer.getLocation()).get().get();
         try {
             // Try decrypting the new metadata with the old key
             byte[] properties = ((CborObject.CborByteArray) ((CborObject.CborList) fileAccess.toCbor()).value.get(1)).value;
@@ -297,7 +298,7 @@ public class MultiUserTests {
             throw new IllegalStateException("We shouldn't be able to decrypt this after a rename! new name = " + props.name);
         } catch (TweetNaCl.InvalidCipherTextException e) {}
         try {
-            FileProperties freshProperties = fileAccess.getFileProperties(priorPointer.baseKey);
+            FileProperties freshProperties = fileAccess.getProperties(priorPointer.baseKey);
             throw new IllegalStateException("We shouldn't be able to decrypt this after a rename!");
         } catch (TweetNaCl.InvalidCipherTextException e) {}
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -171,6 +171,55 @@ public class MultiUserTests {
     }
 
     @Test
+    public void safeCopyOfFriendsFile() throws Exception {
+        UserContext u1 = UserTests.ensureSignedUp("a", "a", network.clear(), crypto);
+        UserContext u2 = UserTests.ensureSignedUp("b", "b", network.clear(), crypto);
+
+        // send follow requests from each other user to "a"
+        u2.sendFollowRequest(u1.username, SymmetricKey.random()).get();
+
+        // make "a" reciprocate all the follow requests
+        List<FollowRequest> u1Requests = u1.processFollowRequests().get();
+        for (FollowRequest u1Request : u1Requests) {
+            boolean accept = true;
+            boolean reciprocate = true;
+            u1.sendReplyFollowRequest(u1Request, accept, reciprocate).get();
+        }
+
+        // complete the friendship connection
+        u2.processFollowRequests().get();//needed for side effect
+
+        // upload a file to "a"'s space
+        FileTreeNode u1Root = u1.getUserRoot().get();
+        String filename = "somefile.txt";
+        byte[] data = UserTests.randomData(10*1024*1024);
+
+        boolean uploaded = u1Root.uploadFile(filename, new AsyncReader.ArrayBacked(data), data.length,
+                u1.network, u1.crypto.random,l -> {}, u1.fragmenter()).get();
+
+        // share the file from "a" to each of the others
+        FileTreeNode u1File = u1.getByPath(u1.username + "/" + filename).get().get();
+        u1.shareWith(Paths.get(u1.username, filename), Collections.singleton(u2.username)).get();
+
+        // check other user can read the file
+        FileTreeNode sharedFile = u2.getByPath(u1.username + "/" + filename).get().get();
+        String dirname = "adir";
+        u2.getUserRoot().get().mkdir(dirname, network, false, crypto.random).get();
+        FileTreeNode targetDir = u2.getByPath(Paths.get(u2.username, dirname).toString()).get().get();
+
+        // copy the friend's file to our own space, this should reupload the file encrypted with a new key
+        // this prevents us exposing to the network our social graph by the fact that we pin the same file fragments
+        sharedFile.copyTo(targetDir, network, crypto.random, u2.fragmenter()).get();
+        FileTreeNode copy = u2.getByPath(Paths.get(u2.username, dirname, filename).toString()).get().get();
+
+        // check that the copied file has the correct contents
+        UserTests.checkFileContents(data, copy, u2);
+        Assert.assertTrue("Different base key", ! copy.getPointer().filePointer.baseKey.equals(u1File.getPointer().filePointer.baseKey));
+        Assert.assertTrue("Different metadata key", ! UserTests.getMetaKey(copy).equals(UserTests.getMetaKey(u1File)));
+        Assert.assertTrue("Different data key", ! UserTests.getDataKey(copy).equals(UserTests.getDataKey(u1File)));
+    }
+
+    @Test
     public void cleanRenamedFiles() throws Exception {
         UserContext u1 = UserTests.ensureSignedUp("a", "a", network.clear(), crypto);
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -417,7 +417,7 @@ public abstract class UserTests {
         }
     }
 
-    private static void checkFileContents(byte[] expected, FileTreeNode f, UserContext context) throws Exception {
+    public static void checkFileContents(byte[] expected, FileTreeNode f, UserContext context) throws Exception {
         byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto.random,
                 f.getFileProperties().size, l-> {}).get(), f.getSize()).get();
         assertTrue("Correct contents", Arrays.equals(retrievedData, expected));
@@ -591,7 +591,7 @@ public abstract class UserTests {
         String foldername = "afolder";
         userRoot.mkdir(foldername, network, false, crypto.random).get();
         FileTreeNode subfolder = context.getByPath(home.resolve(foldername).toString()).get().get();
-        FileTreeNode parentDir = original.copyTo(subfolder, network, crypto.random).get();
+        FileTreeNode parentDir = original.copyTo(subfolder, network, crypto.random, context.fragmenter()).get();
         FileTreeNode copy = context.getByPath(home.resolve(foldername).resolve(filename).toString()).get().get();
         Assert.assertTrue("Different base key", ! copy.getPointer().filePointer.baseKey.equals(original.getPointer().filePointer.baseKey));
         Assert.assertTrue("Different metadata key", ! getMetaKey(copy).equals(getMetaKey(original)));
@@ -599,11 +599,11 @@ public abstract class UserTests {
         checkFileContents(data, copy, context);
     }
 
-    private static SymmetricKey getDataKey(FileTreeNode file) {
+    public static SymmetricKey getDataKey(FileTreeNode file) {
         return file.getPointer().fileAccess.getDataKey(file.getPointer().filePointer.baseKey);
     }
 
-    private static SymmetricKey getMetaKey(FileTreeNode file) {
+    public static SymmetricKey getMetaKey(FileTreeNode file) {
         return file.getPointer().fileAccess.getMetaKey(file.getPointer().filePointer.baseKey);
     }
 
@@ -662,11 +662,12 @@ public abstract class UserTests {
         return UUID.randomUUID().toString();
     }
 
-    private static byte[] randomData(int length) {
+    public static byte[] randomData(int length) {
         byte[] data = new byte[length];
         random.nextBytes(data);
         return data;
     }
+
     private static Path TMP_DIR = Paths.get("test","resources","tmp");
 
     private static void ensureTmpDir() {

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -602,7 +602,7 @@ public abstract class UserTests {
     }
 
     public static SymmetricKey getDataKey(FileTreeNode file) {
-        return file.getPointer().fileAccess.getDataKey(file.getPointer().filePointer.baseKey);
+        return ((FileAccess)file.getPointer().fileAccess).getDataKey(file.getPointer().filePointer.baseKey);
     }
 
     public static SymmetricKey getMetaKey(FileTreeNode file) {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -115,7 +115,7 @@ public class NetworkAccess {
                                 Optional<CborObject> result = Optional.empty();
                                 return CompletableFuture.completedFuture(result);
                             }).thenApply(dataOpt ->  dataOpt
-                                    .map(cbor -> new RetrievedFilePointer(link.toReadableFilePointer(baseKey), FileAccess.fromCbor(cbor))));
+                                    .map(cbor -> new RetrievedFilePointer(link.toReadableFilePointer(baseKey), CryptreeNode.fromCbor(cbor))));
                 }).collect(Collectors.toList());
 
         return Futures.combineAll(all).thenApply(optSet -> optSet.stream()
@@ -139,12 +139,12 @@ public class NetworkAccess {
                         e.readers, e.writers, e.pointer.writer)));
     }
 
-    private CompletableFuture<Optional<FileAccess>> downloadEntryPoint(EntryPoint entry) {
+    private CompletableFuture<Optional<CryptreeNode>> downloadEntryPoint(EntryPoint entry) {
         // download the metadata blob for this entry point
         return btree.get(entry.pointer.location.writer, entry.pointer.location.getMapKey()).thenCompose(btreeValue -> {
             if (btreeValue.isPresent())
                 return dhtClient.get(btreeValue.get())
-                        .thenApply(value -> value.map(FileAccess::fromCbor));
+                        .thenApply(value -> value.map(CryptreeNode::fromCbor));
             return CompletableFuture.completedFuture(Optional.empty());
         });
     }

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -15,6 +15,7 @@ import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.*;
 
 import java.net.*;
@@ -180,7 +181,7 @@ public class NetworkAccess {
                         .collect(Collectors.toList()));
     }
 
-    public CompletableFuture<Boolean> uploadChunk(FileAccess metadata, Location location, SigningPrivateKeyAndPublicHash writer) {
+    public CompletableFuture<Boolean> uploadChunk(CryptreeNode metadata, Location location, SigningPrivateKeyAndPublicHash writer) {
         if (! writer.publicKeyHash.equals(location.writer))
             throw new IllegalStateException("Non matching location writer and signing writer key!");
         try {
@@ -193,14 +194,14 @@ public class NetworkAccess {
         }
     }
 
-    public CompletableFuture<Optional<FileAccess>> getMetadata(Location loc) {
+    public CompletableFuture<Optional<CryptreeNode>> getMetadata(Location loc) {
         if (loc == null)
             return CompletableFuture.completedFuture(Optional.empty());
         return btree.get(loc.writer, loc.getMapKey()).thenCompose(blobHash -> {
             if (!blobHash.isPresent())
                 return CompletableFuture.completedFuture(Optional.empty());
             return dhtClient.get(blobHash.get())
-                    .thenApply(rawOpt -> rawOpt.map(FileAccess::fromCbor));
+                    .thenApply(rawOpt -> rawOpt.map(CryptreeNode::fromCbor));
         });
     }
 

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -3,20 +3,26 @@ package peergos.shared.user.fs;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
-import peergos.shared.user.*;
 import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.*;
 
-import java.io.*;
 import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.*;
 
+/** A DirAccess cryptree node controls read access to a directory.
+ *
+ * It contains the following distinct keys {base, parent, files, metadata}
+ * The serialized encrypted form stores links from the base key to the other keys. With the base key one can decrypt
+ * all the remaining keys. The base key is also known as the sub folders key as it encrypts the links to child
+ * directories. The files key encrypts the links to all the child files. The parent key encrypts the link to the
+ * parent's parent key. The metadata key encrypts the name of the directory.
+ *
+ */
 public class DirAccess implements CryptreeNode {
 
     public static final int MAX_CHILD_LINKS_PER_BLOB = 500;

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -442,6 +442,7 @@ public class DirAccess extends FileAccess {
                 SymmetricLink.fromPair(subfoldersKey, parentKey),
                 new ArrayList<>(), new ArrayList<>(),
                 SymmetricLink.fromPair(parentKey, metaKey),
+                // directories don't have any data, so they can always have a null data key
                 SymmetricLink.fromPair(parentKey, SymmetricKey.createNull()),
                 ArrayOps.concat(metaNonce, metaKey.encrypt(metadata.serialize(), metaNonce)),
                 null,

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -221,14 +221,13 @@ public class DirAccess extends FileAccess {
     public CompletableFuture<Boolean> updateChildLink(FilePointer ourPointer, RetrievedFilePointer original,
                                                       RetrievedFilePointer modified, SigningPrivateKeyAndPublicHash signer,
                                                       NetworkAccess network, SafeRandom random) {
-        removeChild(original, ourPointer, signer, network);
-        CompletableFuture<DirAccess> toUpdate;
-        if (modified.fileAccess.isDirectory())
-            toUpdate = addSubdirAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
-        else {
-            toUpdate = addFileAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
-        }
-        return toUpdate.thenCompose(newDirAccess -> network.uploadChunk(newDirAccess, ourPointer.getLocation(), signer));
+        return removeChild(original, ourPointer, signer, network)
+                .thenCompose(res -> {
+                    if (modified.fileAccess.isDirectory())
+                        return addSubdirAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
+                    else
+                        return addFileAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
+                }).thenApply(x -> true);
     }
 
     public CompletableFuture<Boolean> removeChild(RetrievedFilePointer childRetrievedPointer, FilePointer ourPointer,

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -124,12 +124,14 @@ public class DirAccess implements CryptreeNode {
                 .stream()
                 .map(SymmetricLocationLink::fromCbor)
                 .collect(Collectors.toList());
-        List<SymmetricLocationLink> files = ((CborObject.CborList)value.get(3)).value
+        List<SymmetricLocationLink> files = ((CborObject.CborList)value.get(index++)).value
                 .stream()
                 .map(SymmetricLocationLink::fromCbor)
                 .collect(Collectors.toList());
-        Optional<SymmetricLocationLink> moreFolderContents = value.get(4) instanceof CborObject.CborNull ?
-                Optional.empty() : Optional.of(SymmetricLocationLink.fromCbor(value.get(4)));
+        CborObject linkToNext = value.get(index++);
+        Optional<SymmetricLocationLink> moreFolderContents = linkToNext instanceof CborObject.CborNull ?
+                Optional.empty() :
+                Optional.of(SymmetricLocationLink.fromCbor(linkToNext));
         return new DirAccess(version, subfoldersToFiles, subfoldersToParent, parentToMeta, parentLink,
                 properties, subfolders, files, moreFolderContents);
     }

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -25,9 +25,12 @@ public class DirAccess extends FileAccess {
     private final Optional<SymmetricLocationLink> moreFolderContents;
 
     public DirAccess(SymmetricLink subfolders2files, SymmetricLink subfolders2parent, List<SymmetricLocationLink> subfolders,
-                     List<SymmetricLocationLink> files, SymmetricLink parent2meta, byte[] properties,
+                     List<SymmetricLocationLink> files,
+                     SymmetricLink parent2meta,
+                     SymmetricLink parent2data,
+                     byte[] properties,
                      FileRetriever retriever, SymmetricLocationLink parentLink, Optional<SymmetricLocationLink> moreFolderContents) {
-        super(parent2meta, properties, retriever, parentLink);
+        super(parent2meta, parent2data, properties, retriever, parentLink);
         this.subfolders2files = subfolders2files;
         this.subfolders2parent = subfolders2parent;
         this.subfolders = subfolders;
@@ -36,8 +39,8 @@ public class DirAccess extends FileAccess {
     }
 
     public DirAccess withNextBlob(Optional<SymmetricLocationLink> moreFolderContents) {
-        return new DirAccess(subfolders2files, subfolders2parent, subfolders, files, parent2meta, properties,
-                retriever, parentLink, moreFolderContents);
+        return new DirAccess(subfolders2files, subfolders2parent, subfolders, files,
+                parent2meta, parent2data, properties, retriever, parentLink, moreFolderContents);
     }
 
     @Override
@@ -77,7 +80,7 @@ public class DirAccess extends FileAccess {
         Optional<SymmetricLocationLink> moreFolderContents = value.get(4) instanceof CborObject.CborNull ?
                 Optional.empty() : Optional.of(SymmetricLocationLink.fromCbor(value.get(4)));
         return new DirAccess(subfoldersToFiles, subfoldersToParent, subfolders, files,
-                base.parent2meta, base.properties, base.retriever, base.parentLink, moreFolderContents);
+                base.parent2meta, base.parent2data, base.properties, base.retriever, base.parentLink, moreFolderContents);
     }
 
     public List<SymmetricLocationLink> getSubfolders() {
@@ -100,7 +103,7 @@ public class DirAccess extends FileAccess {
         metaKey = this.getMetaKey(parentKey);
         byte[] metaNonce = metaKey.createNonce();
         DirAccess dira = new DirAccess(this.subfolders2files, this.subfolders2parent,
-                this.subfolders, this.files, this.parent2meta,
+                this.subfolders, this.files, this.parent2meta, this.parent2data,
                 ArrayOps.concat(metaNonce, metaKey.encrypt(newProps.serialize(), metaNonce)),
                 null,
                 parentLink,
@@ -440,6 +443,7 @@ public class DirAccess extends FileAccess {
                 SymmetricLink.fromPair(subfoldersKey, parentKey),
                 new ArrayList<>(), new ArrayList<>(),
                 SymmetricLink.fromPair(parentKey, metaKey),
+                SymmetricLink.fromPair(parentKey, SymmetricKey.createNull()),
                 ArrayOps.concat(metaNonce, metaKey.encrypt(metadata.serialize(), metaNonce)),
                 null,
                 parentLink,

--- a/src/peergos/shared/user/fs/FileAccess.java
+++ b/src/peergos/shared/user/fs/FileAccess.java
@@ -12,6 +12,16 @@ import peergos.shared.util.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+/** A FileAccess cryptree node controls read access to a section of a file, up to 5 MiB in size.
+ *
+ * It contains the following distinct keys {base, metadata, data}
+ * The serialized encrypted form stores links from the base key to the other keys. With the base key one can decrypt
+ * all the remaining keys. The base key is also the parent key. The parent key encrypts the link to the parent's parent
+ * key. The metadata key encrypts the name, size, thumbnail, modification times  and any other properties of the file.
+ *
+ * The file retriever contains the merkle links to the encrypted file fragments of this file section, an optional
+ * erasure coding scheme, nonce and auth for this section as well as an encrypted link to the next section.
+ */
 public class FileAccess implements CryptreeNode {
 
     protected final int version;

--- a/src/peergos/shared/user/fs/FileAccess.java
+++ b/src/peergos/shared/user/fs/FileAccess.java
@@ -9,7 +9,6 @@ import peergos.shared.crypto.symmetric.*;
 import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.*;
 
-import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -43,9 +42,9 @@ public class FileAccess implements CryptreeNode {
                         new CborObject.CborLong(getVersionAndType()),
                         parent2meta.toCbor(),
                         parent2data.toCbor(),
+                        parentLink == null ? new CborObject.CborNull() : parentLink.toCbor(),
                         new CborObject.CborByteArray(properties),
-                        retriever == null ? new CborObject.CborNull() : retriever.toCbor(),
-                        parentLink == null ? new CborObject.CborNull() : parentLink.toCbor()
+                        retriever == null ? new CborObject.CborNull() : retriever.toCbor()
                 ));
     }
 
@@ -160,15 +159,18 @@ public class FileAccess implements CryptreeNode {
         int versionAndType = (int) ((CborObject.CborLong) value.get(index++)).value;
         SymmetricLink parentToMeta = SymmetricLink.fromCbor(value.get(index++));
         SymmetricLink parentToData = SymmetricLink.fromCbor(value.get(index++));
+
+        CborObject parentLinkCbor = value.get(index++);
+        SymmetricLocationLink parentLink = parentLinkCbor instanceof CborObject.CborNull ?
+                null :
+                SymmetricLocationLink.fromCbor(parentLinkCbor);
+
         byte[] properties = ((CborObject.CborByteArray)value.get(index++)).value;
         CborObject retrieverCbor = value.get(index++);
         FileRetriever retriever = retrieverCbor instanceof CborObject.CborNull ?
                 null :
                 FileRetriever.fromCbor(retrieverCbor);
-        CborObject parentLinkCbor = value.get(index++);
-        SymmetricLocationLink parentLink = parentLinkCbor instanceof CborObject.CborNull ?
-                null :
-                SymmetricLocationLink.fromCbor(parentLinkCbor);
+
 
         return new FileAccess(versionAndType >> 1, parentToMeta, parentToData, properties, retriever, parentLink);
     }

--- a/src/peergos/shared/user/fs/FileAccess.java
+++ b/src/peergos/shared/user/fs/FileAccess.java
@@ -92,8 +92,13 @@ public class FileAccess implements Cborable {
         if (!writableFilePointer.isWritable())
             throw new IllegalStateException("Need a writable pointer!");
         SymmetricKey metaKey = this.getMetaKey(writableFilePointer.baseKey);
+        boolean isDirty = metaKey.isDirty();
+        if (isDirty)
+            metaKey = SymmetricKey.random();
+        SymmetricLink toMeta = isDirty ? this.parent2meta : SymmetricLink.fromPair(writableFilePointer.baseKey, metaKey);
+
         byte[] nonce = metaKey.createNonce();
-        FileAccess fa = new FileAccess(this.parent2meta, this.parent2data, ArrayOps.concat(nonce, metaKey.encrypt(newProps.serialize(), nonce)),
+        FileAccess fa = new FileAccess(toMeta, this.parent2data, ArrayOps.concat(nonce, metaKey.encrypt(newProps.serialize(), nonce)),
                 this.retriever, this.parentLink);
         return network.uploadChunk(fa, writableFilePointer.location, writableFilePointer.signer());
     }

--- a/src/peergos/shared/user/fs/FileAccess.java
+++ b/src/peergos/shared/user/fs/FileAccess.java
@@ -139,12 +139,10 @@ public class FileAccess implements Cborable {
                                                           Location newParentLocation, SymmetricKey parentparentKey,
                                                           SigningPrivateKeyAndPublicHash entryWriterKey, byte[] newMapKey,
                                                           NetworkAccess network) {
-        if (!Arrays.equals(baseKey.serialize(), newBaseKey.serialize()))
-            throw new IllegalStateException("FileAccess clone must have same base key as original!");
         FileProperties props = getFileProperties(baseKey);
         boolean isDirectory = isDirectory();
         FileAccess fa = FileAccess.create(newBaseKey,
-                isDirectory ? SymmetricKey.random() : getMetaKey(baseKey),
+                SymmetricKey.random(),
                 isDirectory ? SymmetricKey.random() : getDataKey(baseKey),
                 props, this.retriever, newParentLocation, parentparentKey);
         return network.uploadChunk(fa, new Location(newParentLocation.owner, entryWriterKey.publicKeyHash, newMapKey), entryWriterKey)

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -469,7 +469,7 @@ public class FileTreeNode {
             final AtomicLong filesSize = new AtomicLong(childProps.size);
             FileRetriever retriever = child.getRetriever();
             SymmetricKey baseKey = child.pointer.filePointer.baseKey;
-            SymmetricKey dataKey = child.pointer.fileAccess.getMetaKey(baseKey);
+            SymmetricKey dataKey = child.pointer.fileAccess.getDataKey(baseKey);
 
             List<Long> startIndexes = new ArrayList<>();
 

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -721,7 +721,7 @@ public class FileTreeNode {
     public CompletableFuture<? extends AsyncReader> getInputStream(NetworkAccess network, SafeRandom random,
                                                                    long fileSize, ProgressConsumer<Long> monitor) {
         SymmetricKey baseKey = pointer.filePointer.baseKey;
-        SymmetricKey dataKey = pointer.fileAccess.getMetaKey(baseKey);
+        SymmetricKey dataKey = pointer.fileAccess.getDataKey(baseKey);
         return pointer.fileAccess.retriever().getFile(network, random, dataKey, fileSize, getLocation(), monitor);
     }
 

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -676,8 +676,7 @@ public class FileTreeNode {
             byte[] newMapKey = new byte[32];
             random.randombytes(newMapKey, 0, 32);
             SymmetricKey ourBaseKey = this.getKey();
-            // a file baseKey is the key for the chunk, which hasn't changed, so this must stay the same
-            SymmetricKey newBaseKey = this.isDirectory() ? SymmetricKey.random() : ourBaseKey;
+            SymmetricKey newBaseKey = SymmetricKey.random();
             FilePointer newRFP = new FilePointer(target.getLocation().owner, target.getLocation().writer, newMapKey, newBaseKey);
             Location newParentLocation = target.getLocation();
             SymmetricKey newParentParentKey = target.getParentKey();

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -113,7 +113,7 @@ public class FileUploader implements AutoCloseable {
         CipherText encryptedNextChunkLocation = new CipherText(nextLocationNonce, nextLocation);
         return network.uploadFragments(fragments, chunk.location.owner, monitor, fragmenter.storageIncreaseFactor()).thenCompose(hashes -> {
             FileRetriever retriever = new EncryptedChunkRetriever(chunk.chunk.nonce(), encryptedChunk.getAuth(), hashes, Optional.of(encryptedNextChunkLocation), fragmenter);
-            FileAccess metaBlob = FileAccess.create(baseKey, chunkKey, props, retriever, parentLocation, parentparentKey);
+            FileAccess metaBlob = FileAccess.create(baseKey, SymmetricKey.random(), chunkKey, props, retriever, parentLocation, parentparentKey);
             return network.uploadChunk(metaBlob, new Location(chunk.location.owner, writer.publicKeyHash, chunk.chunk.mapKey()), writer);
         });
     }

--- a/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
+++ b/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
@@ -59,7 +59,9 @@ public class LazyInputStreamCombiner implements AsyncReader {
                     err.completeExceptionally(new EOFException());
                     return err;
                 }
-                FileRetriever nextRet = meta.get().retriever();
+                if (! (meta.get() instanceof FileAccess))
+                    throw new IllegalStateException("File linked to a directory for its next chunk!");
+                FileRetriever nextRet = ((FileAccess) meta.get()).retriever();
                 Location newNextChunkPointer = nextRet.getNext(dataKey).orElse(null);
                 return nextRet.getChunkInputStream(network, random, dataKey, 0, len, nextLocation, monitor)
                         .thenApply(x -> {

--- a/src/peergos/shared/user/fs/RetrievedFilePointer.java
+++ b/src/peergos/shared/user/fs/RetrievedFilePointer.java
@@ -4,15 +4,16 @@ import peergos.shared.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.user.*;
+import peergos.shared.user.fs.cryptree.*;
 
 import java.util.*;
 import java.util.concurrent.*;
 
 public class RetrievedFilePointer {
     public final FilePointer filePointer;
-    public final FileAccess fileAccess;
+    public final CryptreeNode fileAccess;
 
-    public RetrievedFilePointer(FilePointer filePointer, FileAccess fileAccess) {
+    public RetrievedFilePointer(FilePointer filePointer, CryptreeNode fileAccess) {
         if (fileAccess == null)
             throw new IllegalStateException("Null FileAccess!");
         this.filePointer = filePointer;

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -21,7 +21,7 @@ public interface CryptreeNode extends Cborable {
     int getVersion();
 
     default int getVersionAndType() {
-        return getVersion() << 1 | (isDirectory() ? 1 : 0);
+        return getVersion() << 1 | (isDirectory() ? 0 : 1);
     }
 
     SymmetricKey getParentKey(SymmetricKey baseKey);

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -1,0 +1,73 @@
+package peergos.shared.user.fs.cryptree;
+
+import peergos.shared.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.random.*;
+import peergos.shared.crypto.symmetric.*;
+import peergos.shared.user.fs.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public interface CryptreeNode extends Cborable {
+
+    int CURRENT_FILE_VERSION = 1;
+    int CURRENT_DIR_VERSION = 1;
+
+    boolean isDirectory();
+
+    int getVersion();
+
+    default int getVersionAndType() {
+        return getVersion() << 1 | (isDirectory() ? 1 : 0);
+    }
+
+    SymmetricKey getParentKey(SymmetricKey baseKey);
+
+    SymmetricKey getMetaKey(SymmetricKey baseKey);
+
+    SymmetricLocationLink getParentLink();
+
+    FileProperties getProperties(SymmetricKey parentKey);
+
+    CompletableFuture<? extends CryptreeNode> updateProperties(FilePointer writableFilePointer,
+                                                               FileProperties newProps,
+                                                               NetworkAccess network);
+
+    boolean isDirty(SymmetricKey baseKey);
+
+    CompletableFuture<? extends CryptreeNode> copyTo(SymmetricKey baseKey,
+                                                   SymmetricKey newBaseKey,
+                                                   Location newParentLocation,
+                                                   SymmetricKey parentparentKey,
+                                                   PublicKeyHash newOwner,
+                                                   SigningPrivateKeyAndPublicHash entryWriterKey,
+                                                   byte[] newMapKey,
+                                                   NetworkAccess network,
+                                                   SafeRandom random);
+
+    default CompletableFuture<RetrievedFilePointer> getParent(SymmetricKey baseKey, NetworkAccess network) {
+        SymmetricLocationLink parentLink = getParentLink();
+        if (parentLink == null)
+            return CompletableFuture.completedFuture(null);
+
+        return network.retrieveAllMetadata(Arrays.asList(parentLink), baseKey).thenApply(res -> {
+            RetrievedFilePointer retrievedFilePointer = res.stream().findAny().get();
+            return retrievedFilePointer;
+        });
+    }
+
+    static CryptreeNode fromCbor(CborObject cbor) {
+        if (! (cbor instanceof CborObject.CborList))
+            throw new IllegalStateException("Incorrect cbor for FileAccess: " + cbor);
+
+        List<CborObject> value = ((CborObject.CborList) cbor).value;
+        int versionAndType = (int) ((CborObject.CborLong) value.get(0)).value;
+        boolean isFile = (versionAndType & 1) != 0;
+        if (isFile)
+            return FileAccess.fromCbor(cbor);
+        return DirAccess.fromCbor(cbor);
+    }
+}


### PR DESCRIPTION
This is a breaking change because the cryptree structure is extended. Now files, instead of only having a base key(AKA parent key), and metadata key, have an additional "data key". This allows for re-keying the metadata for a dirty file if the file hasn't changed. The test has been improved to verify that the old meta ket can't decrypt the new metadata. 