### PR TITLE
Feat/authenticated writes

### DIFF
--- a/src/peergos/server/RegisteredUserKeyFilter.java
+++ b/src/peergos/server/RegisteredUserKeyFilter.java
@@ -1,0 +1,52 @@
+package peergos.server;
+
+import peergos.server.storage.*;
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.mutable.*;
+import peergos.shared.storage.*;
+import peergos.shared.user.*;
+
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class RegisteredUserKeyFilter implements KeyFilter {
+
+    private final CoreNode core;
+    private final MutablePointers mutable;
+    private final ContentAddressedStorage dht;
+    private final Map<PublicKeyHash, Boolean> allowedKeys = new ConcurrentHashMap<>();
+
+    public RegisteredUserKeyFilter(CoreNode core, MutablePointers mutable, ContentAddressedStorage dht) {
+        this.core = core;
+        this.mutable = mutable;
+        this.dht = dht;
+    }
+
+    private void reloadKeys() {
+        try {
+            List<String> usernames = core.getUsernames("").get();
+            for (String username : usernames) {
+                loadSigningKeys(username);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void loadSigningKeys(String username) {
+        for (PublicKeyHash hash : WriterData.getOwnedKeysRecursive(username, core, mutable, dht)) {
+            allowedKeys.put(hash, true);
+        }
+    }
+
+    @Override
+    public boolean isAllowed(PublicKeyHash signerHash) {
+        if (allowedKeys.getOrDefault(signerHash, false))
+            return true;
+        // slow reload
+        reloadKeys();
+        return allowedKeys.getOrDefault(signerHash, false);
+    }
+}

--- a/src/peergos/server/RegisteredUserKeyFilter.java
+++ b/src/peergos/server/RegisteredUserKeyFilter.java
@@ -11,6 +11,7 @@ import java.util.concurrent.*;
 
 public class RegisteredUserKeyFilter {
 
+    private static final int TEN_MINUTES = 600_000;
     private final CoreNode core;
     private final MutablePointers mutable;
     private final ContentAddressedStorage dht;
@@ -20,6 +21,16 @@ public class RegisteredUserKeyFilter {
         this.core = core;
         this.mutable = mutable;
         this.dht = dht;
+        ForkJoinPool.commonPool().submit(() -> {
+            while(true) {
+                try {
+                    reloadKeys();
+                    Thread.sleep(TEN_MINUTES);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        });
     }
 
     private void reloadKeys() {

--- a/src/peergos/server/RegisteredUserKeyFilter.java
+++ b/src/peergos/server/RegisteredUserKeyFilter.java
@@ -11,7 +11,7 @@ import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-public class RegisteredUserKeyFilter implements KeyFilter {
+public class RegisteredUserKeyFilter {
 
     private final CoreNode core;
     private final MutablePointers mutable;
@@ -41,7 +41,6 @@ public class RegisteredUserKeyFilter implements KeyFilter {
         }
     }
 
-    @Override
     public boolean isAllowed(PublicKeyHash signerHash) {
         if (allowedKeys.getOrDefault(signerHash, false))
             return true;

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -157,7 +157,7 @@ public class UserService
 
         Function<HttpHandler, HttpHandler> wrap = h -> !isLocal ? new HSTSHandler(h) : h;
 
-        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht)));
+        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht, new RegisteredUserKeyFilter(coreNode, mutable, dht))));
         server.createContext(SIGNUP_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
         server.createContext(ACTIVATION_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
 

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -157,7 +157,7 @@ public class UserService
 
         Function<HttpHandler, HttpHandler> wrap = h -> !isLocal ? new HSTSHandler(h) : h;
 
-        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht, new RegisteredUserKeyFilter(coreNode, mutable, dht))));
+        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht, new RegisteredUserKeyFilter(coreNode, mutable, dht)::isAllowed)));
         server.createContext(SIGNUP_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
         server.createContext(ACTIVATION_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
 

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -157,7 +157,7 @@ public class UserService
 
         Function<HttpHandler, HttpHandler> wrap = h -> !isLocal ? new HSTSHandler(h) : h;
 
-        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht, mutable)));
+        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht)));
         server.createContext(SIGNUP_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
         server.createContext(ACTIVATION_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
 

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -157,7 +157,7 @@ public class UserService
 
         Function<HttpHandler, HttpHandler> wrap = h -> !isLocal ? new HSTSHandler(h) : h;
 
-        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht)));
+        server.createContext(DHT_URL, wrap.apply(new DHTHandler(dht, mutable)));
         server.createContext(SIGNUP_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
         server.createContext(ACTIVATION_URL, wrap.apply(new InverseProxyHandler("startDemo.peergos.net", isLocal)));
 

--- a/src/peergos/server/mutable/HttpMutablePointerServer.java
+++ b/src/peergos/server/mutable/HttpMutablePointerServer.java
@@ -89,7 +89,7 @@ public class HttpMutablePointerServer
 
         void getPointer(DataInputStream din, DataOutputStream dout) throws Exception
         {
-            PublicKeyHash encodedSharingKey = PublicKeyHash.fromCbor(CborObject.deserialize(new CborDecoder(din)));
+            PublicKeyHash encodedSharingKey = PublicKeyHash.fromCbor(CborObject.deserialize(new CborDecoder(din), 1024));
             byte[] metadataBlob = mutable.getPointer(encodedSharingKey).get().orElse(new byte[0]);
 
             dout.write(metadataBlob);

--- a/src/peergos/server/mutable/HttpMutablePointerServer.java
+++ b/src/peergos/server/mutable/HttpMutablePointerServer.java
@@ -89,7 +89,7 @@ public class HttpMutablePointerServer
 
         void getPointer(DataInputStream din, DataOutputStream dout) throws Exception
         {
-            PublicKeyHash encodedSharingKey = PublicKeyHash.fromCbor(CborObject.deserialize(new CborDecoder(din), 1024));
+            PublicKeyHash encodedSharingKey = PublicKeyHash.fromCbor(CborObject.deserialize(new CborDecoder(din), PublicKeyHash.MAX_KEY_HASH_SIZE));
             byte[] metadataBlob = mutable.getPointer(encodedSharingKey).get().orElse(new byte[0]);
 
             dout.write(metadataBlob);

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -1,5 +1,6 @@
 package peergos.server.net;
 
+import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
@@ -21,16 +22,18 @@ public class DHTHandler implements HttpHandler
 {
     private static final boolean LOGGING = true;
     private final ContentAddressedStorage dht;
+    private final KeyFilter keyFilter;
     private final String apiPrefix;
 
-    public DHTHandler(ContentAddressedStorage dht, String apiPrefix) throws IOException
+    public DHTHandler(ContentAddressedStorage dht, KeyFilter keyFilter, String apiPrefix) throws IOException
     {
         this.dht = dht;
+        this.keyFilter = keyFilter;
         this.apiPrefix = apiPrefix;
     }
 
-    public DHTHandler(ContentAddressedStorage dht) throws IOException {
-        this(dht, "/api/v0/");
+    public DHTHandler(ContentAddressedStorage dht, KeyFilter keyFilter) throws IOException {
+        this(dht, keyFilter, "/api/v0/");
     }
 
     private Map<String, List<String>> parseQuery(String query) {
@@ -79,6 +82,8 @@ public class DHTHandler implements HttpHandler
                     boolean isRaw = last.apply("format").equals("raw");
 
                     // check writer is allowed to write to this server, and check their free space
+                    if (! keyFilter.isAllowed(writerHash))
+                        throw new IllegalStateException("Key not allowed to write to this server: " + writerHash);
 
                     // get the actual key, unless this is the initial write of the signing key during sign up
                     // In the initial put of a signing key during signup the key signs itself (we still check the hash

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -97,14 +97,11 @@ public class DHTHandler implements HttpHandler
                     };
                     Supplier<PublicSigningKey> inBandOrDht = () -> {
                         try {
-                            // Check if this is possible to cause an OOM error before parsing it as cbor
-                            if (PublicSigningKey.maybeValidKey(data.get(0))) {
-                                PublicSigningKey candidateKey = PublicSigningKey.fromByteArray(data.get(0));
-                                PublicKeyHash calculatedHash = dht.hashKey(candidateKey);
-                                if (calculatedHash.equals(writerHash)) {
-                                    candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
-                                    return candidateKey;
-                                }
+                            PublicSigningKey candidateKey = PublicSigningKey.fromByteArray(data.get(0));
+                            PublicKeyHash calculatedHash = dht.hashKey(candidateKey);
+                            if (calculatedHash.equals(writerHash)) {
+                                candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
+                                return candidateKey;
                             }
                         } catch (Throwable e) {
                             // If signature is not valid then the signing key has already been written, retrieve it

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -93,12 +93,14 @@ public class DHTHandler implements HttpHandler
                     Supplier<PublicSigningKey> inBandOrDht = () -> {
                         try {
                             PublicSigningKey candidateKey = PublicSigningKey.fromByteArray(data.get(0));
-                            // If signature is not valid then the signing key has already been written, retrive it
-                            candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
-                            return candidateKey;
-                        } catch (Exception e) {
-                            return fromDht.get();
-                        }
+                            PublicKeyHash calculatedHash = dht.hashKey(candidateKey);
+                            if (calculatedHash.equals(writerHash)) {
+                                // If signature is not valid then the signing key has already been written, retrieve it
+                                candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
+                                return candidateKey;
+                            }
+                        } catch (Exception e) {}
+                        return fromDht.get();
                     };
                     PublicSigningKey writer = data.size() > 1 ? fromDht.get() : inBandOrDht.get();
 

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -22,17 +22,17 @@ public class DHTHandler implements HttpHandler
 {
     private static final boolean LOGGING = true;
     private final ContentAddressedStorage dht;
-    private final KeyFilter keyFilter;
+    private final Predicate<PublicKeyHash> keyFilter;
     private final String apiPrefix;
 
-    public DHTHandler(ContentAddressedStorage dht, KeyFilter keyFilter, String apiPrefix) throws IOException
+    public DHTHandler(ContentAddressedStorage dht, Predicate<PublicKeyHash> keyFilter, String apiPrefix) throws IOException
     {
         this.dht = dht;
         this.keyFilter = keyFilter;
         this.apiPrefix = apiPrefix;
     }
 
-    public DHTHandler(ContentAddressedStorage dht, KeyFilter keyFilter) throws IOException {
+    public DHTHandler(ContentAddressedStorage dht, Predicate<PublicKeyHash> keyFilter) throws IOException {
         this(dht, keyFilter, "/api/v0/");
     }
 
@@ -82,7 +82,7 @@ public class DHTHandler implements HttpHandler
                     boolean isRaw = last.apply("format").equals("raw");
 
                     // check writer is allowed to write to this server, and check their free space
-                    if (! keyFilter.isAllowed(writerHash))
+                    if (! keyFilter.test(writerHash))
                         throw new IllegalStateException("Key not allowed to write to this server: " + writerHash);
 
                     // Get the actual key, unless this is the initial write of the signing key during sign up

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -64,7 +64,6 @@ public class DHTHandler implements HttpHandler
             switch (path) {
                 case "block/put": {
                     PublicKeyHash writerHash = PublicKeyHash.fromString(last.apply("writer"));
-                    String username = last.apply("username");
                     List<byte[]> signatures = Arrays.stream(last.apply("signatures").split(","))
                             .map(ArrayOps::hexToBytes)
                             .collect(Collectors.toList());
@@ -103,8 +102,8 @@ public class DHTHandler implements HttpHandler
                     }
 
                     (isRaw ?
-                            dht.putRaw(username, writerHash, signatures, data) :
-                            dht.put(username, writerHash, signatures, data)).thenAccept(hashes -> {
+                            dht.putRaw(writerHash, signatures, data) :
+                            dht.put(writerHash, signatures, data)).thenAccept(hashes -> {
                         List<Object> json = hashes.stream().map(h -> wrapHash(h)).collect(Collectors.toList());
                         // make stream of JSON objects
                         String jsonStream = json.stream().map(m -> JSONParser.toString(m)).reduce("", (a, b) -> a + b);

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -99,12 +99,14 @@ public class DHTHandler implements HttpHandler
                         try {
                             // find better way to check if this is a valid public key first without potentially
                             // causing an OOM by deserializing random data
-                            PublicSigningKey candidateKey = PublicSigningKey.fromByteArray(data.get(0));
-                            PublicKeyHash calculatedHash = dht.hashKey(candidateKey);
-                            if (calculatedHash.equals(writerHash)) {
-                                // If signature is not valid then the signing key has already been written, retrieve it
-                                candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
-                                return candidateKey;
+                            if (PublicSigningKey.maybeValidKey(data.get(0))) {
+                                PublicSigningKey candidateKey = PublicSigningKey.fromByteArray(data.get(0));
+                                PublicKeyHash calculatedHash = dht.hashKey(candidateKey);
+                                if (calculatedHash.equals(writerHash)) {
+                                    // If signature is not valid then the signing key has already been written, retrieve it
+                                    candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
+                                    return candidateKey;
+                                }
                             }
                         } catch (Throwable e) {}
                         return fromDht.get();

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -97,6 +97,8 @@ public class DHTHandler implements HttpHandler
                     };
                     Supplier<PublicSigningKey> inBandOrDht = () -> {
                         try {
+                            // find better way to check if this is a valid public key first without potentially
+                            // causing an OOM by deserializing random data
                             PublicSigningKey candidateKey = PublicSigningKey.fromByteArray(data.get(0));
                             PublicKeyHash calculatedHash = dht.hashKey(candidateKey);
                             if (calculatedHash.equals(writerHash)) {
@@ -104,7 +106,7 @@ public class DHTHandler implements HttpHandler
                                 candidateKey.unsignMessage(ArrayOps.concat(signatures.get(0), data.get(0)));
                                 return candidateKey;
                             }
-                        } catch (Exception e) {}
+                        } catch (Throwable e) {}
                         return fromDht.get();
                     };
                     PublicSigningKey writer = data.size() > 1 ? fromDht.get() : inBandOrDht.get();

--- a/src/peergos/server/storage/IpfsDHT.java
+++ b/src/peergos/server/storage/IpfsDHT.java
@@ -30,16 +30,16 @@ public class IpfsDHT implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-        return put(username, writer, signatures, blocks, "cbor");
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return put(writer, signatures, blocks, "cbor");
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-        return put(username, writer, signatures, blocks, "raw");
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return put(writer, signatures, blocks, "raw");
     }
 
-    private CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, String format) {
+    private CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, String format) {
         try {
             return CompletableFuture.completedFuture(ipfs.block.put(blocks, Optional.of(format)))
                     .thenApply(nodes -> nodes.stream().map(n -> n.hash).collect(Collectors.toList()));

--- a/src/peergos/server/storage/IpfsDHT.java
+++ b/src/peergos/server/storage/IpfsDHT.java
@@ -30,16 +30,16 @@ public class IpfsDHT implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks) {
-        return put(writer, blocks, "cbor");
+    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return put(username, writer, signatures, blocks, "cbor");
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> blocks) {
-        return put(writer, blocks, "raw");
+    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return put(username, writer, signatures, blocks, "raw");
     }
 
-    private CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks, String format) {
+    private CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, String format) {
         try {
             return CompletableFuture.completedFuture(ipfs.block.put(blocks, Optional.of(format)))
                     .thenApply(nodes -> nodes.stream().map(n -> n.hash).collect(Collectors.toList()));

--- a/src/peergos/server/storage/KeyFilter.java
+++ b/src/peergos/server/storage/KeyFilter.java
@@ -1,8 +1,0 @@
-package peergos.server.storage;
-
-import peergos.shared.crypto.hash.*;
-
-public interface KeyFilter {
-
-    boolean isAllowed(PublicKeyHash signerHash);
-}

--- a/src/peergos/server/storage/KeyFilter.java
+++ b/src/peergos/server/storage/KeyFilter.java
@@ -1,0 +1,8 @@
+package peergos.server.storage;
+
+import peergos.shared.crypto.hash.*;
+
+public interface KeyFilter {
+
+    boolean isAllowed(PublicKeyHash signerHash);
+}

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -21,12 +21,12 @@ public class RAMStorage implements ContentAddressedStorage {
     private final Set<Multihash> pinnedRoots = new HashSet<>();
 
     @Override
-    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
         return put(writer, blocks, false);
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
         return put(writer, blocks, true);
     }
 

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -56,7 +56,7 @@ public class RAMStorage implements ContentAddressedStorage {
     }
 
     private synchronized CborObject getAndParseObject(Multihash hash) {
-        if (!storage.containsKey(hash))
+        if (! storage.containsKey(hash))
             throw new IllegalStateException("Hash not present! "+ hash);
         return CborObject.fromByteArray(storage.get(hash));
     }

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -21,12 +21,12 @@ public class RAMStorage implements ContentAddressedStorage {
     private final Set<Multihash> pinnedRoots = new HashSet<>();
 
     @Override
-    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks) {
+    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
         return put(writer, blocks, false);
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> blocks) {
+    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
         return put(writer, blocks, true);
     }
 

--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -3,6 +3,7 @@ package peergos.server.tests;
 import org.junit.*;
 import peergos.shared.cbor.*;
 import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.util.*;
 
 import java.util.*;
 
@@ -13,6 +14,16 @@ public class CborObjects {
         byte[] res = new byte[len];
         rnd.nextBytes(res);
         return res;
+    }
+
+    @Test
+    public void dosCborObject() throws Throwable {
+        // make a header for a byte[] that is 2^50 long
+        byte[] raw = ArrayOps.hexToBytes("5b0004000000000000");
+        try {
+            CborObject.fromByteArray(raw);
+            throw new Throwable("Should have failed!");
+        } catch (RuntimeException e) {}
     }
 
     @Test

--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -22,7 +22,7 @@ public class CborObjects {
         byte[] raw = ArrayOps.hexToBytes("5b0004000000000000");
         try {
             CborObject.fromByteArray(raw);
-            throw new Throwable("Should have failed!");
+            Assert.fail("Should have failed!");
         } catch (RuntimeException e) {}
     }
 

--- a/src/peergos/server/tests/CorenodeTests.java
+++ b/src/peergos/server/tests/CorenodeTests.java
@@ -65,11 +65,11 @@ public class CorenodeTests {
             worstLatencies.add(pool.submit(() -> {
                 SigningKeyPair owner = SigningKeyPair.random(crypto.random, crypto.signer);
                 SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
-                PublicKeyHash ownerHash = network.dhtClient.putSigningKey("",
+                PublicKeyHash ownerHash = network.dhtClient.putSigningKey(
                         owner.secretSigningKey.signOnly(owner.publicSigningKey.serialize()),
                         network.dhtClient.hashKey(owner.publicSigningKey),
                         owner.publicSigningKey).get();
-                PublicKeyHash writerHash = network.dhtClient.putSigningKey("",
+                PublicKeyHash writerHash = network.dhtClient.putSigningKey(
                         owner.secretSigningKey.signOnly(writer.publicSigningKey.serialize()),
                         ownerHash, writer.publicSigningKey).get();
 

--- a/src/peergos/server/tests/CorenodeTests.java
+++ b/src/peergos/server/tests/CorenodeTests.java
@@ -65,8 +65,10 @@ public class CorenodeTests {
             worstLatencies.add(pool.submit(() -> {
                 SigningKeyPair owner = SigningKeyPair.random(crypto.random, crypto.signer);
                 SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
-                PublicKeyHash ownerHash = network.dhtClient.putSigningKey(owner.publicSigningKey).get();
-                PublicKeyHash writerHash = network.dhtClient.putSigningKey(writer.publicSigningKey).get();
+                PublicKeyHash ownerHash = network.dhtClient.putSigningKey("",
+                        owner.secretSigningKey.signOnly(owner.publicSigningKey.serialize()), owner.publicSigningKey).get();
+                PublicKeyHash writerHash = network.dhtClient.putSigningKey("",
+                        owner.secretSigningKey.signOnly(writer.publicSigningKey.serialize()), writer.publicSigningKey).get();
 
                 byte[] data = new byte[10];
 

--- a/src/peergos/server/tests/CorenodeTests.java
+++ b/src/peergos/server/tests/CorenodeTests.java
@@ -66,11 +66,11 @@ public class CorenodeTests {
                 SigningKeyPair owner = SigningKeyPair.random(crypto.random, crypto.signer);
                 SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
                 PublicKeyHash ownerHash = network.dhtClient.putSigningKey(
-                        owner.secretSigningKey.signOnly(owner.publicSigningKey.serialize()),
+                        owner.secretSigningKey.signatureOnly(owner.publicSigningKey.serialize()),
                         network.dhtClient.hashKey(owner.publicSigningKey),
                         owner.publicSigningKey).get();
                 PublicKeyHash writerHash = network.dhtClient.putSigningKey(
-                        owner.secretSigningKey.signOnly(writer.publicSigningKey.serialize()),
+                        owner.secretSigningKey.signatureOnly(writer.publicSigningKey.serialize()),
                         ownerHash, writer.publicSigningKey).get();
 
                 byte[] data = new byte[10];

--- a/src/peergos/server/tests/CorenodeTests.java
+++ b/src/peergos/server/tests/CorenodeTests.java
@@ -66,9 +66,12 @@ public class CorenodeTests {
                 SigningKeyPair owner = SigningKeyPair.random(crypto.random, crypto.signer);
                 SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
                 PublicKeyHash ownerHash = network.dhtClient.putSigningKey("",
-                        owner.secretSigningKey.signOnly(owner.publicSigningKey.serialize()), owner.publicSigningKey).get();
+                        owner.secretSigningKey.signOnly(owner.publicSigningKey.serialize()),
+                        network.dhtClient.hashKey(owner.publicSigningKey),
+                        owner.publicSigningKey).get();
                 PublicKeyHash writerHash = network.dhtClient.putSigningKey("",
-                        owner.secretSigningKey.signOnly(writer.publicSigningKey.serialize()), writer.publicSigningKey).get();
+                        owner.secretSigningKey.signOnly(writer.publicSigningKey.serialize()),
+                        ownerHash, writer.publicSigningKey).get();
 
                 byte[] data = new byte[10];
 

--- a/src/peergos/server/tests/JDBCCoreNodeTests.java
+++ b/src/peergos/server/tests/JDBCCoreNodeTests.java
@@ -52,7 +52,7 @@ public class JDBCCoreNodeTests {
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(
             username, user.secretSigningKey, LocalDate.now().plusYears(2));
         try {
-            PublicKeyHash owner = STORAGE.putSigningKey("a",
+            PublicKeyHash owner = STORAGE.putSigningKey(
                     user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
                     STORAGE.hashKey(user.publicSigningKey),
                     user.publicSigningKey).get();

--- a/src/peergos/server/tests/JDBCCoreNodeTests.java
+++ b/src/peergos/server/tests/JDBCCoreNodeTests.java
@@ -52,7 +52,7 @@ public class JDBCCoreNodeTests {
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(
             username, user.secretSigningKey, LocalDate.now().plusYears(2));
         try {
-            PublicKeyHash owner = STORAGE.putSigningKey(user.publicSigningKey).get();
+            PublicKeyHash owner = STORAGE.putSigningKey("a", user.secretSigningKey.signOnly(user.publicSigningKey.serialize()), user.publicSigningKey).get();
             UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
             return coreNode.updateChain(
                 username, Arrays.asList(), Arrays.asList(upl), Arrays.asList(upl));

--- a/src/peergos/server/tests/JDBCCoreNodeTests.java
+++ b/src/peergos/server/tests/JDBCCoreNodeTests.java
@@ -20,10 +20,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 public class JDBCCoreNodeTests {
@@ -53,7 +51,7 @@ public class JDBCCoreNodeTests {
             username, user.secretSigningKey, LocalDate.now().plusYears(2));
         try {
             PublicKeyHash owner = STORAGE.putSigningKey(
-                    user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
+                    user.secretSigningKey.signatureOnly(user.publicSigningKey.serialize()),
                     STORAGE.hashKey(user.publicSigningKey),
                     user.publicSigningKey).get();
             UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);

--- a/src/peergos/server/tests/JDBCCoreNodeTests.java
+++ b/src/peergos/server/tests/JDBCCoreNodeTests.java
@@ -52,7 +52,10 @@ public class JDBCCoreNodeTests {
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(
             username, user.secretSigningKey, LocalDate.now().plusYears(2));
         try {
-            PublicKeyHash owner = STORAGE.putSigningKey("a", user.secretSigningKey.signOnly(user.publicSigningKey.serialize()), user.publicSigningKey).get();
+            PublicKeyHash owner = STORAGE.putSigningKey("a",
+                    user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
+                    STORAGE.hashKey(user.publicSigningKey),
+                    user.publicSigningKey).get();
             UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
             return coreNode.updateChain(
                 username, Arrays.asList(), Arrays.asList(upl), Arrays.asList(upl));

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -30,7 +30,7 @@ public class MerkleBtree {
         SigningKeyPair random = SigningKeyPair.random(crypto.random, crypto.signer);
         try {
             RAMStorage storage = createStorage();
-            PublicKeyHash publicHash = storage.putSigningKey("",
+            PublicKeyHash publicHash = storage.putSigningKey(
                     random.secretSigningKey.signOnly(random.publicSigningKey.serialize()),
                     storage.hashKey(random.publicSigningKey),
                     random.publicSigningKey).get();

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -219,7 +219,7 @@ public class MerkleBtree {
         }
 
         int size = ((RAMStorage)tree.storage).size();
-        if (size != 30)
+        if (size != 31)
             throw new IllegalStateException("Storage size != 3");
 
         long t1 = System.currentTimeMillis();

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -123,7 +123,7 @@ public class MerkleBtree {
 
         long t1 = System.currentTimeMillis();
         Random r = new Random(1);
-        int lim = 140000;
+        int lim = 14000;
         for (int i = 0; i < lim; i++) {
             if (i % (lim/10) == 0)
                 System.out.println((10*i/lim)+"0 %");

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -29,7 +29,11 @@ public class MerkleBtree {
     public SigningPrivateKeyAndPublicHash createUser() {
         SigningKeyPair random = SigningKeyPair.random(crypto.random, crypto.signer);
         try {
-            PublicKeyHash publicHash = createStorage().putSigningKey("", random.secretSigningKey.signOnly(random.publicSigningKey.serialize()), random.publicSigningKey).get();
+            RAMStorage storage = createStorage();
+            PublicKeyHash publicHash = storage.putSigningKey("",
+                    random.secretSigningKey.signOnly(random.publicSigningKey.serialize()),
+                    storage.hashKey(random.publicSigningKey),
+                    random.publicSigningKey).get();
             return new SigningPrivateKeyAndPublicHash(publicHash, random.secretSigningKey);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -31,7 +31,7 @@ public class MerkleBtree {
         try {
             RAMStorage storage = createStorage();
             PublicKeyHash publicHash = storage.putSigningKey(
-                    random.secretSigningKey.signOnly(random.publicSigningKey.serialize()),
+                    random.secretSigningKey.signatureOnly(random.publicSigningKey.serialize()),
                     storage.hashKey(random.publicSigningKey),
                     random.publicSigningKey).get();
             return new SigningPrivateKeyAndPublicHash(publicHash, random.secretSigningKey);

--- a/src/peergos/server/tests/MerkleBtree.java
+++ b/src/peergos/server/tests/MerkleBtree.java
@@ -2,6 +2,8 @@ package peergos.server.tests;
 
 import org.junit.*;
 import peergos.server.storage.*;
+import peergos.shared.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.merklebtree.*;
@@ -14,20 +16,28 @@ import java.util.concurrent.*;
 
 public class MerkleBtree {
 
+    private Crypto crypto = Crypto.initJava();
+
     public RAMStorage createStorage() {
         return RAMStorage.getSingleton();
     }
 
-    public CompletableFuture<MerkleBTree> createTree(PublicKeyHash user) throws IOException {
+    public CompletableFuture<MerkleBTree> createTree(SigningPrivateKeyAndPublicHash user) throws IOException {
         return createTree(user, RAMStorage.getSingleton());
     }
 
-    public PublicKeyHash createUser() {
-        return PublicKeyHash.NULL;
+    public SigningPrivateKeyAndPublicHash createUser() {
+        SigningKeyPair random = SigningKeyPair.random(crypto.random, crypto.signer);
+        try {
+            PublicKeyHash publicHash = createStorage().putSigningKey("", random.secretSigningKey.signOnly(random.publicSigningKey.serialize()), random.publicSigningKey).get();
+            return new SigningPrivateKeyAndPublicHash(publicHash, random.secretSigningKey);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    public CompletableFuture<MerkleBTree> createTree(PublicKeyHash user, ContentAddressedStorage dht) throws IOException {
-        return MerkleBTree.create(user, MaybeMultihash.empty(), dht);
+    public CompletableFuture<MerkleBTree> createTree(SigningPrivateKeyAndPublicHash user, ContentAddressedStorage dht) throws IOException {
+        return MerkleBTree.create(user, dht);
     }
 
     public Multihash hash(byte[] in) {
@@ -36,7 +46,7 @@ public class MerkleBtree {
 
     @Test
     public void basic() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         MerkleBTree tree = createTree(user).get();
         byte[] key1 = new byte[]{0, 1, 2, 3};
         Multihash value1 = hash(new byte[]{1, 1, 1, 1});
@@ -48,7 +58,7 @@ public class MerkleBtree {
 
     @Test
     public void basic2() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         RAMStorage dht = createStorage();
         MerkleBTree tree = createTree(user, dht).get();
         for (int i=0; i < 16; i++) {
@@ -65,7 +75,7 @@ public class MerkleBtree {
 
     @Test
     public void overwriteValue() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         MerkleBTree tree = createTree(user).get();
         byte[] key1 = new byte[]{0, 1, 2, 3};
         Multihash value1 = hash(new byte[]{1, 1, 1, 1});
@@ -82,7 +92,7 @@ public class MerkleBtree {
 
 //    @Test
     public void huge() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         MerkleBTree tree = createTree(user).get();
         long t1 = System.currentTimeMillis();
         for (int i=0; i < 1000000; i++) {
@@ -107,7 +117,7 @@ public class MerkleBtree {
 
     @Test
     public void random() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         MerkleBTree tree = createTree(user).get();
         int keylen = 32;
 
@@ -135,7 +145,7 @@ public class MerkleBtree {
 
 //    @Test
     public void delete() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         MerkleBTree tree = createTree(user).get();
         int keylen = 32;
 
@@ -185,7 +195,7 @@ public class MerkleBtree {
 
     @Test
     public void storageSize() throws Exception {
-        PublicKeyHash user = createUser();
+        SigningPrivateKeyAndPublicHash user = createUser();
         MerkleBTree tree = createTree(user).get();
         int keylen = 32;
 

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -34,7 +34,7 @@ public class UserPublicKeyLinkTests {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2));
 
-        PublicKeyHash owner = ipfs.putSigningKey(user.publicSigningKey).get();
+        PublicKeyHash owner = ipfs.putSigningKey("", user.secretSigningKey.signOnly(user.publicSigningKey.serialize()), user.publicSigningKey).get();
         UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
         testSerialization(upl);
     }
@@ -51,8 +51,8 @@ public class UserPublicKeyLinkTests {
     public void createChain() throws Exception {
         SigningKeyPair oldUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         SigningKeyPair newUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
-        PublicKeyHash oldHash = ipfs.putSigningKey(oldUser.publicSigningKey).get();
-        PublicKeyHash newHash = ipfs.putSigningKey(newUser.publicSigningKey).get();
+        PublicKeyHash oldHash = ipfs.putSigningKey("", oldUser.secretSigningKey.signOnly(oldUser.publicSigningKey.serialize()), oldUser.publicSigningKey).get();
+        PublicKeyHash newHash = ipfs.putSigningKey("", newUser.secretSigningKey.signOnly(newUser.publicSigningKey.serialize()), newUser.publicSigningKey).get();
 
         SigningPrivateKeyAndPublicHash oldSigner = new SigningPrivateKeyAndPublicHash(oldHash, oldUser.secretSigningKey);
         SigningPrivateKeyAndPublicHash newSigner = new SigningPrivateKeyAndPublicHash(newHash, newUser.secretSigningKey);
@@ -69,7 +69,7 @@ public class UserPublicKeyLinkTests {
 
         // register the username
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2));
-        PublicKeyHash userHash = ipfs.putSigningKey(user.publicSigningKey).get();
+        PublicKeyHash userHash = ipfs.putSigningKey("", user.secretSigningKey.signOnly(user.publicSigningKey.serialize()), user.publicSigningKey).get();
         UserPublicKeyLink upl = new UserPublicKeyLink(userHash, node);
         boolean success = core.updateChain(username, Arrays.asList(upl)).get();
         List<UserPublicKeyLink> chain = core.getChain(username).get();
@@ -86,7 +86,7 @@ public class UserPublicKeyLinkTests {
 
         // now change the keys
         SigningKeyPair user2 = SigningKeyPair.insecureRandom();
-        PublicKeyHash user2Hash = ipfs.putSigningKey(user2.publicSigningKey).get();
+        PublicKeyHash user2Hash = ipfs.putSigningKey("", user2.secretSigningKey.signOnly(user2.publicSigningKey.serialize()), user2.publicSigningKey).get();
         SigningPrivateKeyAndPublicHash oldUser = new SigningPrivateKeyAndPublicHash(userHash, user.secretSigningKey);
         SigningPrivateKeyAndPublicHash newUser = new SigningPrivateKeyAndPublicHash(user2Hash, user2.secretSigningKey);
         List<UserPublicKeyLink> chain3 = UserPublicKeyLink.createChain(oldUser, newUser, username, LocalDate.now().plusWeeks(1));
@@ -111,7 +111,7 @@ public class UserPublicKeyLinkTests {
 
         // try to claim the same username with a different key
         SigningKeyPair user3 = SigningKeyPair.insecureRandom();
-        PublicKeyHash user3Hash = ipfs.putSigningKey(user3.publicSigningKey).get();
+        PublicKeyHash user3Hash = ipfs.putSigningKey("", user3.secretSigningKey.signOnly(user3.publicSigningKey.serialize()), user3.publicSigningKey).get();
         UserPublicKeyLink.UsernameClaim node3 = UserPublicKeyLink.UsernameClaim.create(username, user3.secretSigningKey, LocalDate.now().plusMonths(2));
         UserPublicKeyLink upl3 = new UserPublicKeyLink(user3Hash, node3);
         try {

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -35,7 +35,7 @@ public class UserPublicKeyLinkTests {
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2));
 
         PublicKeyHash owner = ipfs.putSigningKey(
-                user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
+                user.secretSigningKey.signatureOnly(user.publicSigningKey.serialize()),
                 ipfs.hashKey(user.publicSigningKey),
                 user.publicSigningKey).get();
         UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
@@ -55,11 +55,11 @@ public class UserPublicKeyLinkTests {
         SigningKeyPair oldUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         SigningKeyPair newUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         PublicKeyHash oldHash = ipfs.putSigningKey(
-                oldUser.secretSigningKey.signOnly(oldUser.publicSigningKey.serialize()),
+                oldUser.secretSigningKey.signatureOnly(oldUser.publicSigningKey.serialize()),
                 ipfs.hashKey(oldUser.publicSigningKey),
                 oldUser.publicSigningKey).get();
         PublicKeyHash newHash = ipfs.putSigningKey(
-                newUser.secretSigningKey.signOnly(newUser.publicSigningKey.serialize()),
+                newUser.secretSigningKey.signatureOnly(newUser.publicSigningKey.serialize()),
                 ipfs.hashKey(newUser.publicSigningKey),
                 newUser.publicSigningKey).get();
 
@@ -79,7 +79,7 @@ public class UserPublicKeyLinkTests {
         // register the username
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2));
         PublicKeyHash userHash = ipfs.putSigningKey(
-                user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
+                user.secretSigningKey.signatureOnly(user.publicSigningKey.serialize()),
                 ipfs.hashKey(user.publicSigningKey),
                 user.publicSigningKey).get();
         UserPublicKeyLink upl = new UserPublicKeyLink(userHash, node);
@@ -99,7 +99,7 @@ public class UserPublicKeyLinkTests {
         // now change the keys
         SigningKeyPair user2 = SigningKeyPair.insecureRandom();
         PublicKeyHash user2Hash = ipfs.putSigningKey(
-                user2.secretSigningKey.signOnly(user2.publicSigningKey.serialize()),
+                user2.secretSigningKey.signatureOnly(user2.publicSigningKey.serialize()),
                 ipfs.hashKey(user2.publicSigningKey),
                 user2.publicSigningKey).get();
         SigningPrivateKeyAndPublicHash oldUser = new SigningPrivateKeyAndPublicHash(userHash, user.secretSigningKey);
@@ -127,7 +127,7 @@ public class UserPublicKeyLinkTests {
         // try to claim the same username with a different key
         SigningKeyPair user3 = SigningKeyPair.insecureRandom();
         PublicKeyHash user3Hash = ipfs.putSigningKey(
-                user3.secretSigningKey.signOnly(user3.publicSigningKey.serialize()),
+                user3.secretSigningKey.signatureOnly(user3.publicSigningKey.serialize()),
                 ipfs.hashKey(user3.publicSigningKey),
                 user3.publicSigningKey).get();
         UserPublicKeyLink.UsernameClaim node3 = UserPublicKeyLink.UsernameClaim.create(username, user3.secretSigningKey, LocalDate.now().plusMonths(2));

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -34,7 +34,10 @@ public class UserPublicKeyLinkTests {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2));
 
-        PublicKeyHash owner = ipfs.putSigningKey("", user.secretSigningKey.signOnly(user.publicSigningKey.serialize()), user.publicSigningKey).get();
+        PublicKeyHash owner = ipfs.putSigningKey("",
+                user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
+                ipfs.hashKey(user.publicSigningKey),
+                user.publicSigningKey).get();
         UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
         testSerialization(upl);
     }
@@ -51,8 +54,14 @@ public class UserPublicKeyLinkTests {
     public void createChain() throws Exception {
         SigningKeyPair oldUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         SigningKeyPair newUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
-        PublicKeyHash oldHash = ipfs.putSigningKey("", oldUser.secretSigningKey.signOnly(oldUser.publicSigningKey.serialize()), oldUser.publicSigningKey).get();
-        PublicKeyHash newHash = ipfs.putSigningKey("", newUser.secretSigningKey.signOnly(newUser.publicSigningKey.serialize()), newUser.publicSigningKey).get();
+        PublicKeyHash oldHash = ipfs.putSigningKey("",
+                oldUser.secretSigningKey.signOnly(oldUser.publicSigningKey.serialize()),
+                ipfs.hashKey(oldUser.publicSigningKey),
+                oldUser.publicSigningKey).get();
+        PublicKeyHash newHash = ipfs.putSigningKey("",
+                newUser.secretSigningKey.signOnly(newUser.publicSigningKey.serialize()),
+                ipfs.hashKey(newUser.publicSigningKey),
+                newUser.publicSigningKey).get();
 
         SigningPrivateKeyAndPublicHash oldSigner = new SigningPrivateKeyAndPublicHash(oldHash, oldUser.secretSigningKey);
         SigningPrivateKeyAndPublicHash newSigner = new SigningPrivateKeyAndPublicHash(newHash, newUser.secretSigningKey);
@@ -69,7 +78,10 @@ public class UserPublicKeyLinkTests {
 
         // register the username
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2));
-        PublicKeyHash userHash = ipfs.putSigningKey("", user.secretSigningKey.signOnly(user.publicSigningKey.serialize()), user.publicSigningKey).get();
+        PublicKeyHash userHash = ipfs.putSigningKey("",
+                user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
+                ipfs.hashKey(user.publicSigningKey),
+                user.publicSigningKey).get();
         UserPublicKeyLink upl = new UserPublicKeyLink(userHash, node);
         boolean success = core.updateChain(username, Arrays.asList(upl)).get();
         List<UserPublicKeyLink> chain = core.getChain(username).get();
@@ -86,7 +98,10 @@ public class UserPublicKeyLinkTests {
 
         // now change the keys
         SigningKeyPair user2 = SigningKeyPair.insecureRandom();
-        PublicKeyHash user2Hash = ipfs.putSigningKey("", user2.secretSigningKey.signOnly(user2.publicSigningKey.serialize()), user2.publicSigningKey).get();
+        PublicKeyHash user2Hash = ipfs.putSigningKey("",
+                user2.secretSigningKey.signOnly(user2.publicSigningKey.serialize()),
+                ipfs.hashKey(user2.publicSigningKey),
+                user2.publicSigningKey).get();
         SigningPrivateKeyAndPublicHash oldUser = new SigningPrivateKeyAndPublicHash(userHash, user.secretSigningKey);
         SigningPrivateKeyAndPublicHash newUser = new SigningPrivateKeyAndPublicHash(user2Hash, user2.secretSigningKey);
         List<UserPublicKeyLink> chain3 = UserPublicKeyLink.createChain(oldUser, newUser, username, LocalDate.now().plusWeeks(1));
@@ -111,7 +126,10 @@ public class UserPublicKeyLinkTests {
 
         // try to claim the same username with a different key
         SigningKeyPair user3 = SigningKeyPair.insecureRandom();
-        PublicKeyHash user3Hash = ipfs.putSigningKey("", user3.secretSigningKey.signOnly(user3.publicSigningKey.serialize()), user3.publicSigningKey).get();
+        PublicKeyHash user3Hash = ipfs.putSigningKey("",
+                user3.secretSigningKey.signOnly(user3.publicSigningKey.serialize()),
+                ipfs.hashKey(user3.publicSigningKey),
+                user3.publicSigningKey).get();
         UserPublicKeyLink.UsernameClaim node3 = UserPublicKeyLink.UsernameClaim.create(username, user3.secretSigningKey, LocalDate.now().plusMonths(2));
         UserPublicKeyLink upl3 = new UserPublicKeyLink(user3Hash, node3);
         try {

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -34,7 +34,7 @@ public class UserPublicKeyLinkTests {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2));
 
-        PublicKeyHash owner = ipfs.putSigningKey("",
+        PublicKeyHash owner = ipfs.putSigningKey(
                 user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
                 ipfs.hashKey(user.publicSigningKey),
                 user.publicSigningKey).get();
@@ -54,11 +54,11 @@ public class UserPublicKeyLinkTests {
     public void createChain() throws Exception {
         SigningKeyPair oldUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         SigningKeyPair newUser = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
-        PublicKeyHash oldHash = ipfs.putSigningKey("",
+        PublicKeyHash oldHash = ipfs.putSigningKey(
                 oldUser.secretSigningKey.signOnly(oldUser.publicSigningKey.serialize()),
                 ipfs.hashKey(oldUser.publicSigningKey),
                 oldUser.publicSigningKey).get();
-        PublicKeyHash newHash = ipfs.putSigningKey("",
+        PublicKeyHash newHash = ipfs.putSigningKey(
                 newUser.secretSigningKey.signOnly(newUser.publicSigningKey.serialize()),
                 ipfs.hashKey(newUser.publicSigningKey),
                 newUser.publicSigningKey).get();
@@ -78,7 +78,7 @@ public class UserPublicKeyLinkTests {
 
         // register the username
         UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2));
-        PublicKeyHash userHash = ipfs.putSigningKey("",
+        PublicKeyHash userHash = ipfs.putSigningKey(
                 user.secretSigningKey.signOnly(user.publicSigningKey.serialize()),
                 ipfs.hashKey(user.publicSigningKey),
                 user.publicSigningKey).get();
@@ -98,7 +98,7 @@ public class UserPublicKeyLinkTests {
 
         // now change the keys
         SigningKeyPair user2 = SigningKeyPair.insecureRandom();
-        PublicKeyHash user2Hash = ipfs.putSigningKey("",
+        PublicKeyHash user2Hash = ipfs.putSigningKey(
                 user2.secretSigningKey.signOnly(user2.publicSigningKey.serialize()),
                 ipfs.hashKey(user2.publicSigningKey),
                 user2.publicSigningKey).get();
@@ -126,7 +126,7 @@ public class UserPublicKeyLinkTests {
 
         // try to claim the same username with a different key
         SigningKeyPair user3 = SigningKeyPair.insecureRandom();
-        PublicKeyHash user3Hash = ipfs.putSigningKey("",
+        PublicKeyHash user3Hash = ipfs.putSigningKey(
                 user3.secretSigningKey.signOnly(user3.publicSigningKey.serialize()),
                 ipfs.hashKey(user3.publicSigningKey),
                 user3.publicSigningKey).get();

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -191,7 +191,7 @@ public class NetworkAccess {
             throw new IllegalStateException("Non matching location writer and signing writer key!");
         try {
             byte[] metaBlob = metadata.serialize();
-            return dhtClient.put("", location.owner, writer.secret.signOnly(metaBlob), metaBlob)
+            return dhtClient.put("", location.writer, writer.secret.signOnly(metaBlob), metaBlob)
                     .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), metadata.committedHash(), blobHash)
                             .thenApply(res -> blobHash));
         } catch (Exception e) {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -2,11 +2,9 @@ package peergos.shared;
 
 import jsinterop.annotations.*;
 import peergos.client.*;
-import peergos.server.tests.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.io.ipfs.cid.*;
@@ -174,7 +172,7 @@ public class NetworkAccess {
                 .map(g -> bulkUploadFragments(
                         g,
                         writer.publicKeyHash,
-                        g.stream().map(f -> writer.secret.signOnly(f.data)).collect(Collectors.toList())
+                        g.stream().map(f -> writer.secret.signatureOnly(f.data)).collect(Collectors.toList())
                 ).thenApply(hash -> {
                     if (progressCounter != null)
                         progressCounter.accept((long)(g.stream().mapToInt(f -> f.data.length).sum() / spaceIncreaseFactor));
@@ -191,7 +189,7 @@ public class NetworkAccess {
             throw new IllegalStateException("Non matching location writer and signing writer key!");
         try {
             byte[] metaBlob = metadata.serialize();
-            return dhtClient.put(location.writer, writer.secret.signOnly(metaBlob), metaBlob)
+            return dhtClient.put(location.writer, writer.secret.signatureOnly(metaBlob), metaBlob)
                     .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), metadata.committedHash(), blobHash)
                             .thenApply(res -> blobHash));
         } catch (Exception e) {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -153,11 +153,11 @@ public class NetworkAccess {
     }
 
     private CompletableFuture<Multihash> uploadFragment(Fragment f, PublicKeyHash writer, byte[] signature) {
-        return dhtClient.putRaw("", writer, signature, f.data);
+        return dhtClient.putRaw(writer, signature, f.data);
     }
 
     private CompletableFuture<List<Multihash>> bulkUploadFragments(List<Fragment> fragments, PublicKeyHash writer, List<byte[]> signatures) {
-        return dhtClient.putRaw("", writer, signatures, fragments
+        return dhtClient.putRaw(writer, signatures, fragments
                 .stream()
                 .map(f -> f.data)
                 .collect(Collectors.toList()));
@@ -191,7 +191,7 @@ public class NetworkAccess {
             throw new IllegalStateException("Non matching location writer and signing writer key!");
         try {
             byte[] metaBlob = metadata.serialize();
-            return dhtClient.put("", location.writer, writer.secret.signOnly(metaBlob), metaBlob)
+            return dhtClient.put(location.writer, writer.secret.signOnly(metaBlob), metaBlob)
                     .thenCompose(blobHash -> btree.put(writer, location.getMapKey(), metadata.committedHash(), blobHash)
                             .thenApply(res -> blobHash));
         } catch (Exception e) {

--- a/src/peergos/shared/cbor/CborDecoder.java
+++ b/src/peergos/shared/cbor/CborDecoder.java
@@ -99,14 +99,14 @@ public class CborDecoder {
      * @return the read byte string, never <code>null</code>. In case the encoded string has a length of <tt>0</tt>, an empty string is returned.
      * @throws IOException in case of I/O problems reading the CBOR-encoded value from the underlying input stream.
      */
-    public byte[] readByteString() throws IOException {
+    public byte[] readByteString(int maxLen) throws IOException {
         long len = readMajorTypeWithSize(TYPE_BYTE_STRING);
-        if (len < 0) {
+        if (len < 0)
             fail("Infinite-length byte strings not supported!");
-        }
-        if (len > Integer.MAX_VALUE) {
+        if (len > Integer.MAX_VALUE)
             fail("String length too long!");
-        }
+        if (len > maxLen)
+            fail("Invalid cbor: byte string longer than original bytes!");
         return readFully(new byte[(int) len]);
     }
 
@@ -309,14 +309,14 @@ public class CborDecoder {
      * @return the read UTF-8 encoded string, never <code>null</code>. In case the encoded string has a length of <tt>0</tt>, an empty string is returned.
      * @throws IOException in case of I/O problems reading the CBOR-encoded value from the underlying input stream.
      */
-    public String readTextString() throws IOException {
+    public String readTextString(int maxLen) throws IOException {
         long len = readMajorTypeWithSize(TYPE_TEXT_STRING);
-        if (len < 0) {
+        if (len < 0)
             fail("Infinite-length text strings not supported!");
-        }
-        if (len > Integer.MAX_VALUE) {
+        if (len > Integer.MAX_VALUE)
             fail("String length too long!");
-        }
+        if (len > maxLen)
+            fail("Invalid cbor: text string longer than original bytes!");
         return new String(readFully(new byte[(int) len]), "UTF-8");
     }
 

--- a/src/peergos/shared/cbor/CborEncoder.java
+++ b/src/peergos/shared/cbor/CborEncoder.java
@@ -10,8 +10,7 @@ package peergos.shared.cbor;
 
 import static peergos.shared.cbor.CborConstants.*;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.io.*;
 
 /**
  * Provides an encoder capable of encoding data into CBOR format to a given {@link OutputStream}.

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -26,6 +26,8 @@ public interface CborObject {
     int LINK_TAG = 42;
 
     static CborObject fromByteArray(byte[] cbor) {
+        if (hasLargerGroup(cbor, cbor.length))
+            throw new IllegalStateException("Invalid cbor: element size larger than original bytes!");
         return deserialize(new CborDecoder(new ByteArrayInputStream(cbor)));
     }
 

--- a/src/peergos/shared/crypto/asymmetric/PublicSigningKey.java
+++ b/src/peergos/shared/crypto/asymmetric/PublicSigningKey.java
@@ -61,6 +61,12 @@ public interface PublicSigningKey extends Cborable {
         }
     }
 
+    static boolean maybeValidKey(byte[] raw) {
+        if (raw.length > 64) // All currently supported public keys are smaller than this
+            return false;
+        return ! CborObject.hasLargerGroup(raw, 64);
+    }
+
     static PublicSigningKey createNull() {
         return new Ed25519PublicKey(new byte[32], PublicSigningKey.PROVIDERS.get(PublicSigningKey.Type.Ed25519));
     }

--- a/src/peergos/shared/crypto/asymmetric/PublicSigningKey.java
+++ b/src/peergos/shared/crypto/asymmetric/PublicSigningKey.java
@@ -61,12 +61,6 @@ public interface PublicSigningKey extends Cborable {
         }
     }
 
-    static boolean maybeValidKey(byte[] raw) {
-        if (raw.length > 64) // All currently supported public keys are smaller than this
-            return false;
-        return ! CborObject.hasLargerGroup(raw, 64);
-    }
-
     static PublicSigningKey createNull() {
         return new Ed25519PublicKey(new byte[32], PublicSigningKey.PROVIDERS.get(PublicSigningKey.Type.Ed25519));
     }

--- a/src/peergos/shared/crypto/asymmetric/SecretSigningKey.java
+++ b/src/peergos/shared/crypto/asymmetric/SecretSigningKey.java
@@ -10,7 +10,19 @@ public interface SecretSigningKey extends Cborable {
 
     PublicSigningKey.Type type();
 
+    /**
+     *
+     * @param message
+     * @return The signature + message
+     */
     byte[] signMessage(byte[] message);
+
+    /**
+     *
+     * @param message
+     * @return Only the signature, excluding the original message
+     */
+    byte[] signOnly(byte[] message);
 
     static SecretSigningKey fromCbor(CborObject cbor) {
         if (! (cbor instanceof CborObject.CborList))

--- a/src/peergos/shared/crypto/asymmetric/SecretSigningKey.java
+++ b/src/peergos/shared/crypto/asymmetric/SecretSigningKey.java
@@ -22,7 +22,7 @@ public interface SecretSigningKey extends Cborable {
      * @param message
      * @return Only the signature, excluding the original message
      */
-    byte[] signOnly(byte[] message);
+    byte[] signatureOnly(byte[] message);
 
     static SecretSigningKey fromCbor(CborObject cbor) {
         if (! (cbor instanceof CborObject.CborList))

--- a/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519SecretKey.java
+++ b/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519SecretKey.java
@@ -50,7 +50,7 @@ public class Ed25519SecretKey implements SecretSigningKey {
     }
 
     @Override
-    public byte[] signOnly(byte[] message) {
+    public byte[] signatureOnly(byte[] message) {
         return Arrays.copyOfRange(implementation.crypto_sign(message, secretKey), 0, TweetNaCl.SIGNATURE_SIZE_BYTES);
     }
 

--- a/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519SecretKey.java
+++ b/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519SecretKey.java
@@ -1,6 +1,7 @@
 package peergos.shared.crypto.asymmetric.curve25519;
 
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.PublicSigningKey;
 import peergos.shared.crypto.asymmetric.SecretSigningKey;
 
@@ -43,8 +44,14 @@ public class Ed25519SecretKey implements SecretSigningKey {
         return new CborObject.CborList(Arrays.asList(new CborObject.CborLong(type().value), new CborObject.CborByteArray(secretKey)));
     }
 
+    @Override
     public byte[] signMessage(byte[] message) {
         return implementation.crypto_sign(message, secretKey);
+    }
+
+    @Override
+    public byte[] signOnly(byte[] message) {
+        return Arrays.copyOfRange(implementation.crypto_sign(message, secretKey), 0, TweetNaCl.SIGNATURE_SIZE_BYTES);
     }
 
     public static SecretSigningKey fromCbor(CborObject cbor, Ed25519 provider) {

--- a/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519SecretKey.java
+++ b/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519SecretKey.java
@@ -51,7 +51,7 @@ public class Ed25519SecretKey implements SecretSigningKey {
 
     @Override
     public byte[] signatureOnly(byte[] message) {
-        return Arrays.copyOfRange(implementation.crypto_sign(message, secretKey), 0, TweetNaCl.SIGNATURE_SIZE_BYTES);
+        return Arrays.copyOf(implementation.crypto_sign(message, secretKey), TweetNaCl.SIGNATURE_SIZE_BYTES);
     }
 
     public static SecretSigningKey fromCbor(CborObject cbor, Ed25519 provider) {

--- a/src/peergos/shared/crypto/hash/PublicKeyHash.java
+++ b/src/peergos/shared/crypto/hash/PublicKeyHash.java
@@ -5,6 +5,7 @@ import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multihash.*;
 
 public class PublicKeyHash extends Multihash implements Cborable {
+    public static final int MAX_KEY_HASH_SIZE = 1024;
     public static final PublicKeyHash NULL = new PublicKeyHash(new Multihash(Type.sha2_256, new byte[32]));
 
     public final Multihash hash;

--- a/src/peergos/shared/merklebtree/MerkleBTree.java
+++ b/src/peergos/shared/merklebtree/MerkleBTree.java
@@ -38,7 +38,7 @@ public class MerkleBTree
     public static CompletableFuture<MerkleBTree> create(SigningPrivateKeyAndPublicHash writer, ContentAddressedStorage dht) {
         TreeNode newRoot = new TreeNode(new TreeSet<>());
         byte[] raw = newRoot.serialize();
-        return dht.put(writer.publicKeyHash, writer.secret.signOnly(raw), raw)
+        return dht.put(writer.publicKeyHash, writer.secret.signatureOnly(raw), raw)
                 .thenApply(put -> new MerkleBTree(newRoot, put, dht, MAX_NODE_CHILDREN));
     }
 
@@ -81,7 +81,7 @@ public class MerkleBTree
             return CompletableFuture.completedFuture(newRoot.hash.get());
         }
         byte[] raw = newRoot.serialize();
-        return storage.put(writer.publicKeyHash, writer.secret.signOnly(raw), raw).thenApply(newRootHash -> {
+        return storage.put(writer.publicKeyHash, writer.secret.signatureOnly(raw), raw).thenApply(newRootHash -> {
             root = new TreeNode(newRoot.keys, newRootHash);
             return newRootHash;
         });

--- a/src/peergos/shared/merklebtree/MerkleBTree.java
+++ b/src/peergos/shared/merklebtree/MerkleBTree.java
@@ -1,5 +1,6 @@
 package peergos.shared.merklebtree;
 
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.storage.ContentAddressedStorage;
@@ -27,20 +28,18 @@ public class MerkleBTree
     }
 
     public static CompletableFuture<MerkleBTree> create(PublicKeyHash writer, Multihash rootHash, ContentAddressedStorage dht) {
-        return create(writer, MaybeMultihash.of(rootHash), dht);
-    }
-
-    public static CompletableFuture<MerkleBTree> create(PublicKeyHash writer, MaybeMultihash rootHash, ContentAddressedStorage dht) {
-        if (!  rootHash.isPresent()) {
-            TreeNode newRoot = new TreeNode(new TreeSet<>());
-            return dht.put(writer, newRoot.serialize())
-                    .thenApply(put -> new MerkleBTree(newRoot, put, dht, MAX_NODE_CHILDREN));
-        }
-        return dht.get(rootHash.get()).thenApply(rawOpt -> {
+        return dht.get(rootHash).thenApply(rawOpt -> {
             if (! rawOpt.isPresent())
-                throw new IllegalStateException("Null byte[] returned by DHT for hash: " + rootHash.get());
+                throw new IllegalStateException("Null byte[] returned by DHT for hash: " + rootHash);
             return new MerkleBTree(TreeNode.fromCbor(rawOpt.get()), rootHash, dht, MAX_NODE_CHILDREN);
         });
+    }
+
+    public static CompletableFuture<MerkleBTree> create(SigningPrivateKeyAndPublicHash writer, ContentAddressedStorage dht) {
+        TreeNode newRoot = new TreeNode(new TreeSet<>());
+        byte[] raw = newRoot.serialize();
+        return dht.put(writer.publicKeyHash, writer.secret.signOnly(raw), raw)
+                .thenApply(put -> new MerkleBTree(newRoot, put, dht, MAX_NODE_CHILDREN));
     }
 
     /**
@@ -60,7 +59,7 @@ public class MerkleBTree
      * @return hash of new tree root
      * @throws IOException
      */
-    public CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] rawKey, MaybeMultihash existing, Multihash value) {
+    public CompletableFuture<Multihash> put(SigningPrivateKeyAndPublicHash writer, byte[] rawKey, MaybeMultihash existing, Multihash value) {
         return root.put(writer, new ByteArrayWrapper(rawKey), existing, value, storage, maxChildren)
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
@@ -71,17 +70,18 @@ public class MerkleBTree
      * @return hash of new tree root
      * @throws IOException
      */
-    public CompletableFuture<Multihash> delete(PublicKeyHash writer, byte[] rawKey, MaybeMultihash existing) {
+    public CompletableFuture<Multihash> delete(SigningPrivateKeyAndPublicHash writer, byte[] rawKey, MaybeMultihash existing) {
         return root.delete(writer, new ByteArrayWrapper(rawKey), existing, storage, maxChildren)
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
 
-    private CompletableFuture<Multihash> commit(PublicKeyHash writer, TreeNode newRoot) {
+    private CompletableFuture<Multihash> commit(SigningPrivateKeyAndPublicHash writer, TreeNode newRoot) {
         if (newRoot.hash.isPresent()) {
             root = newRoot;
             return CompletableFuture.completedFuture(newRoot.hash.get());
         }
-        return storage.put(writer, newRoot.serialize()).thenApply(newRootHash -> {
+        byte[] raw = newRoot.serialize();
+        return storage.put(writer.publicKeyHash, writer.secret.signOnly(raw), raw).thenApply(newRootHash -> {
             root = new TreeNode(newRoot.keys, newRootHash);
             return newRootHash;
         });

--- a/src/peergos/shared/merklebtree/MerkleNode.java
+++ b/src/peergos/shared/merklebtree/MerkleNode.java
@@ -76,8 +76,7 @@ public class MerkleNode implements Cborable {
      * @throws IOException for an invalid encoding
      */
     public static MerkleNode deserialize(byte[] in) {
-        CborDecoder decoder = new CborDecoder(new ByteArrayInputStream(in));
-        CborObject cbor = CborObject.deserialize(decoder);
+        CborObject cbor = CborObject.fromByteArray(in);
         return fromCbor(cbor);
     }
 

--- a/src/peergos/shared/merklebtree/TreeNode.java
+++ b/src/peergos/shared/merklebtree/TreeNode.java
@@ -1,6 +1,7 @@
 package peergos.shared.merklebtree;
 
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.storage.ContentAddressedStorage;
@@ -80,7 +81,7 @@ public class TreeNode implements Cborable {
                         .get(key, storage));
     }
 
-    public CompletableFuture<TreeNode> put(PublicKeyHash writer,
+    public CompletableFuture<TreeNode> put(SigningPrivateKeyAndPublicHash writer,
                                            ByteArrayWrapper key,
                                            MaybeMultihash existing,
                                            Multihash value,
@@ -218,7 +219,7 @@ public class TreeNode implements Cborable {
                         .smallestKey(storage));
     }
 
-    public CompletableFuture<TreeNode> delete(PublicKeyHash writer, ByteArrayWrapper key, MaybeMultihash existing, ContentAddressedStorage storage, int maxChildren) {
+    public CompletableFuture<TreeNode> delete(SigningPrivateKeyAndPublicHash writer, ByteArrayWrapper key, MaybeMultihash existing, ContentAddressedStorage storage, int maxChildren) {
         KeyElement dummy = KeyElement.dummy(key);
         SortedSet<KeyElement> tailSet = keys.tailSet(dummy);
         KeyElement nextSmallest;
@@ -296,7 +297,7 @@ public class TreeNode implements Cborable {
                 });
     }
 
-    private static CompletableFuture<TreeNode> rebalance(PublicKeyHash writer, TreeNode parent, TreeNode child, Multihash originalChildHash,
+    private static CompletableFuture<TreeNode> rebalance(SigningPrivateKeyAndPublicHash writer, TreeNode parent, TreeNode child, Multihash originalChildHash,
                                                          ContentAddressedStorage storage, int maxChildren) {
         System.out.println("Btree:rebalance");
         // child has too few children

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -26,8 +26,8 @@ public class CachingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks) {
-        return target.put(writer, blocks);
+    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return target.put(username, writer, signatures, blocks);
     }
 
     @Override
@@ -57,8 +57,8 @@ public class CachingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> blocks) {
-        return target.putRaw(writer, blocks);
+    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return target.putRaw(username, writer, signatures, blocks);
     }
 
     @Override

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -26,8 +26,8 @@ public class CachingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-        return target.put(username, writer, signatures, blocks);
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return target.put(writer, signatures, blocks);
     }
 
     @Override
@@ -57,8 +57,8 @@ public class CachingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-        return target.putRaw(username, writer, signatures, blocks);
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return target.putRaw(writer, signatures, blocks);
     }
 
     @Override

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -26,24 +26,20 @@ public interface ContentAddressedStorage {
     }
 
     default CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] signature, byte[] block) {
-        return put("", writer, signature, block);
-    }
-
-    default CompletableFuture<Multihash> put(String username, PublicKeyHash writer, byte[] signature, byte[] block) {
-        return put(username, writer, Arrays.asList(signature), Arrays.asList(block))
+        return put(writer, Arrays.asList(signature), Arrays.asList(block))
                 .thenApply(hashes -> hashes.get(0));
     }
 
-    default CompletableFuture<Multihash> putRaw(String username, PublicKeyHash writer, byte[] signature, byte[] block) {
-        return putRaw(username, writer, Arrays.asList(signature), Arrays.asList(block))
+    default CompletableFuture<Multihash> putRaw(PublicKeyHash writer, byte[] signature, byte[] block) {
+        return putRaw(writer, Arrays.asList(signature), Arrays.asList(block))
                 .thenApply(hashes -> hashes.get(0));
     }
 
-    CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks);
+    CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks);
 
     CompletableFuture<Optional<CborObject>> get(Multihash object);
 
-    CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks);
+    CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks);
 
     CompletableFuture<Optional<byte[]>> getRaw(Multihash object);
 
@@ -57,11 +53,10 @@ public interface ContentAddressedStorage {
 
     CompletableFuture<Optional<Integer>> getSize(Multihash block);
 
-    default CompletableFuture<PublicKeyHash> putSigningKey(String username,
-                                                           byte[] signature,
+    default CompletableFuture<PublicKeyHash> putSigningKey(byte[] signature,
                                                            PublicKeyHash authKeyHash,
                                                            PublicSigningKey newKey) {
-        return put(username, authKeyHash, signature, newKey.toCbor().toByteArray())
+        return put(authKeyHash, signature, newKey.toCbor().toByteArray())
                 .thenApply(PublicKeyHash::new);
     }
 
@@ -72,7 +67,7 @@ public interface ContentAddressedStorage {
     }
 
     default CompletableFuture<PublicKeyHash> putBoxingKey(PublicKeyHash controller, byte[] signature, PublicBoxingKey key) {
-        return put("", controller, signature, key.toCbor().toByteArray())
+        return put(controller, signature, key.toCbor().toByteArray())
                 .thenApply(PublicKeyHash::new);
     }
 
@@ -112,19 +107,18 @@ public interface ContentAddressedStorage {
         }
 
         @Override
-        public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-            return put(username, writer, signatures, blocks, "cbor");
+        public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+            return put(writer, signatures, blocks, "cbor");
         }
 
         @Override
-        public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-            return put(username, writer, signatures, blocks, "raw");
+        public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+            return put(writer, signatures, blocks, "raw");
         }
 
-        private CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, String format) {
+        private CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, String format) {
             return poster.postMultipart(apiPrefix + "block/put?format=" + format
                     + "&writer=" + encode(writer.toString())
-                    + "&username=" + username
                     + "&signatures=" + signatures.stream().map(ArrayOps::bytesToHex).reduce("", (a, b) -> a + "," + b).substring(1), blocks)
                     .thenApply(bytes -> JSONParser.parseStream(new String(bytes))
                             .stream()

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -57,9 +57,18 @@ public interface ContentAddressedStorage {
 
     CompletableFuture<Optional<Integer>> getSize(Multihash block);
 
-    default CompletableFuture<PublicKeyHash> putSigningKey(String username, byte[] signature, PublicSigningKey key) {
-        return put(username, PublicKeyHash.NULL, signature, key.toCbor().toByteArray())
+    default CompletableFuture<PublicKeyHash> putSigningKey(String username,
+                                                           byte[] signature,
+                                                           PublicKeyHash authKeyHash,
+                                                           PublicSigningKey newKey) {
+        return put(username, authKeyHash, signature, newKey.toCbor().toByteArray())
                 .thenApply(PublicKeyHash::new);
+    }
+
+    default PublicKeyHash hashKey(PublicSigningKey key) {
+        return new PublicKeyHash(new Cid(1, Cid.Codec.DagCbor, new Multihash(
+                            Multihash.Type.sha2_256,
+                            Hash.sha256(key.serialize()))));
     }
 
     default CompletableFuture<PublicKeyHash> putBoxingKey(PublicKeyHash controller, byte[] signature, PublicBoxingKey key) {

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -22,7 +22,7 @@ public interface ContentAddressedStorage {
     int MAX_OBJECT_LENGTH  = 1024*256;
 
     default CompletableFuture<Multihash> put(SigningPrivateKeyAndPublicHash writer, byte[] block) {
-        return put(writer.publicKeyHash, writer.secret.signOnly(block), block);
+        return put(writer.publicKeyHash, writer.secret.signatureOnly(block), block);
     }
 
     default CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] signature, byte[] block) {

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -1,6 +1,7 @@
 package peergos.shared.storage;
 
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.api.*;
@@ -8,6 +9,7 @@ import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multiaddr.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.user.*;
+import peergos.shared.util.*;
 
 import java.io.*;
 import java.net.*;
@@ -19,19 +21,29 @@ public interface ContentAddressedStorage {
 
     int MAX_OBJECT_LENGTH  = 1024*256;
 
-    default CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] block) {
-        return put(writer, Arrays.asList(block)).thenApply(hashes -> hashes.get(0));
+    default CompletableFuture<Multihash> put(SigningPrivateKeyAndPublicHash writer, byte[] block) {
+        return put(writer.publicKeyHash, writer.secret.signOnly(block), block);
     }
 
-    default CompletableFuture<Multihash> putRaw(PublicKeyHash writer, byte[] block) {
-        return putRaw(writer, Arrays.asList(block)).thenApply(hashes -> hashes.get(0));
+    default CompletableFuture<Multihash> put(PublicKeyHash writer, byte[] signature, byte[] block) {
+        return put("", writer, signature, block);
     }
 
-    CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks);
+    default CompletableFuture<Multihash> put(String username, PublicKeyHash writer, byte[] signature, byte[] block) {
+        return put(username, writer, Arrays.asList(signature), Arrays.asList(block))
+                .thenApply(hashes -> hashes.get(0));
+    }
+
+    default CompletableFuture<Multihash> putRaw(String username, PublicKeyHash writer, byte[] signature, byte[] block) {
+        return putRaw(username, writer, Arrays.asList(signature), Arrays.asList(block))
+                .thenApply(hashes -> hashes.get(0));
+    }
+
+    CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks);
 
     CompletableFuture<Optional<CborObject>> get(Multihash object);
 
-    CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> blocks);
+    CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks);
 
     CompletableFuture<Optional<byte[]>> getRaw(Multihash object);
 
@@ -45,13 +57,13 @@ public interface ContentAddressedStorage {
 
     CompletableFuture<Optional<Integer>> getSize(Multihash block);
 
-    default CompletableFuture<PublicKeyHash> putSigningKey(PublicSigningKey key) {
-        return put(PublicKeyHash.NULL, key.toCbor().toByteArray())
+    default CompletableFuture<PublicKeyHash> putSigningKey(String username, byte[] signature, PublicSigningKey key) {
+        return put(username, PublicKeyHash.NULL, signature, key.toCbor().toByteArray())
                 .thenApply(PublicKeyHash::new);
     }
 
-    default CompletableFuture<PublicKeyHash> putBoxingKey(PublicKeyHash controller, PublicBoxingKey key) {
-        return put(controller, key.toCbor().toByteArray())
+    default CompletableFuture<PublicKeyHash> putBoxingKey(PublicKeyHash controller, byte[] signature, PublicBoxingKey key) {
+        return put("", controller, signature, key.toCbor().toByteArray())
                 .thenApply(PublicKeyHash::new);
     }
 
@@ -91,18 +103,20 @@ public interface ContentAddressedStorage {
         }
 
         @Override
-        public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks) {
-            return put(writer, blocks, "cbor");
+        public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+            return put(username, writer, signatures, blocks, "cbor");
         }
 
         @Override
-        public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> blocks) {
-            return put(writer, blocks, "raw");
+        public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+            return put(username, writer, signatures, blocks, "raw");
         }
 
-        private CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks, String format) {
+        private CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, String format) {
             return poster.postMultipart(apiPrefix + "block/put?format=" + format
-                    + "&writer=" + encode(writer.toString()), blocks)
+                    + "&writer=" + encode(writer.toString())
+                    + "&username=" + username
+                    + "&signatures=" + signatures.stream().map(ArrayOps::bytesToHex).reduce("", (a, b) -> a + "," + b).substring(1), blocks)
                     .thenApply(bytes -> JSONParser.parseStream(new String(bytes))
                             .stream()
                             .map(json -> getObjectHash(json))

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -36,8 +36,8 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> blocks) {
-        return source.put(writer, blocks)
+    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return source.put(username, writer, signatures, blocks)
                 .thenApply(hashes -> hashes.stream()
                         .map(h -> verify(blocks.get(hashes.indexOf(h)), h, () -> h))
                         .collect(Collectors.toList()));
@@ -50,8 +50,8 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> blocks) {
-        return source.putRaw(writer, blocks)
+    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return source.putRaw(username, writer, signatures, blocks)
                 .thenApply(hashes -> hashes.stream()
                         .map(h -> verify(blocks.get(hashes.indexOf(h)), h, () -> h))
                         .collect(Collectors.toList()));

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -36,8 +36,8 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-        return source.put(username, writer, signatures, blocks)
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return source.put(writer, signatures, blocks)
                 .thenApply(hashes -> hashes.stream()
                         .map(h -> verify(blocks.get(hashes.indexOf(h)), h, () -> h))
                         .collect(Collectors.toList()));
@@ -50,8 +50,8 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> putRaw(String username, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
-        return source.putRaw(username, writer, signatures, blocks)
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return source.putRaw(writer, signatures, blocks)
                 .thenApply(hashes -> hashes.stream()
                         .map(h -> verify(blocks.get(hashes.indexOf(h)), h, () -> h))
                         .collect(Collectors.toList()));

--- a/src/peergos/shared/user/BtreeImpl.java
+++ b/src/peergos/shared/user/BtreeImpl.java
@@ -99,7 +99,7 @@ public class BtreeImpl implements Btree {
                     lock.complete(committed);
                     WriterData holder = committed.props;
                     if (! holder.btree.isPresent())
-                        return CompletableFuture.completedFuture(MaybeMultihash.empty());
+                        throw new IllegalStateException("Btree root not present for " + writer);
                     return MerkleBTree.create(writer, holder.btree.get(), dht)
                             .thenCompose(btree -> btree.get(mapKey))
                             .thenApply(maybe -> LOGGING ?

--- a/src/peergos/shared/user/BtreeImpl.java
+++ b/src/peergos/shared/user/BtreeImpl.java
@@ -99,7 +99,7 @@ public class BtreeImpl implements Btree {
                     lock.complete(committed);
                     WriterData holder = committed.props;
                     if (! holder.btree.isPresent())
-                        throw new IllegalStateException("Btree root not present!");
+                        return CompletableFuture.completedFuture(MaybeMultihash.empty());
                     return MerkleBTree.create(writer, holder.btree.get(), dht)
                             .thenCompose(btree -> btree.get(mapKey))
                             .thenApply(maybe -> LOGGING ?

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -140,7 +140,7 @@ public class UserContext {
                             System.out.println("Couldn't register username");
                             throw new IllegalStateException("Couldn't register username: " + username);
                         }
-                        return network.dhtClient.putSigningKey(username,
+                        return network.dhtClient.putSigningKey(
                                 secretSigningKey.signOnly(publicSigningKey.serialize()),
                                 network.dhtClient.hashKey(publicSigningKey),
                                 publicSigningKey)
@@ -388,7 +388,6 @@ public class UserContext {
                                         .thenCompose(wd -> {
                                             PublicSigningKey newPublicSigningKey = updatedUser.getUser().publicSigningKey;
                                                     return network.dhtClient.putSigningKey(
-                                                            username,
                                                             existingUser.getUser().secretSigningKey.signOnly(newPublicSigningKey.serialize()),
                                                             network.dhtClient.hashKey(existingUser.getUser().publicSigningKey),
                                                             newPublicSigningKey
@@ -423,7 +422,7 @@ public class UserContext {
         long t1 = System.currentTimeMillis();
         SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
         System.out.println("Random User generation took " + (System.currentTimeMillis()-t1) + " mS");
-        return network.dhtClient.putSigningKey(username,
+        return network.dhtClient.putSigningKey(
                 owner.secret.signOnly(writer.publicSigningKey.serialize()),
                 owner.publicKeyHash,
                 writer.publicSigningKey).thenCompose(writerHash -> {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -437,8 +437,8 @@ public class UserContext {
             SigningPrivateKeyAndPublicHash writerWithHash = new SigningPrivateKeyAndPublicHash(writerHash, writer.secretSigningKey);
             FilePointer rootPointer = new FilePointer(this.signer.publicKeyHash, writerWithHash, rootMapKey, rootRKey);
             EntryPoint entry = new EntryPoint(rootPointer, this.username, Collections.emptySet(), Collections.emptySet());
-            return addToStaticDataAndCommit(entry)
-                    .thenCompose(x -> addOwnedKeyAndCommit(entry.pointer.location.writer)).thenCompose(x -> {
+            return addOwnedKeyAndCommit(entry.pointer.location.writer)
+                    .thenCompose(x -> {
                         long t2 = System.currentTimeMillis();
                         DirAccess root = DirAccess.create(MaybeMultihash.empty(), rootRKey, new FileProperties(directoryName, "",
                                 0, LocalDateTime.now(), false, Optional.empty()), (Location) null, null, null);
@@ -451,7 +451,7 @@ public class UserContext {
                             System.out.println("Committing static data took " + (System.currentTimeMillis() - t3) + " mS");
                             return new RetrievedFilePointer(rootPointer, root.withHash(chunkHash));
                         });
-                    });
+                    }).thenCompose(x -> addToStaticDataAndCommit(entry).thenApply(y -> x));
         });
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -392,7 +392,9 @@ public class UserContext {
                                                             network.dhtClient.hashKey(existingUser.getUser().publicSigningKey),
                                                             newPublicSigningKey
                                                     ).thenCompose(newSignerHash -> wd.props
-                                                            .changeKeys(new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey),
+                                                            .changeKeys(
+                                                                    signer,
+                                                                    new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey),
                                                                     wd.hash,
                                                                     updatedUser.getBoxingPair().publicBoxingKey,
                                                                     updatedUser.getRoot(),

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -158,25 +158,25 @@ public class UserContext {
                                             UserContext context = new UserContext(username, signer, userWithRoot.getBoxingPair(),
                                                     network, crypto, CompletableFuture.completedFuture(notCommitted), new TrieNode());
 
-                                                System.out.println("Creating user's root directory");
-                                                long t1 = System.currentTimeMillis();
-                                                return context.createEntryDirectory(signer, username).thenCompose(userRoot -> {
-                                                    System.out.println("Creating root directory took " + (System.currentTimeMillis() - t1) + " mS");
-                                                    return ((DirAccess) userRoot.fileAccess).mkdir(
-                                                            SHARED_DIR_NAME,
-                                                            network,
-                                                            userRoot.filePointer.getLocation().owner,
-                                                            userRoot.filePointer.signer(),
-                                                            userRoot.filePointer.location.getMapKey(),
-                                                            userRoot.filePointer.baseKey,
-                                                            null,
-                                                            true,
-                                                            crypto.random)
-                                                            .thenCompose(x -> signIn(username, password, network.clear(), crypto));
-                                                });
+                                            System.out.println("Creating user's root directory");
+                                            long t1 = System.currentTimeMillis();
+                                            return context.createEntryDirectory(signer, username).thenCompose(userRoot -> {
+                                                System.out.println("Creating root directory took " + (System.currentTimeMillis() - t1) + " mS");
+                                                return ((DirAccess) userRoot.fileAccess).mkdir(
+                                                        SHARED_DIR_NAME,
+                                                        network,
+                                                        userRoot.filePointer.getLocation().owner,
+                                                        userRoot.filePointer.signer(),
+                                                        userRoot.filePointer.location.getMapKey(),
+                                                        userRoot.filePointer.baseKey,
+                                                        null,
+                                                        true,
+                                                        crypto.random)
+                                                        .thenCompose(x -> signIn(username, password, network.clear(), crypto));
                                             });
                                         });
-                            });
+                                });
+                    });
                 }).exceptionally(Futures::logError);
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -142,12 +142,12 @@ public class UserContext {
                             throw new IllegalStateException("Couldn't register username: " + username);
                         }
                         return network.dhtClient.putSigningKey(
-                                secretSigningKey.signOnly(publicSigningKey.serialize()),
+                                secretSigningKey.signatureOnly(publicSigningKey.serialize()),
                                 network.dhtClient.hashKey(publicSigningKey),
                                 publicSigningKey)
                                 .thenCompose(returnedSignerHash -> {
                                     PublicBoxingKey publicBoxingKey = userWithRoot.getBoxingPair().publicBoxingKey;
-                                    return network.dhtClient.putBoxingKey(signerHash, secretSigningKey.signOnly(publicBoxingKey.serialize()), publicBoxingKey)
+                                    return network.dhtClient.putBoxingKey(signerHash, secretSigningKey.signatureOnly(publicBoxingKey.serialize()), publicBoxingKey)
                                         .thenCompose(boxerHash -> {
                                             WriterData newUserData = WriterData.createEmpty(
                                                     signerHash,
@@ -388,7 +388,7 @@ public class UserContext {
                                         .thenCompose(wd -> {
                                             PublicSigningKey newPublicSigningKey = updatedUser.getUser().publicSigningKey;
                                                     return network.dhtClient.putSigningKey(
-                                                            existingUser.getUser().secretSigningKey.signOnly(newPublicSigningKey.serialize()),
+                                                            existingUser.getUser().secretSigningKey.signatureOnly(newPublicSigningKey.serialize()),
                                                             network.dhtClient.hashKey(existingUser.getUser().publicSigningKey),
                                                             newPublicSigningKey
                                                     ).thenCompose(newSignerHash -> wd.props
@@ -425,7 +425,7 @@ public class UserContext {
         SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
         System.out.println("Random User generation took " + (System.currentTimeMillis()-t1) + " mS");
         return network.dhtClient.putSigningKey(
-                owner.secret.signOnly(writer.publicSigningKey.serialize()),
+                owner.secret.signatureOnly(writer.publicSigningKey.serialize()),
                 owner.publicKeyHash,
                 writer.publicSigningKey).thenCompose(writerHash -> {
             byte[] rootMapKey = new byte[32]; // root will be stored under this in the core node

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -135,6 +135,7 @@ public class UserContext {
                     SecretSigningKey secretSigningKey = userWithRoot.getUser().secretSigningKey;
                     PublicKeyHash signerHash = network.dhtClient.hashKey(publicSigningKey);
                     SigningPrivateKeyAndPublicHash signer = new SigningPrivateKeyAndPublicHash(signerHash, secretSigningKey);
+                    System.out.println("Registering username " + username);
                     return UserContext.register(username, signer, network).thenCompose(registered -> {
                         if (! registered) {
                             System.out.println("Couldn't register username");
@@ -156,7 +157,6 @@ public class UserContext {
                                             CommittedWriterData notCommitted = new CommittedWriterData(MaybeMultihash.empty(), newUserData);
                                             UserContext context = new UserContext(username, signer, userWithRoot.getBoxingPair(),
                                                     network, crypto, CompletableFuture.completedFuture(notCommitted), new TrieNode());
-                                            System.out.println("Registering username " + username);
 
                                                 System.out.println("Creating user's root directory");
                                                 long t1 = System.currentTimeMillis();

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -143,7 +143,7 @@ public class WriterData implements Cborable {
                                                          Consumer<CommittedWriterData> updater) {
         byte[] raw = serialize();
 
-        return immutable.put("", signer.publicKeyHash, signer.secret.signOnly(raw), raw)
+        return immutable.put(signer.publicKeyHash, signer.secret.signOnly(raw), raw)
                 .thenCompose(blobHash -> {
                     MaybeMultihash newHash = MaybeMultihash.of(blobHash);
                     if (newHash.equals(currentHash)) {

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -134,7 +134,7 @@ public class WriterData implements Cborable {
         WriterData tmp = addOwnedKey(signer.publicKeyHash);
         return tmp.commit(oldSigner, currentHash, network, x -> {}).thenCompose(tmpCommited -> {
             Optional<UserStaticData> newEntryPoints = staticData.map(sd -> sd.withKey(newKey));
-            return network.dhtClient.putBoxingKey(signer.publicKeyHash, signer.secret.signOnly(followRequestReceiver.serialize()), followRequestReceiver)
+            return network.dhtClient.putBoxingKey(signer.publicKeyHash, signer.secret.signatureOnly(followRequestReceiver.serialize()), followRequestReceiver)
                     .thenCompose(boxerHash -> {
                         WriterData updated = new WriterData(signer.publicKeyHash,
                                 Optional.of(newAlgorithm),
@@ -158,7 +158,7 @@ public class WriterData implements Cborable {
                                                          Consumer<CommittedWriterData> updater) {
         byte[] raw = serialize();
 
-        return immutable.put(signer.publicKeyHash, signer.secret.signOnly(raw), raw)
+        return immutable.put(signer.publicKeyHash, signer.secret.signatureOnly(raw), raw)
                 .thenCompose(blobHash -> {
                     MaybeMultihash newHash = MaybeMultihash.of(blobHash);
                     if (newHash.equals(currentHash)) {

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -120,7 +120,7 @@ public class WriterData implements Cborable {
                                                              UserGenerationAlgorithm newAlgorithm,
                                                              NetworkAccess network, Consumer<CommittedWriterData> updater) {
         Optional<UserStaticData> newEntryPoints = staticData.map(sd -> sd.withKey(newKey));
-        return network.dhtClient.putBoxingKey(signer.publicKeyHash, followRequestReceiver)
+        return network.dhtClient.putBoxingKey(signer.publicKeyHash, signer.secret.signOnly(followRequestReceiver.serialize()), followRequestReceiver)
                 .thenCompose(boxerHash -> {
                     WriterData updated = new WriterData(signer.publicKeyHash,
                             Optional.of(newAlgorithm),
@@ -143,7 +143,7 @@ public class WriterData implements Cborable {
                                                          Consumer<CommittedWriterData> updater) {
         byte[] raw = serialize();
 
-        return immutable.put(signer.publicKeyHash, raw)
+        return immutable.put("", signer.publicKeyHash, signer.secret.signOnly(raw), raw)
                 .thenCompose(blobHash -> {
                     MaybeMultihash newHash = MaybeMultihash.of(blobHash);
                     if (newHash.equals(currentHash)) {

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -121,7 +121,7 @@ public class FileUploader implements AutoCloseable {
             byte[] nextLocationNonce = chunkKey.createNonce();
             byte[] nextLocation = nextChunkLocation.encrypt(chunkKey, nextLocationNonce);
             CipherText encryptedNextChunkLocation = new CipherText(nextLocationNonce, nextLocation);
-            return network.uploadFragments(fragments, chunk.location.owner, monitor, fragmenter.storageIncreaseFactor())
+            return network.uploadFragments(fragments, writer, monitor, fragmenter.storageIncreaseFactor())
                     .thenCompose(hashes -> {
                         FileRetriever retriever = new EncryptedChunkRetriever(chunk.chunk.nonce(), encryptedChunk.getAuth(),
                                 hashes, Optional.of(encryptedNextChunkLocation), fragmenter);


### PR DESCRIPTION
This pr makes all writes authenticated. This means that the data being written is signed. 
so the api is now
`put(signing key hash, signature, data)`

This means the server can choose to reject writes based on their owner. Currently implemented is a key filter that allows all registered users. A future pr will include an arbitrary white-list of usernames. 

This involved some careful reordering of operations during sign up and password change. Also required was a defensive cbor technique to prevent out of memory errors when trying to parse random bytes as cbor (we should probably use these everywhere to prevent another form of DOSsing). 

The commit messages should be quite helpful for understanding. It all stems from the ContentAddressedStorage interface. 