### PR TITLE
Immutable cryptree and filetreenode, and btree CAS at key level

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -197,7 +197,7 @@
   </target>
 
   <target name="gwtc" depends="javac" description="GWT compile to JavaScript (production mode)">
-    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="2g">
+    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="512m">
       <classpath>
         <pathelement location="src"/>
         <path refid="project.class.path"/>

--- a/build.xml
+++ b/build.xml
@@ -197,7 +197,7 @@
   </target>
 
   <target name="gwtc" depends="javac" description="GWT compile to JavaScript (production mode)">
-    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="512m">
+    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="2g">
       <classpath>
         <pathelement location="src"/>
         <path refid="project.class.path"/>

--- a/src/peergos/gwt/emu/java/util/concurrent/atomic/AtomicBoolean.java
+++ b/src/peergos/gwt/emu/java/util/concurrent/atomic/AtomicBoolean.java
@@ -1,0 +1,23 @@
+package java.util.concurrent.atomic;
+
+import java.io.Serializable;
+
+public class AtomicBoolean implements Serializable {
+    private boolean value;
+
+    public AtomicBoolean(boolean value) {
+        this.value = value;
+    }
+
+    public AtomicBoolean() {
+        this(false);
+    }
+
+    public boolean get()  {
+        return value;
+    }
+
+    public void set(boolean value) {
+        this.value = value;
+    }
+}

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -108,7 +108,7 @@ public class UserRepository implements CoreNode, MutablePointers {
 
                                 MaybeMultihash existing = current
                                         .map(signed -> HashCasPair.fromCbor(CborObject.fromByteArray(writerKey.unsignMessage(signed))).updated)
-                                        .orElse(MaybeMultihash.EMPTY());
+                                        .orElse(MaybeMultihash.empty());
                                 if (! existing.equals(claimedCurrentHash))
                                     return CompletableFuture.completedFuture(false);
                                 if (LOGGING)

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -142,8 +142,8 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             if (!parent.isPresent())
                 return 1;
 
-            boolean removed = file.get().remove(context.network, parent.get()).get();
-            return removed ? 0 : 1;
+            FileTreeNode updatedParent = file.get().remove(context.network, parent.get()).get();
+            return updatedParent != parent.get() ? 0 : 1;
         } catch (Exception ioe) {
             ioe.printStackTrace();
             return 1;
@@ -179,9 +179,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
                 if (!renamedOriginal.isPresent())
                     return 1;
                 renamedOriginal.get().copyTo(newParent.get(), context.network, context.crypto.random, context.fragmenter()).get();
-                boolean removed = source.treeNode.remove(context.network, parent).get();
-                if (!removed)
-                    return 1;
+                FileTreeNode updatedParent = source.treeNode.remove(context.network, parent).get();
             }
             return 0;
         } catch (Exception ioe) {
@@ -485,7 +483,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
     private int rmdir(PeergosStat stat, PeergosStat parentStat) {
         FileTreeNode treeNode = stat.treeNode;
         try {
-            Boolean removed = treeNode.remove(context.network, parentStat.treeNode).get();
+            FileTreeNode updatedParent = treeNode.remove(context.network, parentStat.treeNode).get();
             return 0;
         } catch (Exception ioe) {
             ioe.printStackTrace();

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -571,8 +571,8 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             // TODO do this smarter by only writing the chunk containing the new endpoint, and deleting all following chunks
             // or extending with 0s
             byte[] truncated = Arrays.copyOfRange(original, 0, (int)size);
-            file.treeNode.remove(context.network, parent.treeNode);
-            FileTreeNode b = parent.treeNode.uploadFile(file.properties.name, new AsyncReader.ArrayBacked(truncated),
+            FileTreeNode newParent = file.treeNode.remove(context.network, parent.treeNode).get();
+            FileTreeNode b = newParent.uploadFile(file.properties.name, new AsyncReader.ArrayBacked(truncated),
                     truncated.length, context.network, context.crypto.random, l -> {
                     }, context.fragmenter()).get();
             return (int) size;

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -574,9 +574,10 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             // or extending with 0s
             byte[] truncated = Arrays.copyOfRange(original, 0, (int)size);
             file.treeNode.remove(context.network, parent.treeNode);
-            boolean b = parent.treeNode.uploadFile(file.properties.name, new AsyncReader.ArrayBacked(truncated),
-                    truncated.length, context.network, context.crypto.random, l -> {}, context.fragmenter()).get();
-            return b ? (int) size : 1;
+            FileTreeNode b = parent.treeNode.uploadFile(file.properties.name, new AsyncReader.ArrayBacked(truncated),
+                    truncated.length, context.network, context.crypto.random, l -> {
+                    }, context.fragmenter()).get();
+            return (int) size;
         } catch (Throwable t) {
             t.printStackTrace();
             return 1;
@@ -591,9 +592,9 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
                 throw new IllegalStateException("Cannot write more than " + Integer.MAX_VALUE + " bytes");
             }
 
-            boolean b = parent.treeNode.uploadFileSection(name, new AsyncReader.ArrayBacked(toWrite), offset, offset + size,
+            FileTreeNode b = parent.treeNode.uploadFileSection(name, new AsyncReader.ArrayBacked(toWrite), offset, offset + size,
                     context.network, context.crypto.random, l -> {}, context.fragmenter()).get();
-            return b ? (int) size : 1;
+            return (int) size;
         } catch (Throwable t) {
             t.printStackTrace();
             return 1;

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -171,15 +171,15 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
                 return 1;
 
             FileTreeNode parent = sourceParent.treeNode;
-            source.treeNode.rename(requested.getFileName().toString(), context.network, parent);
+            FileTreeNode updatedParent = source.treeNode.rename(requested.getFileName().toString(), context.network, parent).get();
             // TODO clean up on error conditions
-            if (!parent.equals(newParent.get())) {
+            if (! parent.equals(newParent.get())) {
                 Path renamedInPlacePath = Paths.get(sourcePath).getParent().resolve(requested.getFileName().toString());
                 Optional<FileTreeNode> renamedOriginal = context.getByPath(renamedInPlacePath.toString()).get();;
-                if (!renamedOriginal.isPresent())
+                if (! renamedOriginal.isPresent())
                     return 1;
                 renamedOriginal.get().copyTo(newParent.get(), context.network, context.crypto.random, context.fragmenter()).get();
-                FileTreeNode updatedParent = source.treeNode.remove(context.network, parent).get();
+                FileTreeNode updatedParent2 = renamedOriginal.get().remove(context.network, parent).get();
             }
             return 0;
         } catch (Exception ioe) {

--- a/src/peergos/server/tests/CorenodeTests.java
+++ b/src/peergos/server/tests/CorenodeTests.java
@@ -7,28 +7,16 @@ import peergos.server.*;
 import peergos.server.corenode.UsernameValidator;
 import peergos.server.storage.*;
 import peergos.shared.*;
-import peergos.shared.corenode.CoreNode;
 import peergos.shared.crypto.*;
-import peergos.shared.crypto.asymmetric.*;
-import peergos.shared.crypto.asymmetric.curve25519.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.crypto.random.*;
-import peergos.shared.crypto.symmetric.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.merklebtree.*;
-import peergos.shared.user.*;
-import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
-import java.io.*;
 import java.lang.reflect.*;
 import java.net.*;
-import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.stream.*;
-
-import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class CorenodeTests {
@@ -82,7 +70,7 @@ public class CorenodeTests {
 
                 byte[] data = new byte[10];
 
-                MaybeMultihash current = MaybeMultihash.EMPTY();
+                MaybeMultihash current = MaybeMultihash.empty();
                 long t1 = System.currentTimeMillis();
                 int iterations = 100;
                 long maxLatency = 0;

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -173,7 +173,7 @@ public class MerkleBtree {
             MaybeMultihash value = tree.get(key.data).get();
             if (! value.isPresent())
                 throw new IllegalStateException("Key not present!");
-            tree.delete(user, key.data).get();
+            tree.delete(user, key.data, value).get();
             if (tree.get(key.data).get().isPresent())
                 throw new IllegalStateException("Key still present!");
             tree.put(user, key.data, MaybeMultihash.empty(), value.get()).get();
@@ -218,7 +218,7 @@ public class MerkleBtree {
             MaybeMultihash value = tree.get(key).get();
             if (! value.isPresent())
                 throw new IllegalStateException("Key not present!");
-            tree.delete(user, key).get();
+            tree.delete(user, key, value).get();
             if (tree.get(key).get().isPresent())
                 throw new IllegalStateException("Key still present!");
         }

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -2,7 +2,6 @@ package peergos.server.tests;
 
 import org.junit.*;
 import peergos.server.storage.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.merklebtree.*;
@@ -28,7 +27,7 @@ public class MerkleBtree {
     }
 
     public CompletableFuture<MerkleBTree> createTree(PublicKeyHash user, ContentAddressedStorage dht) throws IOException {
-        return MerkleBTree.create(user, MaybeMultihash.EMPTY(), dht);
+        return MerkleBTree.create(user, MaybeMultihash.empty(), dht);
     }
 
     public Multihash hash(byte[] in) {
@@ -41,7 +40,7 @@ public class MerkleBtree {
         MerkleBTree tree = createTree(user).get();
         byte[] key1 = new byte[]{0, 1, 2, 3};
         Multihash value1 = hash(new byte[]{1, 1, 1, 1});
-        tree.put(user, key1, value1).get();
+        tree.put(user, key1, MaybeMultihash.empty(), value1).get();
         MaybeMultihash res1 = tree.get(key1).get();
         if (!res1.get().equals(value1))
             throw new IllegalStateException("Results not equal");
@@ -55,7 +54,7 @@ public class MerkleBtree {
         for (int i=0; i < 16; i++) {
             byte[] key1 = new byte[]{0, 1, 2, (byte)i};
             Multihash value1 = hash(new byte[]{1, 1, 1, (byte)i});
-            tree.put(user, key1, value1).get();
+            tree.put(user, key1, MaybeMultihash.empty(), value1).get();
             MaybeMultihash res1 = tree.get(key1).get();
             if (! res1.get().equals(value1))
                 throw new IllegalStateException("Results not equal");
@@ -70,12 +69,12 @@ public class MerkleBtree {
         MerkleBTree tree = createTree(user).get();
         byte[] key1 = new byte[]{0, 1, 2, 3};
         Multihash value1 = hash(new byte[]{1, 1, 1, 1});
-        tree.put(user, key1, value1);
+        tree.put(user, key1, MaybeMultihash.empty(), value1);
         MaybeMultihash res1 = tree.get(key1).get();
         if (! res1.get().equals(value1))
             throw new IllegalStateException("Results not equal");
         Multihash value2 = hash(new byte[]{2, 2, 2, 2});
-        tree.put(user, key1, value2);
+        tree.put(user, key1, MaybeMultihash.of(value1), value2);
         MaybeMultihash res2 = tree.get(key1).get();
         if (! res2.get().equals(value2))
             throw new IllegalStateException("Results not equal");
@@ -89,7 +88,7 @@ public class MerkleBtree {
         for (int i=0; i < 1000000; i++) {
             byte[] key1 = new byte[]{0, 1, 2, (byte)i};
             Multihash value1 = hash(new byte[]{1, 1, 1, (byte)i});
-            tree.put(user, key1, value1).get();
+            tree.put(user, key1, MaybeMultihash.empty(), value1).get();
             MaybeMultihash res1 = tree.get(key1).get();
             if (! res1.get().equals(value1))
                 throw new IllegalStateException("Results not equal");
@@ -123,7 +122,7 @@ public class MerkleBtree {
             byte[] value1Raw = new byte[keylen];
             r.nextBytes(value1Raw);
             Multihash value1 = hash(value1Raw);
-            tree.put(user, key1, value1).get();
+            tree.put(user, key1, MaybeMultihash.empty(), value1).get();
 
             MaybeMultihash res1 = tree.get(key1).get();
             if (! res1.get().equals(value1))
@@ -155,7 +154,7 @@ public class MerkleBtree {
             MaybeMultihash existing = tree.get(key1).get();
             if (existing.isPresent())
                 throw new IllegalStateException("Already present!");
-            tree.put(user, key1, value1).get();
+            tree.put(user, key1, MaybeMultihash.empty(), value1).get();
 
             MaybeMultihash res1 = tree.get(key1).get();
             if (! res1.get().equals(value1))
@@ -177,7 +176,7 @@ public class MerkleBtree {
             tree.delete(user, key.data).get();
             if (tree.get(key.data).get().isPresent())
                 throw new IllegalStateException("Key still present!");
-            tree.put(user, key.data, value.get()).get();
+            tree.put(user, key.data, MaybeMultihash.empty(), value.get()).get();
         }
         long t2 = System.currentTimeMillis();
         System.out.printf("size+get+delete+get+put rate = %f /s\n", (double)lim / (t2 - t1) * 1000);
@@ -202,7 +201,7 @@ public class MerkleBtree {
             byte[] value1Raw = new byte[keylen];
             r.nextBytes(value1Raw);
             Multihash value1 = hash(value1Raw);
-            tree.put(user, key1, value1).get();
+            tree.put(user, key1, MaybeMultihash.empty(), value1).get();
 
             MaybeMultihash res1 = tree.get(key1).get();
             if (! res1.get().equals(value1))

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -415,11 +415,11 @@ public class MultiUserTests {
 
         for (int i = 0; i < usersNew.size(); i++) {
             UserContext user = users.get(i);
-            u1.unShare(Paths.get(u1.username, folderName), user.username);
+            u1.unShare(Paths.get(u1.username, folderName), user.username).get();
 
             Optional<FileTreeNode> updatedSharedFolder = user.getByPath(u1New.username + "/" + folderName).get();
 
-            // test that u1 can still access the original file
+            // test that u1 can still access the original file, and user cannot
             Optional<FileTreeNode> fileWithNewBaseKey = u1New.getByPath(u1New.username + "/" + folderName + "/" + filename).get();
             Assert.assertTrue(! updatedSharedFolder.isPresent());
             Assert.assertTrue(fileWithNewBaseKey.isPresent());

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -421,7 +421,7 @@ public class MultiUserTests {
 
             // test that u1 can still access the original file
             Optional<FileTreeNode> fileWithNewBaseKey = u1New.getByPath(u1New.username + "/" + folderName + "/" + filename).get();
-            Assert.assertTrue(!updatedSharedFolder.isPresent());
+            Assert.assertTrue(! updatedSharedFolder.isPresent());
             Assert.assertTrue(fileWithNewBaseKey.isPresent());
 
             // Now modify the file

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -163,7 +163,7 @@ public class MultiUserTests {
         AsyncReader suffixStream = new AsyncReader.ArrayBacked(suffix);
         FileTreeNode parent = u1New.getByPath(u1New.username).get().get();
         parent.uploadFileSection(filename, suffixStream, originalFileContents.length, originalFileContents.length + suffix.length,
-                Optional.empty(), u1New.network, u1New.crypto.random, l -> {}, u1New.fragmenter());
+                Optional.empty(), u1New.network, u1New.crypto.random, l -> {}, u1New.fragmenter()).get();
         AsyncReader extendedContents = u1New.getByPath(u1.username + "/" + filename).get().get().getInputStream(u1New.network,
                 u1New.crypto.random, l -> {}).get();
         byte[] newFileContents = Serialize.readFully(extendedContents, originalFileContents.length + suffix.length).get();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -111,7 +111,7 @@ public class MultiUserTests {
         byte[] originalFileContents = "Hello Peergos friend!".getBytes();
         Files.write(f.toPath(), originalFileContents);
         ResetableFileInputStream resetableFileInputStream = new ResetableFileInputStream(f);
-        boolean uploaded = u1Root.uploadFile(filename, resetableFileInputStream, f.length(),
+        FileTreeNode uploaded = u1Root.uploadFile(filename, resetableFileInputStream, f.length(),
                 u1.network, u1.crypto.random,l -> {}, u1.fragmenter()).get();
 
         // share the file from "a" to each of the others
@@ -195,7 +195,7 @@ public class MultiUserTests {
         String filename = "somefile.txt";
         byte[] data = UserTests.randomData(10*1024*1024);
 
-        boolean uploaded = u1Root.uploadFile(filename, new AsyncReader.ArrayBacked(data), data.length,
+        FileTreeNode uploaded = u1Root.uploadFile(filename, new AsyncReader.ArrayBacked(data), data.length,
                 u1.network, u1.crypto.random,l -> {}, u1.fragmenter()).get();
 
         // share the file from "a" to each of the others
@@ -250,7 +250,7 @@ public class MultiUserTests {
         byte[] originalFileContents = "Hello Peergos friend!".getBytes();
         Files.write(f.toPath(), originalFileContents);
         ResetableFileInputStream resetableFileInputStream = new ResetableFileInputStream(f);
-        boolean uploaded = u1Root.uploadFile(filename, resetableFileInputStream, f.length(),
+        FileTreeNode uploaded = u1Root.uploadFile(filename, resetableFileInputStream, f.length(),
                 u1.network, u1.crypto.random,l -> {}, u1.fragmenter()).get();
 
         // share the file from "a" to each of the others
@@ -385,12 +385,12 @@ public class MultiUserTests {
         String filename = "somefile.txt";
         byte[] originalFileContents = "Hello Peergos friend!".getBytes();
         AsyncReader resetableFileInputStream = new AsyncReader.ArrayBacked(originalFileContents);
-        boolean uploaded = folder.uploadFile(filename, resetableFileInputStream, originalFileContents.length, u1.network,
+        FileTreeNode updatedFolder = folder.uploadFile(filename, resetableFileInputStream, originalFileContents.length, u1.network,
                 u1.crypto.random, l -> {}, u1.fragmenter()).get();
         String originalFilePath = u1.username + "/" + folderName + "/" + filename;
 
         // file is uploaded, do the actual sharing
-        boolean finished = u1.shareWithAll(folder, users.stream().map(c -> c.username).collect(Collectors.toSet())).get();
+        boolean finished = u1.shareWithAll(updatedFolder, users.stream().map(c -> c.username).collect(Collectors.toSet())).get();
 
         // check each user can see the shared folder and directory
         for (UserContext user : users) {

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -281,7 +281,7 @@ public class MultiUserTests {
         u1.unShare(Paths.get(u1.username, filename), userToUnshareWith.username).get();
 
         String newname = "newname.txt";
-        boolean renamed = u1.getByPath(originalPath).get().get()
+        FileTreeNode updatedParent = u1.getByPath(originalPath).get().get()
                 .rename(newname, network, u1.getUserRoot().get()).get();
 
         // check still logged in user can't read the new name

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -277,7 +277,7 @@ public abstract class UserTests {
         Set<FileTreeNode> files = context.getUserRoot().get().getChildren(context.network).get();
         Set<String> names = files.stream().filter(f -> ! f.getFileProperties().isHidden).map(f -> f.getName()).collect(Collectors.toSet());
         Set<String> expectedNames = IntStream.range(0, concurrency).mapToObj(i -> i + ".bin").collect(Collectors.toSet());
-        Assert.assertTrue("All children present and accounted for", names.equals(expectedNames));
+        Assert.assertTrue("All children present and accounted for: " + names, names.equals(expectedNames));
     }
 
     @Test

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -511,12 +511,6 @@ public abstract class UserTests {
         UserContext context = ensureSignedUp(username, password, network.clear(), crypto);
         FileTreeNode userRoot = context.getUserRoot().get();
 
-        Set<FileTreeNode> children = userRoot.getChildren(context.network).get();
-
-        children.stream()
-                .map(FileTreeNode::toString)
-                .forEach(System.out::println);
-
         String name = randomString();
         Path tmpPath = createTmpFile(name);
         byte[] data = randomData(10*1024*1024); // 2 chunks to test block chaining

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -184,13 +184,14 @@ public class NetworkAccess {
                         .collect(Collectors.toList()));
     }
 
-    public CompletableFuture<Boolean> uploadChunk(CryptreeNode metadata, Location location, SigningPrivateKeyAndPublicHash writer) {
+    public CompletableFuture<Multihash> uploadChunk(CryptreeNode metadata, Location location, SigningPrivateKeyAndPublicHash writer) {
         if (! writer.publicKeyHash.equals(location.writer))
             throw new IllegalStateException("Non matching location writer and signing writer key!");
         try {
             byte[] metaBlob = metadata.serialize();
             return dhtClient.put(location.owner, metaBlob)
-                    .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), metadata.committedHash(), blobHash));
+                    .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), metadata.committedHash(), blobHash)
+                            .thenApply(res -> blobHash));
         } catch (Exception e) {
             System.out.println(e.getMessage());
             throw new RuntimeException(e);

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -110,12 +110,15 @@ public class NetworkAccess {
                     return btree.get(loc.writer, loc.getMapKey())
                             .thenCompose(key -> {
                                 if (key.isPresent())
-                                    return dhtClient.get(key.get());
+                                    return dhtClient.get(key.get())
+                                            .thenApply(dataOpt ->  dataOpt
+                                                    .map(cbor -> new RetrievedFilePointer(
+                                                            link.toReadableFilePointer(baseKey),
+                                                            CryptreeNode.fromCbor(cbor, key.get()))));
                                 System.err.println("Couldn't download link at: " + loc);
-                                Optional<CborObject> result = Optional.empty();
+                                Optional<RetrievedFilePointer> result = Optional.empty();
                                 return CompletableFuture.completedFuture(result);
-                            }).thenApply(dataOpt ->  dataOpt
-                                    .map(cbor -> new RetrievedFilePointer(link.toReadableFilePointer(baseKey), CryptreeNode.fromCbor(cbor))));
+                            });
                 }).collect(Collectors.toList());
 
         return Futures.combineAll(all).thenApply(optSet -> optSet.stream()
@@ -144,7 +147,7 @@ public class NetworkAccess {
         return btree.get(entry.pointer.location.writer, entry.pointer.location.getMapKey()).thenCompose(btreeValue -> {
             if (btreeValue.isPresent())
                 return dhtClient.get(btreeValue.get())
-                        .thenApply(value -> value.map(CryptreeNode::fromCbor));
+                        .thenApply(value -> value.map(cbor -> CryptreeNode.fromCbor(cbor,  btreeValue.get())));
             return CompletableFuture.completedFuture(Optional.empty());
         });
     }
@@ -187,7 +190,7 @@ public class NetworkAccess {
         try {
             byte[] metaBlob = metadata.serialize();
             return dhtClient.put(location.owner, metaBlob)
-                    .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), blobHash));
+                    .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), metadata.committedHash(), blobHash));
         } catch (Exception e) {
             System.out.println(e.getMessage());
             throw new RuntimeException(e);
@@ -201,7 +204,7 @@ public class NetworkAccess {
             if (!blobHash.isPresent())
                 return CompletableFuture.completedFuture(Optional.empty());
             return dhtClient.get(blobHash.get())
-                    .thenApply(rawOpt -> rawOpt.map(CryptreeNode::fromCbor));
+                    .thenApply(rawOpt -> rawOpt.map(cbor -> CryptreeNode.fromCbor(cbor, blobHash.get())));
         });
     }
 

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -54,7 +54,7 @@ public class TofuCoreNode implements CoreNode {
                     AsyncReader.ArrayBacked dataReader = new AsyncReader.ArrayBacked(data);
                     return home.uploadFile(KEY_STORE_NAME, dataReader, true, (long) data.length,
                             context.network, context.crypto.random, x-> {}, context.fragmenter());
-                });
+                }).thenApply(x -> true);
     }
 
     public CompletableFuture<Boolean> updateUser(String username) {
@@ -93,7 +93,8 @@ public class TofuCoreNode implements CoreNode {
             return CompletableFuture.completedFuture(localChain);
         return source.getChain(username)
                 .thenCompose(chain -> tofu.updateChain(username, chain, context.network.dhtClient)
-                        .thenCompose(x -> commit()).thenApply(x -> tofu.getChain(username)));
+                        .thenCompose(x -> commit())
+                        .thenApply(x -> tofu.getChain(username)));
     }
 
     @Override

--- a/src/peergos/shared/merklebtree/MaybeMultihash.java
+++ b/src/peergos/shared/merklebtree/MaybeMultihash.java
@@ -42,7 +42,7 @@ public class MaybeMultihash implements Cborable {
 
     public static MaybeMultihash fromCbor(CborObject cbor) {
         if (cbor instanceof CborObject.CborNull)
-            return MaybeMultihash.EMPTY();
+            return MaybeMultihash.empty();
 
         if (! (cbor instanceof CborObject.CborByteArray))
             throw new IllegalStateException("Incorrect cbor for MaybeMultihash: " + cbor);
@@ -56,7 +56,7 @@ public class MaybeMultihash implements Cborable {
 
     private static MaybeMultihash EMPTY = new MaybeMultihash(null);
 
-    public static MaybeMultihash EMPTY() {
+    public static MaybeMultihash empty() {
         return EMPTY;
     }
 

--- a/src/peergos/shared/merklebtree/MerkleBTree.java
+++ b/src/peergos/shared/merklebtree/MerkleBTree.java
@@ -1,6 +1,5 @@
 package peergos.shared.merklebtree;
 
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.storage.ContentAddressedStorage;
@@ -61,8 +60,8 @@ public class MerkleBTree
      * @return hash of new tree root
      * @throws IOException
      */
-    public CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] rawKey, Multihash value) {
-        return root.put(writer, new ByteArrayWrapper(rawKey), value, storage, maxChildren)
+    public CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] rawKey, MaybeMultihash existing, Multihash value) {
+        return root.put(writer, new ByteArrayWrapper(rawKey), existing, value, storage, maxChildren)
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
 

--- a/src/peergos/shared/merklebtree/MerkleBTree.java
+++ b/src/peergos/shared/merklebtree/MerkleBTree.java
@@ -71,8 +71,8 @@ public class MerkleBTree
      * @return hash of new tree root
      * @throws IOException
      */
-    public CompletableFuture<Multihash> delete(PublicKeyHash writer, byte[] rawKey) {
-        return root.delete(writer, new ByteArrayWrapper(rawKey), storage, maxChildren)
+    public CompletableFuture<Multihash> delete(PublicKeyHash writer, byte[] rawKey, MaybeMultihash existing) {
+        return root.delete(writer, new ByteArrayWrapper(rawKey), existing, storage, maxChildren)
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
 

--- a/src/peergos/shared/merklebtree/TreeNode.java
+++ b/src/peergos/shared/merklebtree/TreeNode.java
@@ -103,7 +103,7 @@ public class TreeNode implements Cborable {
             // ensure CAS
             if (! nextSmallest.valueHash.equals(existing)) {
                 CompletableFuture<TreeNode> res = new CompletableFuture<>();
-                res.completeExceptionally(new Btree.CASException());
+                res.completeExceptionally(new Btree.CasException(nextSmallest.valueHash, existing));
                 return res;
             }
             keys.remove(nextSmallest);

--- a/src/peergos/shared/user/Btree.java
+++ b/src/peergos/shared/user/Btree.java
@@ -38,7 +38,7 @@ public interface Btree {
      * @return  hash(sharingKey.metadata) | the new root hash of the btree
      * @throws IOException
      */
-    CompletableFuture<Boolean> remove(SigningPrivateKeyAndPublicHash sharingKey, byte[] mapKey);
+    CompletableFuture<Boolean> remove(SigningPrivateKeyAndPublicHash sharingKey, byte[] mapKey, MaybeMultihash existing);
 
 
     class CasException extends RuntimeException {

--- a/src/peergos/shared/user/Btree.java
+++ b/src/peergos/shared/user/Btree.java
@@ -41,5 +41,10 @@ public interface Btree {
     CompletableFuture<Boolean> remove(SigningPrivateKeyAndPublicHash sharingKey, byte[] mapKey);
 
 
-    class CASException extends RuntimeException {}
+    class CasException extends RuntimeException {
+
+        public CasException(MaybeMultihash actualExisting, MaybeMultihash claimedExisting) {
+            super("CAS exception updating cryptree node. existing: " + actualExisting + ", claimed: " + claimedExisting);
+        }
+    }
 }

--- a/src/peergos/shared/user/Btree.java
+++ b/src/peergos/shared/user/Btree.java
@@ -7,6 +7,7 @@ import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.merklebtree.MaybeMultihash;
 
 import java.io.*;
+import java.util.*;
 import java.util.concurrent.*;
 
 public interface Btree {
@@ -19,7 +20,7 @@ public interface Btree {
      * @return the new root hash of the btree
      * @throws IOException
      */
-    CompletableFuture<Boolean> put(SigningPrivateKeyAndPublicHash sharingKey, byte[] mapKey, Multihash value);
+    CompletableFuture<Boolean> put(SigningPrivateKeyAndPublicHash sharingKey, byte[] mapKey, MaybeMultihash existing, Multihash value);
 
     /**
      *
@@ -39,4 +40,6 @@ public interface Btree {
      */
     CompletableFuture<Boolean> remove(SigningPrivateKeyAndPublicHash sharingKey, byte[] mapKey);
 
+
+    class CASException extends RuntimeException {}
 }

--- a/src/peergos/shared/user/BtreeImpl.java
+++ b/src/peergos/shared/user/BtreeImpl.java
@@ -106,7 +106,7 @@ public class BtreeImpl implements Btree {
     }
 
     @Override
-    public CompletableFuture<Boolean> remove(SigningPrivateKeyAndPublicHash writer, byte[] mapKey) {
+    public CompletableFuture<Boolean> remove(SigningPrivateKeyAndPublicHash writer, byte[] mapKey, MaybeMultihash existing) {
         PublicKeyHash publicWriter = writer.publicKeyHash;
         CompletableFuture<CommittedWriterData> future = new CompletableFuture<>();
 
@@ -115,7 +115,7 @@ public class BtreeImpl implements Btree {
                     WriterData holder = committed.props;
                     MaybeMultihash btreeRootHash = holder.btree.isPresent() ? MaybeMultihash.of(holder.btree.get()) : MaybeMultihash.empty();
                     return MerkleBTree.create(publicWriter, btreeRootHash, dht)
-                            .thenCompose(btree -> btree.delete(publicWriter, mapKey))
+                            .thenCompose(btree -> btree.delete(publicWriter, mapKey, existing))
                             .thenApply(pair -> LOGGING ? log(pair, "BTREE.rm (" + ArrayOps.bytesToHex(mapKey) + "  => " + pair) : pair)
                             .thenCompose(newBtreeRoot -> holder.withBtree(newBtreeRoot)
                                     .commit(writer, committed.hash, mutable, dht, future::complete))

--- a/src/peergos/shared/user/BtreeImpl.java
+++ b/src/peergos/shared/user/BtreeImpl.java
@@ -82,7 +82,9 @@ public class BtreeImpl implements Btree {
                             .thenApply(x -> true)
                             .exceptionally(e -> {
                                 lock.complete(committed);
-                                return null;
+                                if (e instanceof RuntimeException)
+                                    throw (RuntimeException) e;
+                                throw new RuntimeException(e);
                             });
                 });
     }

--- a/src/peergos/shared/user/BtreeImpl.java
+++ b/src/peergos/shared/user/BtreeImpl.java
@@ -79,7 +79,11 @@ public class BtreeImpl implements Btree {
                                     + ", " + value + ") => CAS(" + btreeRootHash + ", " + newRoot + ")") : newRoot)
                             .thenCompose(newBtreeRoot -> holder.withBtree(newBtreeRoot)
                                     .commit(writer, committed.hash, mutable, dht, lock::complete))
-                            .thenApply(x -> true);
+                            .thenApply(x -> true)
+                            .exceptionally(e -> {
+                                lock.complete(committed);
+                                return null;
+                            });
                 });
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -402,7 +402,8 @@ public class UserContext {
             EntryPoint entry = new EntryPoint(rootPointer, this.username, Collections.emptySet(), Collections.emptySet());
 
             long t2 = System.currentTimeMillis();
-            DirAccess root = DirAccess.create(rootRKey, new FileProperties(directoryName, 0, LocalDateTime.now(), false, Optional.empty()), (Location) null, null, null);
+            DirAccess root = DirAccess.create(MaybeMultihash.empty(), rootRKey, new FileProperties(directoryName,
+                    0, LocalDateTime.now(), false, Optional.empty()), (Location) null, null, null);
             Location rootLocation = new Location(this.signer.publicKeyHash, writerHash, rootMapKey);
             System.out.println("Uploading entry point directory");
             return network.uploadChunk(root, rootLocation, writerWithHash).thenCompose(chunkHash -> {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -867,7 +867,7 @@ public class UserContext {
                         byte[] keyFromResponse = freq.key.map(k -> k.serialize()).orElse(null);
                         if (keyFromResponse == null || !Arrays.equals(keyFromResponse, ourKeyForThem)) {
                             // They didn't reciprocate (follow us)
-                            CompletableFuture<Boolean> removeDir = ourDirForThem.remove(network, sharing);
+                            CompletableFuture<FileTreeNode> removeDir = ourDirForThem.remove(network, sharing);
                             // remove entry point as well
                             CompletableFuture<CommittedWriterData> cleanStatic = removeFromStaticData(ourDirForThem);
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -96,7 +96,7 @@ public class UserContext {
                                                                 .thenCompose(x -> {
                                                                     System.out.println("Initializing context..");
                                                                     return result.init();
-                                                                });
+                                                                }).exceptionally(Futures::logError);
                                                     }));
                                 } catch (Throwable t) {
                                     throw new IllegalStateException("Incorrect password");

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -127,7 +127,7 @@ public class UserContext {
                                                 Optional.of(new PublicKeyHash(boxerHash)),
                                                 userWithRoot.getRoot());
 
-                                        CommittedWriterData notCommitted = new CommittedWriterData(MaybeMultihash.EMPTY(), newUserData);
+                                        CommittedWriterData notCommitted = new CommittedWriterData(MaybeMultihash.empty(), newUserData);
                                         SigningPrivateKeyAndPublicHash signer = new SigningPrivateKeyAndPublicHash(signerHash, userWithRoot.getUser().secretSigningKey);
                                         UserContext context = new UserContext(username, signer, userWithRoot.getBoxingPair(),
                                                 network, crypto, CompletableFuture.completedFuture(notCommitted), new TrieNode());
@@ -163,7 +163,7 @@ public class UserContext {
         FilePointer entryPoint = FilePointer.fromLink(link);
         EntryPoint entry = new EntryPoint(entryPoint, "", Collections.emptySet(), Collections.emptySet());
         WriterData empty = WriterData.createEmpty(entryPoint.location.owner, Optional.empty(), null);
-        CommittedWriterData committed = new CommittedWriterData(MaybeMultihash.EMPTY(), empty);
+        CommittedWriterData committed = new CommittedWriterData(MaybeMultihash.empty(), empty);
         CompletableFuture<CommittedWriterData> userData = CompletableFuture.completedFuture(committed);
         UserContext context = new UserContext(null, null, null, network.clear(), crypto, userData, new TrieNode());
         return context.addEntryPoint(null, context.entrie, entry, network).thenApply(trieNode -> {
@@ -1040,7 +1040,7 @@ public class UserContext {
                 .thenCompose(casOpt -> network.dhtClient.getSigningKey(signerHash)
                         .thenApply(signer -> casOpt.map(raw -> HashCasPair.fromCbor(CborObject.fromByteArray(
                                 signer.get().unsignMessage(raw))).updated)
-                                .orElse(MaybeMultihash.EMPTY())))
+                                .orElse(MaybeMultihash.empty())))
                         .thenCompose(key -> network.dhtClient.get(key.get())
                                 .thenApply(Optional::get)
                                 .thenApply(cbor -> new Pair<>(key.get(), cbor))

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -2,7 +2,6 @@ package peergos.shared.user;
 
 import peergos.shared.*;
 import peergos.shared.cbor.*;
-import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
@@ -12,9 +11,7 @@ import peergos.shared.merklebtree.*;
 import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.user.fs.*;
-import peergos.shared.util.*;
 
-import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -132,7 +129,7 @@ public class WriterData implements Cborable {
                             ownedKeys,
                             newEntryPoints,
                             btree);
-                    return updated.commit(signer, MaybeMultihash.EMPTY(), network, updater);
+                    return updated.commit(signer, MaybeMultihash.empty(), network, updater);
                 });
     }
 

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -503,7 +503,7 @@ public class DirAccess implements CryptreeNode {
     }
 
     private DirAccess withSubfolders(List<SymmetricLocationLink> newSubfolders) {
-        return new DirAccess(MaybeMultihash.empty(), version, subfolders2files, subfolders2parent, parent2meta, parentLink, properties,
+        return new DirAccess(lastCommittedHash, version, subfolders2files, subfolders2parent, parent2meta, parentLink, properties,
                 newSubfolders, files, moreFolderContents);
     }
 

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -297,9 +297,9 @@ public class DirAccess implements CryptreeNode {
         return removeChild(original, ourPointer, signer, network)
                 .thenCompose(res -> {
                     if (modified.fileAccess.isDirectory())
-                        return addSubdirAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
+                        return res.addSubdirAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
                     else
-                        return addFileAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
+                        return res.addFileAndCommit(modified.filePointer, ourPointer.baseKey, ourPointer, signer, network, random);
                 });
     }
 

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -459,7 +459,7 @@ public class DirAccess implements CryptreeNode {
 
     public CompletableFuture<DirAccess> commit(Location ourLocation, SigningPrivateKeyAndPublicHash signer, NetworkAccess network) {
         return network.uploadChunk(this, ourLocation, signer)
-                .thenApply(x -> this);
+                .thenApply(hash -> this.withHash(hash));
     }
 
     @Override

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -206,7 +206,7 @@ public class DirAccess implements CryptreeNode {
                                 // create and upload new metadata blob
                                 SymmetricKey nextSubfoldersKey = SymmetricKey.random();
                                 SymmetricKey ourParentKey = subfolders2parent.target(ourSubfolders);
-                                DirAccess next = DirAccess.create(nextSubfoldersKey, FileProperties.EMPTY,
+                                DirAccess next = DirAccess.create(MaybeMultihash.empty(), nextSubfoldersKey, FileProperties.EMPTY,
                                         parentLink.targetLocation(ourParentKey), parentLink.target(ourParentKey), ourParentKey);
                                 byte[] nextMapKey = random.randomBytes(32);
                                 Location nextLocation = ourPointer.getLocation().withMapKey(nextMapKey);
@@ -258,7 +258,7 @@ public class DirAccess implements CryptreeNode {
                         // create and upload new metadata blob
                         SymmetricKey nextSubfoldersKey = SymmetricKey.random();
                         SymmetricKey ourParentKey = subfolders2parent.target(ourSubfolders);
-                        DirAccess next = DirAccess.create(nextSubfoldersKey, FileProperties.EMPTY,
+                        DirAccess next = DirAccess.create(MaybeMultihash.empty(), nextSubfoldersKey, FileProperties.EMPTY,
                                 parentLink != null ? parentLink.targetLocation(ourParentKey) : null,
                                 parentLink != null ? parentLink.target(ourParentKey) : null, ourParentKey);
                         byte[] nextMapKey = random.randomBytes(32);
@@ -446,7 +446,7 @@ public class DirAccess implements CryptreeNode {
         random.randombytes(dirMapKey, 0, 32);
         SymmetricKey ourParentKey = this.getParentKey(baseKey);
         Location ourLocation = new Location(ownerPublic, writer.publicKeyHash, ourMapKey);
-        DirAccess dir = DirAccess.create(dirReadKey, new FileProperties(name, 0, LocalDateTime.now(),
+        DirAccess dir = DirAccess.create(MaybeMultihash.empty(), dirReadKey, new FileProperties(name, 0, LocalDateTime.now(),
                 isSystemFolder, Optional.empty()), ourLocation, ourParentKey, null);
         Location chunkLocation = new Location(ownerPublic, writer.publicKeyHash, dirMapKey);
         return network.uploadChunk(dir, chunkLocation, writer).thenCompose(resultHash -> {
@@ -474,7 +474,7 @@ public class DirAccess implements CryptreeNode {
                                                SafeRandom random) {
         SymmetricKey parentKey = getParentKey(baseKey);
         FileProperties props = getProperties(parentKey);
-        DirAccess da = DirAccess.create(newBaseKey, props, newParentLocation, parentparentKey, parentKey);
+        DirAccess da = DirAccess.create(MaybeMultihash.empty(), newBaseKey, props, newParentLocation, parentparentKey, parentKey);
         SymmetricKey ourNewParentKey = da.getParentKey(newBaseKey);
         Location ourNewLocation = new Location(newOwner, entryWriterKey.publicKeyHash, newMapKey);
 
@@ -512,7 +512,7 @@ public class DirAccess implements CryptreeNode {
                 subfolders, newFiles, moreFolderContents);
     }
 
-    public static DirAccess create(SymmetricKey subfoldersKey, FileProperties metadata, Location parentLocation, SymmetricKey parentParentKey, SymmetricKey parentKey) {
+    public static DirAccess create(MaybeMultihash lastCommittedHash, SymmetricKey subfoldersKey, FileProperties metadata, Location parentLocation, SymmetricKey parentParentKey, SymmetricKey parentKey) {
         SymmetricKey metaKey = SymmetricKey.random();
         if (parentKey == null)
             parentKey = SymmetricKey.random();
@@ -520,7 +520,7 @@ public class DirAccess implements CryptreeNode {
         byte[] metaNonce = metaKey.createNonce();
         SymmetricLocationLink parentLink = parentLocation == null ? null : SymmetricLocationLink.create(parentKey, parentParentKey, parentLocation);
         return new DirAccess(
-                MaybeMultihash.empty(),
+                lastCommittedHash,
                 CryptreeNode.CURRENT_DIR_VERSION,
                 SymmetricLink.fromPair(subfoldersKey, filesKey),
                 SymmetricLink.fromPair(subfoldersKey, parentKey),

--- a/src/peergos/shared/user/fs/FileRetriever.java
+++ b/src/peergos/shared/user/fs/FileRetriever.java
@@ -4,6 +4,7 @@ import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
+import peergos.shared.merklebtree.*;
 import peergos.shared.user.*;
 import peergos.shared.util.*;
 
@@ -21,6 +22,7 @@ public interface FileRetriever extends Cborable {
                                            SymmetricKey dataKey,
                                            long fileSize,
                                            Location ourLocation,
+                                           MaybeMultihash ourExistingHash,
                                            ProgressConsumer<Long> monitor);
 
     CompletableFuture<Optional<LocatedEncryptedChunk>> getEncryptedChunk(long bytesRemainingUntilStart,
@@ -28,6 +30,7 @@ public interface FileRetriever extends Cborable {
                                                                          byte[] nonce,
                                                                          SymmetricKey dataKey,
                                                                          Location ourLocation,
+                                                                         MaybeMultihash ourExistingHash,
                                                                          NetworkAccess network,
                                                                          ProgressConsumer<Long> monitor);
 
@@ -42,6 +45,7 @@ public interface FileRetriever extends Cborable {
                                                                   long startIndex,
                                                                   long truncateTo,
                                                                   Location ourLocation,
+                                                                  MaybeMultihash ourExistingHash,
                                                                   ProgressConsumer<Long> monitor);
 
     static FileRetriever fromCbor(CborObject cbor) {

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -159,11 +159,13 @@ public class FileTreeNode {
             SymmetricKey newParentKey = SymmetricKey.random();
             FileProperties props = getFileProperties();
 
+            DirAccess existing = (DirAccess) pointer.fileAccess;
+
             // Create new DirAccess, but don't upload it
-            DirAccess newDirAccess = DirAccess.create(newSubfoldersKey, props, parent.pointer.filePointer.getLocation(),
+            DirAccess newDirAccess = DirAccess.create(existing.committedHash(), newSubfoldersKey, props, parent.pointer.filePointer.getLocation(),
                     parent.getParentKey(), newParentKey);
             // re add children
-            DirAccess existing = (DirAccess) pointer.fileAccess;
+
             List<FilePointer> subdirs = existing.getSubfolders().stream().map(link ->
                     new FilePointer(link.targetLocation(pointer.filePointer.baseKey),
                             Optional.empty(), link.target(pointer.filePointer.baseKey))).collect(Collectors.toList());

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -559,7 +559,7 @@ public class FileTreeNode {
             if (! existing.contains(candidate))
                 return candidate;
         }
-        throw new IllegalStateException("Too many concurrent writes trying to add a file of the saem name!");
+        throw new IllegalStateException("Too many concurrent writes trying to add a file of the same name!");
     }
 
     private CompletableFuture<FileTreeNode> updateExistingChild(FileTreeNode existingChild, AsyncReader fileData,

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -486,13 +486,17 @@ public class FileTreeNode {
                             fragmenter);
                     byte[] mapKey = random.randomBytes(32);
                     Location nextChunkLocation = new Location(getLocation().owner, getLocation().writer, mapKey);
-                    chunks.upload(network, random, parentLocation.owner, getSigner(), nextChunkLocation).thenAccept(fileLocation -> {
-                        FilePointer filePointer = new FilePointer(fileLocation, Optional.empty(), fileKey);
-                        dirAccess.addFileAndCommit(filePointer, rootRKey, pointer.filePointer, getSigner(), network, random)
-                                .thenAccept(uploadResult -> {
-                                    setModified();
-                                    result.complete(this.withCryptreeNode(uploadResult));
-                                });
+                    chunks.upload(network, random, parentLocation.owner, getSigner(), nextChunkLocation)
+                            .thenAccept(fileLocation -> {
+                                FilePointer filePointer = new FilePointer(fileLocation, Optional.empty(), fileKey);
+                                dirAccess.addFileAndCommit(filePointer, rootRKey, pointer.filePointer, getSigner(), network, random)
+                                        .thenAccept(uploadResult -> {
+                                            setModified();
+                                            result.complete(this.withCryptreeNode(uploadResult));
+                                        });
+                            }).exceptionally(e -> {
+                                result.completeExceptionally(e);
+                                return null;
                     });
                 });
             });

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -498,7 +498,7 @@ public class FileTreeNode {
                                                 // reload directory and try again
                                                 network.getMetadata(parentLocation).thenAccept(opt -> {
                                                     DirAccess updatedUs = (DirAccess) opt.get();
-                                                    // todo check another file of same name hasn't been added in the change
+                                                    // todo check another file of same name hasn't been added in the concurrent change
 
                                                     updatedUs.addFileAndCommit(filePointer, rootRKey, pointer.filePointer, getSigner(), network, random)
                                                             .thenAccept(uploadResult -> {

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -150,7 +150,6 @@ public class FileTreeNode {
      */
     public CompletableFuture<FileTreeNode> makeDirty(NetworkAccess network, SafeRandom random,
                                                      FileTreeNode parent, Set<String> readersToRemove) {
-        setModified();
         if (!isWritable())
             throw new IllegalStateException("You cannot mark a file as dirty without write access!");
         if (isDirectory()) {
@@ -196,6 +195,9 @@ public class FileTreeNode {
                                                 .thenApply(x -> theNewUs);
                                     });
                                 });
+                    }).thenApply(x -> {
+                        setModified();
+                        return x;
                     });
         } else {
             // create a new baseKey == parentKey and mark the metaDataKey as dirty
@@ -211,6 +213,9 @@ public class FileTreeNode {
                 return ((DirAccess) parent.pointer.fileAccess)
                         .updateChildLink(parent.writableFilePointer(), pointer, newPointer, getSigner(), network, random)
                         .thenApply(x -> new FileTreeNode(newPointer, ownername, newReaders, writers, entryWriterKey));
+            }).thenApply(x -> {
+                setModified();
+                return x;
             });
         }
     }

--- a/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
+++ b/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
@@ -4,6 +4,7 @@ import peergos.shared.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.user.*;
+import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.*;
 
 import java.io.*;
@@ -59,11 +60,12 @@ public class LazyInputStreamCombiner implements AsyncReader {
                     err.completeExceptionally(new EOFException());
                     return err;
                 }
-                if (! (meta.get() instanceof FileAccess))
+                CryptreeNode access = meta.get();
+                if (! (access instanceof FileAccess))
                     throw new IllegalStateException("File linked to a directory for its next chunk!");
-                FileRetriever nextRet = ((FileAccess) meta.get()).retriever();
+                FileRetriever nextRet = ((FileAccess) access).retriever();
                 Location newNextChunkPointer = nextRet.getNext(dataKey).orElse(null);
-                return nextRet.getChunkInputStream(network, random, dataKey, 0, len, nextLocation, monitor)
+                return nextRet.getChunkInputStream(network, random, dataKey, 0, len, nextLocation, access.committedHash(), monitor)
                         .thenApply(x -> {
                             byte[] nextData = x.get().chunk.data();
                             updateState(0,globalIndex + Chunk.MAX_SIZE, nextData, newNextChunkPointer);

--- a/src/peergos/shared/user/fs/LocatedChunk.java
+++ b/src/peergos/shared/user/fs/LocatedChunk.java
@@ -1,11 +1,15 @@
 package peergos.shared.user.fs;
 
+import peergos.shared.merklebtree.*;
+
 public class LocatedChunk {
     public final Location location;
+    public final MaybeMultihash existingHash;
     public final Chunk chunk;
 
-    public LocatedChunk(Location location, Chunk chunk) {
+    public LocatedChunk(Location location, MaybeMultihash existingHash, Chunk chunk) {
         this.location = location;
+        this.existingHash = existingHash;
         this.chunk = chunk;
     }
 }

--- a/src/peergos/shared/user/fs/LocatedEncryptedChunk.java
+++ b/src/peergos/shared/user/fs/LocatedEncryptedChunk.java
@@ -1,12 +1,16 @@
 package peergos.shared.user.fs;
 
+import peergos.shared.merklebtree.*;
+
 public class LocatedEncryptedChunk {
     public final Location location;
+    public final MaybeMultihash existingHash;
     public final EncryptedChunk chunk;
     public final byte[] nonce;
 
-    public LocatedEncryptedChunk(Location location, EncryptedChunk chunk, byte[] nonce) {
+    public LocatedEncryptedChunk(Location location, MaybeMultihash existingHash, EncryptedChunk chunk, byte[] nonce) {
         this.location = location;
+        this.existingHash = existingHash;
         this.chunk = chunk;
         this.nonce = nonce;
     }

--- a/src/peergos/shared/user/fs/RetrievedFilePointer.java
+++ b/src/peergos/shared/user/fs/RetrievedFilePointer.java
@@ -28,12 +28,14 @@ public class RetrievedFilePointer {
         return filePointer.equals(((RetrievedFilePointer)that).filePointer);
     }
 
-    public CompletableFuture<Boolean> remove(NetworkAccess network, RetrievedFilePointer parentRetrievedFilePointer, SigningPrivateKeyAndPublicHash signer) {
-        if (!this.filePointer.isWritable())
+    public CompletableFuture<Boolean> remove(NetworkAccess network,
+                                             RetrievedFilePointer parentRetrievedFilePointer,
+                                             SigningPrivateKeyAndPublicHash signer) {
+        if (! filePointer.isWritable())
             return CompletableFuture.completedFuture(false);
-        if (!this.fileAccess.isDirectory()) {
+        if (! fileAccess.isDirectory()) {
             CompletableFuture<Boolean> result = new CompletableFuture<>();
-            network.btree.remove(signer, this.filePointer.location.getMapKey()).thenAccept(removed -> {
+            network.btree.remove(signer, this.filePointer.location.getMapKey(), fileAccess.committedHash()).thenAccept(removed -> {
                 // remove from parent
                 if (parentRetrievedFilePointer != null)
                     ((DirAccess) parentRetrievedFilePointer.fileAccess).removeChild(this, parentRetrievedFilePointer.filePointer, signer, network);
@@ -41,11 +43,11 @@ public class RetrievedFilePointer {
             });
             return result;
         }
-        return ((DirAccess)fileAccess).getChildren(network, this.filePointer.baseKey).thenCompose(files -> {
+        return ((DirAccess) fileAccess).getChildren(network, this.filePointer.baseKey).thenCompose(files -> {
             for (RetrievedFilePointer file : files)
                 file.remove(network, null, signer);
             CompletableFuture<Boolean> result = new CompletableFuture<>();
-            network.btree.remove(signer, this.filePointer.location.getMapKey()).thenAccept(removed -> {
+            network.btree.remove(signer, this.filePointer.location.getMapKey(), fileAccess.committedHash()).thenAccept(removed -> {
                 // remove from parent
                 if (parentRetrievedFilePointer != null)
                     ((DirAccess) parentRetrievedFilePointer.fileAccess).removeChild(this, parentRetrievedFilePointer.filePointer, signer, network);

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -6,6 +6,8 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.merklebtree.*;
 import peergos.shared.user.fs.*;
 
 import java.util.*;
@@ -15,6 +17,8 @@ public interface CryptreeNode extends Cborable {
 
     int CURRENT_FILE_VERSION = 1;
     int CURRENT_DIR_VERSION = 1;
+
+    MaybeMultihash committedHash();
 
     boolean isDirectory();
 
@@ -59,7 +63,7 @@ public interface CryptreeNode extends Cborable {
         });
     }
 
-    static CryptreeNode fromCbor(CborObject cbor) {
+    static CryptreeNode fromCbor(CborObject cbor, Multihash hash) {
         if (! (cbor instanceof CborObject.CborList))
             throw new IllegalStateException("Incorrect cbor for FileAccess: " + cbor);
 
@@ -67,7 +71,7 @@ public interface CryptreeNode extends Cborable {
         int versionAndType = (int) ((CborObject.CborLong) value.get(0)).value;
         boolean isFile = (versionAndType & 1) != 0;
         if (isFile)
-            return FileAccess.fromCbor(cbor);
-        return DirAccess.fromCbor(cbor);
+            return FileAccess.fromCbor(cbor, hash);
+        return DirAccess.fromCbor(cbor, hash);
     }
 }


### PR DESCRIPTION
Changed the btree api to make puts do a cas on the expected hash for a given key. This removes a class of data loss errors possible under current modifications to the same file or folder. 