### PR TITLE
Implement mime-type in FileProperties

### DIFF
--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -294,7 +294,7 @@ public class MultiUserTests {
             byte[] properties = ((CborObject.CborByteArray) ((CborObject.CborList) fileAccess.toCbor()).value.get(1)).value;
             byte[] nonce = Arrays.copyOfRange(properties, 0, TweetNaCl.SECRETBOX_NONCE_BYTES);
             byte[] cipher = Arrays.copyOfRange(properties, TweetNaCl.SECRETBOX_NONCE_BYTES, properties.length);
-            FileProperties props =  FileProperties.deserialize(priorMetaKey.decrypt(cipher, nonce));
+            FileProperties props =  FileProperties.fromCbor(CborObject.fromByteArray(priorMetaKey.decrypt(cipher, nonce)));
             throw new IllegalStateException("We shouldn't be able to decrypt this after a rename! new name = " + props.name);
         } catch (TweetNaCl.InvalidCipherTextException e) {}
         try {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -402,7 +402,7 @@ public class UserContext {
             EntryPoint entry = new EntryPoint(rootPointer, this.username, Collections.emptySet(), Collections.emptySet());
 
             long t2 = System.currentTimeMillis();
-            DirAccess root = DirAccess.create(MaybeMultihash.empty(), rootRKey, new FileProperties(directoryName,
+            DirAccess root = DirAccess.create(MaybeMultihash.empty(), rootRKey, new FileProperties(directoryName, "",
                     0, LocalDateTime.now(), false, Optional.empty()), (Location) null, null, null);
             Location rootLocation = new Location(this.signer.publicKeyHash, writerHash, rootMapKey);
             System.out.println("Uploading entry point directory");

--- a/src/peergos/shared/user/fs/DirAccess.java
+++ b/src/peergos/shared/user/fs/DirAccess.java
@@ -446,7 +446,7 @@ public class DirAccess implements CryptreeNode {
         random.randombytes(dirMapKey, 0, 32);
         SymmetricKey ourParentKey = this.getParentKey(baseKey);
         Location ourLocation = new Location(ownerPublic, writer.publicKeyHash, ourMapKey);
-        DirAccess dir = DirAccess.create(MaybeMultihash.empty(), dirReadKey, new FileProperties(name, 0, LocalDateTime.now(),
+        DirAccess dir = DirAccess.create(MaybeMultihash.empty(), dirReadKey, new FileProperties(name, "", 0, LocalDateTime.now(),
                 isSystemFolder, Optional.empty()), ourLocation, ourParentKey, null);
         Location chunkLocation = new Location(ownerPublic, writer.publicKeyHash, dirMapKey);
         return network.uploadChunk(dir, chunkLocation, writer).thenCompose(resultHash -> {

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -500,9 +500,10 @@ public class FileTreeNode {
             SymmetricKey dirParentKey = dirAccess.getParentKey(rootRKey);
             Location parentLocation = getLocation();
             int thumbnailSrcImageSize = startIndex == 0 && endIndex < Integer.MAX_VALUE ? (int)endIndex : 0;
+            boolean hasMime = thumbnailSrcImageSize > 0;
             return generateThumbnail(network, fileData, thumbnailSrcImageSize, filename)
                     .thenCompose(thumbData -> fileData.reset()
-                            .thenCompose(forMime -> calculateMimeType(forMime)
+                            .thenCompose(forMime -> (hasMime ? calculateMimeType(forMime) : CompletableFuture.completedFuture(""))
                                     .thenCompose(mimeType -> fileData.reset().thenCompose(resetReader -> {
                                         FileProperties fileProps = new FileProperties(filename, mimeType, endIndex,
                                                 LocalDateTime.now(), isHidden, Optional.of(thumbData));

--- a/src/peergos/shared/user/fs/FileTreeNode.java
+++ b/src/peergos/shared/user/fs/FileTreeNode.java
@@ -500,7 +500,7 @@ public class FileTreeNode {
             SymmetricKey dirParentKey = dirAccess.getParentKey(rootRKey);
             Location parentLocation = getLocation();
             int thumbnailSrcImageSize = startIndex == 0 && endIndex < Integer.MAX_VALUE ? (int)endIndex : 0;
-            boolean hasMime = thumbnailSrcImageSize > 0;
+            boolean hasMime = thumbnailSrcImageSize >= 8;
             return generateThumbnail(network, fileData, thumbnailSrcImageSize, filename)
                     .thenCompose(thumbData -> fileData.reset()
                             .thenCompose(forMime -> (hasMime ? calculateMimeType(forMime) : CompletableFuture.completedFuture(""))

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -30,12 +30,15 @@ public class FileUploader implements AutoCloseable {
     private final AsyncReader reader; // resettable input stream
 
     @JsConstructor
-    public FileUploader(String name, AsyncReader fileData, int offsetHi, int offsetLow, int lengthHi, int lengthLow,
-                        SymmetricKey baseKey, SymmetricKey metaKey, Location parentLocation, SymmetricKey parentparentKey,
-                        ProgressConsumer<Long> monitor, FileProperties fileProperties, Fragmenter fragmenter) {
+    public FileUploader(String name, String mimeType, AsyncReader fileData,
+                        int offsetHi, int offsetLow, int lengthHi, int lengthLow,
+                        SymmetricKey baseKey, SymmetricKey metaKey,
+                        Location parentLocation, SymmetricKey parentparentKey,
+                        ProgressConsumer<Long> monitor,
+                        FileProperties fileProperties, Fragmenter fragmenter) {
         long length = lengthLow + ((lengthHi & 0xFFFFFFFFL) << 32);
         if (fileProperties == null)
-            this.props = new FileProperties(name, length, LocalDateTime.now(), false, Optional.empty());
+            this.props = new FileProperties(name, mimeType, length, LocalDateTime.now(), false, Optional.empty());
         else
             this.props = fileProperties;
         if (baseKey == null) baseKey = SymmetricKey.random();
@@ -57,9 +60,10 @@ public class FileUploader implements AutoCloseable {
         this.monitor = monitor;
     }
 
-    public FileUploader(String name, AsyncReader fileData, long offset, long length, SymmetricKey baseKey, SymmetricKey metaKey, Location parentLocation, SymmetricKey parentparentKey,
+    public FileUploader(String name, String mimeType, AsyncReader fileData, long offset, long length,
+                        SymmetricKey baseKey, SymmetricKey metaKey, Location parentLocation, SymmetricKey parentparentKey,
                         ProgressConsumer<Long> monitor, FileProperties fileProperties, Fragmenter fragmenter) {
-        this(name, fileData, (int)(offset >> 32), (int) offset, (int) (length >> 32), (int) length,
+        this(name, mimeType, fileData, (int)(offset >> 32), (int) offset, (int) (length >> 32), (int) length,
                 baseKey, metaKey, parentLocation, parentparentKey, monitor, fileProperties, fragmenter);
     }
 


### PR DESCRIPTION
(and change the properties to cbor) It is calculated based on the file start. 

This will allow an easy solution to stop the video/audio player having to guess the mime type from the filename.