### PR TITLE
[issue_304]  usage-state caching

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -288,8 +288,10 @@ public class Main {
             long defaultQuota = a.getLong("default-quota");
             Logging.LOG().info("Using default user space quota of " + defaultQuota);
             Path quotaFilePath = a.fromPeergosDir("quotas_file","quotas.txt");
+            Path statePath = a.fromPeergosDir("state_path","state_path.txt");
+
             UserQuotas userQuotas = new UserQuotas(quotaFilePath, defaultQuota);
-            SpaceCheckingKeyFilter spaceChecker = new SpaceCheckingKeyFilter(core, sqlMutable, localDht, userQuotas::quota);
+            SpaceCheckingKeyFilter spaceChecker = new SpaceCheckingKeyFilter(core, sqlMutable, localDht, userQuotas::quota, statePath);
             CorenodeEventPropagator corePropagator = new CorenodeEventPropagator(core);
             corePropagator.addListener(spaceChecker::accept);
             MutableEventPropagator localMutable = new MutableEventPropagator(sqlMutable);
@@ -330,7 +332,7 @@ public class Main {
             peergos.initAndStart(localAddress, tlsProps, webroot, useWebAssetCache);
             if (! isPkiNode)
                 ((MirrorCoreNode) core).start();
-            spaceChecker.loadAllOwnerAndUsage();
+            spaceChecker.calculateUsage();
         } catch (Exception e) {
             e.printStackTrace();
             System.exit(1);

--- a/src/peergos/server/SpaceCheckingKeyFilter.java
+++ b/src/peergos/server/SpaceCheckingKeyFilter.java
@@ -2,7 +2,6 @@ package peergos.server;
 
 import java.util.logging.*;
 
-import peergos.server.util.Args;
 import peergos.server.util.Logging;
 
 import peergos.server.corenode.*;
@@ -11,14 +10,11 @@ import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.hash.*;
-import peergos.server.storage.UserQuotas;
 import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.user.*;
 import peergos.shared.util.*;
 
-import java.net.URL;
-import java.nio.file.Paths;
 import java.time.*;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -470,30 +466,5 @@ public class SpaceCheckingKeyFilter {
         }
         usage.addPending(writer, size);
         return true;
-    }
-
-    public static void main(String[] args) throws Exception {
-        Args parsed = Args.parse(args);
-        String peergosAddress = parsed.getArg("peergos_address");
-        long defaultQuota = parsed.getLong("default-quota", 1000L);
-        String quota = parsed.getArg("quota_path", "quotas.txt");
-        String state = parsed.getArg("state_path", "state.cbor");
-
-        Crypto.initJava();
-
-        System.out.println(
-            String.format("Starting space-checking-key-filter with peergos-addres %s, default-quota %d, quota_path %s",peergosAddress, defaultQuota, quota));
-
-        Path quotaFilePath = Paths.get(quota);
-        UserQuotas userQuotas = new UserQuotas(quotaFilePath, defaultQuota);
-
-        System.out.println("Connecting to " + peergosAddress);
-        NetworkAccess network = NetworkAccess.buildJava(new URL(peergosAddress)).get();
-
-
-        SpaceCheckingKeyFilter spaceCheckingKeyFilter = new SpaceCheckingKeyFilter(network.coreNode, network.mutable, network.dhtClient, userQuotas::quota, Paths.get(state));
-        System.out.println("Calculating usages...");
-        spaceCheckingKeyFilter.calculateUsage();
-        System.out.println("Finished calculating usages");
     }
 }

--- a/src/peergos/server/SpaceCheckingKeyFilter.java
+++ b/src/peergos/server/SpaceCheckingKeyFilter.java
@@ -1,4 +1,5 @@
 package peergos.server;
+
 import java.util.logging.*;
 
 import peergos.server.util.Args;
@@ -10,10 +11,7 @@ import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.hash.*;
-import peergos.server.storage.IPFS;
-import peergos.server.storage.IpfsDHT;
 import peergos.server.storage.UserQuotas;
-import peergos.shared.io.ipfs.api.JSONParser;
 import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.user.*;

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -173,15 +173,6 @@ public class UserService {
             }
         }
 
-        long defaultQuota = Long.MAX_VALUE; //TODO: fixme
-        LOG.info("Using default user space quota of " + defaultQuota);
-        Path quotaFilePath = Paths.get("quotas.txt");
-        Path usagePath = Paths.get("usage.json");
-        UserQuotas userQuotas = new UserQuotas(quotaFilePath, defaultQuota);
-
-        SpaceCheckingKeyFilter spaceChecker = new SpaceCheckingKeyFilter(coreNode, mutable, storage, userQuotas::quota, usagePath);
-        spaceChecker.calculateUsage();
-
         //define web-root static-handler
         if (webroot.isPresent())
             LOG.info("Using webroot from local file system: " + webroot);

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -4,6 +4,7 @@ import java.util.function.*;
 import java.util.logging.Logger;
 
 import peergos.server.storage.admin.*;
+import peergos.server.storage.UserQuotas;
 import peergos.server.util.Logging;
 import java.util.logging.Level;
 
@@ -172,13 +173,13 @@ public class UserService {
             }
         }
 
-        long defaultQuota = 1e6; //TODO: fixme 
+        long defaultQuota = Long.MAX_VALUE; //TODO: fixme
         LOG.info("Using default user space quota of " + defaultQuota);
         Path quotaFilePath = Paths.get("quotas.txt");
         Path usagePath = Paths.get("usage.json");
         UserQuotas userQuotas = new UserQuotas(quotaFilePath, defaultQuota);
 
-        SpaceCheckingKeyFilter spaceChecker = new SpaceCheckingKeyFilter(coreNode, mutable, dht, userQuotas::quota, usagePath);
+        SpaceCheckingKeyFilter spaceChecker = new SpaceCheckingKeyFilter(coreNode, mutable, storage, userQuotas::quota, usagePath);
         spaceChecker.calculateUsage();
 
         //define web-root static-handler

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -4,7 +4,6 @@ import java.util.function.*;
 import java.util.logging.Logger;
 
 import peergos.server.storage.admin.*;
-import peergos.server.storage.UserQuotas;
 import peergos.server.util.Logging;
 import java.util.logging.Level;
 

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -172,6 +172,15 @@ public class UserService {
             }
         }
 
+        long defaultQuota = 1e6; //TODO: fixme 
+        LOG.info("Using default user space quota of " + defaultQuota);
+        Path quotaFilePath = Paths.get("quotas.txt");
+        Path usagePath = Paths.get("usage.json");
+        UserQuotas userQuotas = new UserQuotas(quotaFilePath, defaultQuota);
+
+        SpaceCheckingKeyFilter spaceChecker = new SpaceCheckingKeyFilter(coreNode, mutable, dht, userQuotas::quota, usagePath);
+        spaceChecker.calculateUsage();
+
         //define web-root static-handler
         if (webroot.isPresent())
             LOG.info("Using webroot from local file system: " + webroot);

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -56,7 +56,7 @@ public class DHTHandler implements HttpHandler {
                     PublicKeyHash ownerHash = PublicKeyHash.fromString(last.apply("owner"));
                     dht.startTransaction(ownerHash).thenAccept(tid -> {
                         replyJson(httpExchange, tid.toString(), Optional.empty());
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case TRANSACTION_CLOSE: {
@@ -64,7 +64,7 @@ public class DHTHandler implements HttpHandler {
                     TransactionId tid = new TransactionId(args.get(0));
                     dht.closeTransaction(ownerHash, tid).thenAccept(b -> {
                         replyJson(httpExchange, JSONParser.toString(b ? 1 : 0), Optional.empty());
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case BLOCK_PUT: {
@@ -151,7 +151,7 @@ public class DHTHandler implements HttpHandler {
                         Map<String, Object> json = new TreeMap<>();
                         json.put("Pins", pinned.stream().map(h -> h.toString()).collect(Collectors.toList()));
                         replyJson(httpExchange, JSONParser.toString(json), Optional.empty());
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case PIN_UPDATE: {

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -141,7 +141,7 @@ public class DHTHandler implements HttpHandler {
                             dht.get(hash).thenApply(opt -> opt.map(CborObject::toByteArray)))
                             .thenAccept(opt -> replyBytes(httpExchange,
                                     opt.orElse(new byte[0]), opt.map(x -> hash)))
-                            .exceptionally(Futures::logError).get();
+                            .exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case PIN_ADD: {
@@ -162,7 +162,7 @@ public class DHTHandler implements HttpHandler {
                         Map<String, Object> json = new TreeMap<>();
                         json.put("Pins", pinned.stream().map(h -> h.toString()).collect(Collectors.toList()));
                         replyJson(httpExchange, JSONParser.toString(json), Optional.empty());
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case PIN_RM: {
@@ -175,7 +175,7 @@ public class DHTHandler implements HttpHandler {
                         Map<String, Object> json = new TreeMap<>();
                         json.put("Pins", unpinned.stream().map(h -> h.toString()).collect(Collectors.toList()));
                         replyJson(httpExchange, JSONParser.toString(json), Optional.empty());
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case BLOCK_STAT: {
@@ -185,7 +185,7 @@ public class DHTHandler implements HttpHandler {
                         res.put("Size", sizeOpt.orElse(0));
                         String json = JSONParser.toString(res);
                         replyJson(httpExchange, json, Optional.of(block));
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case REFS: {
@@ -195,14 +195,14 @@ public class DHTHandler implements HttpHandler {
                         // make stream of JSON objects
                         String jsonStream = json.stream().map(m -> JSONParser.toString(m)).reduce("", (a, b) -> a + b);
                         replyJson(httpExchange, jsonStream, Optional.of(block));
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 case ID: {
                     dht.id().thenAccept(id -> {
                         Object json = wrapHash("ID", id);
                         replyJson(httpExchange, JSONParser.toString(json), Optional.empty());
-                    }).exceptionally(Futures::logError).get();
+                    }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
                 default: {

--- a/src/peergos/server/tests/SpaceCheckingKeyFilterTests.java
+++ b/src/peergos/server/tests/SpaceCheckingKeyFilterTests.java
@@ -1,0 +1,46 @@
+package peergos.server.tests;
+import org.junit.*;
+import static org.junit.Assert.*;
+import peergos.server.SpaceCheckingKeyFilter;
+import peergos.shared.Crypto;
+import peergos.shared.cbor.CborObject;
+import peergos.shared.crypto.hash.PublicKeyHash;
+import peergos.shared.crypto.hash.Sha256;
+import peergos.shared.io.ipfs.multihash.Multihash;
+import peergos.shared.merklebtree.MaybeMultihash;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.Map;
+import static peergos.server.SpaceCheckingKeyFilter.*;
+
+public class SpaceCheckingKeyFilterTests {
+    private static Random RANDOM = new Random(666);
+    private final Crypto crypto = Crypto.initJava();
+
+    private static byte[] random() {
+        byte[] bytes = new byte[Multihash.Type.sha2_256.length];
+        RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+    @Test
+    public void serdeTest() {
+
+        ConcurrentHashMap<PublicKeyHash, SpaceCheckingKeyFilter.Stat> currentView = new ConcurrentHashMap<>();
+        Multihash hash = new Multihash(Multihash.Type.sha2_256, random());
+        currentView.put(new PublicKeyHash(hash), new Stat("test1", MaybeMultihash.empty(), 10, new HashSet<>()));
+
+        ConcurrentHashMap<String, SpaceCheckingKeyFilter.Usage> usage = new ConcurrentHashMap<>();
+        usage.put("test2", new Usage(RANDOM.nextInt()));
+
+        State state = new State(currentView, usage);
+
+        CborObject cborObject = state.toCbor();
+        byte[] serialized = cborObject.serialize();
+
+        State deserialized = fromCbor(CborObject.fromByteArray(serialized));
+        //check that deserialize(serialize(object)) == object
+        Assert.assertEquals(deserialized, state);
+    }
+}

--- a/src/peergos/server/tests/SpaceCheckingKeyFilterTests.java
+++ b/src/peergos/server/tests/SpaceCheckingKeyFilterTests.java
@@ -3,11 +3,11 @@ import org.junit.*;
 import static org.junit.Assert.*;
 import peergos.server.SpaceCheckingKeyFilter;
 import peergos.shared.Crypto;
+import peergos.shared.MaybeMultihash;
 import peergos.shared.cbor.CborObject;
 import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.crypto.hash.Sha256;
 import peergos.shared.io.ipfs.multihash.Multihash;
-import peergos.shared.merklebtree.MaybeMultihash;
 
 import java.util.HashSet;
 import java.util.Random;

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -181,18 +181,6 @@ public interface CborObject extends Cborable {
             return values != null ? values.hashCode() : 0;
         }
 
-        public Cborable get(String key) {
-            return values.get(new CborString(key));
-        }
-
-        public String getString(String key) {
-            return ((CborString) get(key)).value;
-        }
-
-        public long getLong(String key) {
-            return ((CborLong) get(key)).value;
-        }
-
         public CborList getList(String key) {
             return (CborList) get(key);
         }

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -23,7 +23,6 @@ public interface CborObject extends Cborable {
         serialize(encoder);
         return bout.toByteArray();
     }
-    public interface CborComparable extends CborObject, Comparable {}
 
     @Override
     default CborObject toCbor() {

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -23,6 +23,7 @@ public interface CborObject extends Cborable {
         serialize(encoder);
         return bout.toByteArray();
     }
+    public interface CborComparable extends CborObject, Comparable {}
 
     @Override
     default CborObject toCbor() {
@@ -179,13 +180,46 @@ public interface CborObject extends Cborable {
         public int hashCode() {
             return values != null ? values.hashCode() : 0;
         }
+
+        public Cborable get(String key) {
+            return values.get(new CborString(key));
+        }
+
+        public String getString(String key) {
+            return ((CborString) get(key)).value;
+        }
+
+        public long getLong(String key) {
+            return ((CborLong) get(key)).value;
+        }
+
+        public CborList getList(String key) {
+            return (CborList) get(key);
+        }
+
+        public <T> T get(String key, Function<? super Cborable, T> fromCbor) {
+            return fromCbor.apply(get(key));
+        }
+
+        public <K,V> Map<K,V> getMap(Function<? super Cborable, K> toKey, Function<? super Cborable, V> toValue) {
+            return values.entrySet().stream()
+                .collect(Collectors.toMap(
+                    e -> toKey.apply(e.getKey()),
+                    e -> toValue.apply(e.getValue())
+                ));
+        }
     }
 
-    final class CborMerkleLink implements CborObject {
+    final class CborMerkleLink implements CborObject, Comparable<CborMerkleLink> {
         public final Multihash target;
 
         public CborMerkleLink(Multihash target) {
             this.target = target;
+        }
+
+        @Override
+        public int compareTo(CborMerkleLink that) {
+            return this.target.compareTo(that.target);
         }
 
         @Override
@@ -223,11 +257,17 @@ public interface CborObject extends Cborable {
         }
     }
 
-    final class CborList implements CborObject {
+    final class CborList implements CborObject, Cborable {
         public final List<? extends Cborable> value;
 
         public CborList(List<? extends Cborable> value) {
             this.value = value;
+        }
+
+        public CborList(Map<? extends Cborable, ? extends Cborable> map) {
+            this.value = map.entrySet().stream()
+                .flatMap(e -> Stream.of(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
         }
 
         @Override
@@ -262,6 +302,29 @@ public interface CborObject extends Cborable {
         @Override
         public int hashCode() {
             return value != null ? value.hashCode() : 0;
+        }
+
+        public <T> List<T> map(Function<? super Cborable, T> fromCbor) {
+            return value.stream()
+                .map(fromCbor)
+                .collect(Collectors.toList());
+        }
+
+        public <T> T get(int index, Function<? super Cborable, T> fromCbor) {
+            return fromCbor.apply(value.get(index));
+        }
+
+        public <K,V> Map<K, V> getMap(Function<? super Cborable, K> toKey, Function<? super Cborable, V> toValue) {
+            if (value.size() % 2 != 0)
+                throw new IllegalStateException();
+
+            Map<K, V> map = new HashMap<>();
+            for (int i = 0; i < value.size(); i += 2) {
+                K key = toKey.apply(value.get(i));
+                V _value = toValue.apply(value.get(i + 1));
+                map.put(key, _value);
+            }
+            return map;
         }
     }
 

--- a/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519PublicKey.java
+++ b/src/peergos/shared/crypto/asymmetric/curve25519/Ed25519PublicKey.java
@@ -46,6 +46,8 @@ public class Ed25519PublicKey implements PublicSigningKey {
     }
 
     public byte[] unsignMessage(byte[] signed) {
+        if (implementation == null)
+            throw new IllegalStateException("Uninitialized crypto-implementation: call peergos.shared.Crypto::init");
         return implementation.crypto_sign_open(signed, publicKey);
     }
 

--- a/src/peergos/shared/io/ipfs/multihash/Multihash.java
+++ b/src/peergos/shared/io/ipfs/multihash/Multihash.java
@@ -68,14 +68,6 @@ public class Multihash implements Comparable<Multihash> {
         return compare;
     }
 
-    public Multihash(Multihash toClone) {
-        this(toClone.type, toClone.hash); // N.B. despite being a byte[], hash is immutable
-    }
-
-    public Multihash(byte[] multihash) {
-        this(Type.lookup(multihash[0] & 0xff), Arrays.copyOfRange(multihash, 2, multihash.length));
-    }
-
     public byte[] toBytes() {
         byte[] res = new byte[hash.length+2];
         res[0] = (byte)type.index;

--- a/src/peergos/shared/io/ipfs/multihash/Multihash.java
+++ b/src/peergos/shared/io/ipfs/multihash/Multihash.java
@@ -8,7 +8,7 @@ import java.io.*;
 import java.util.*;
 
 @JsType
-public class Multihash {
+public class Multihash implements Comparable<Multihash> {
     @JsType
     public enum Type {
         id(0, -1),
@@ -54,6 +54,26 @@ public class Multihash {
 
     public static Multihash decode(byte[] multihash) {
         return new Multihash(Type.lookup(multihash[0] & 0xff), Arrays.copyOfRange(multihash, 2, multihash.length));
+    }
+    @Override
+    public int compareTo(Multihash that) {
+        int compare = Integer.compare(this.hash.length, that.hash.length);
+        if (compare != 0)
+            return compare;
+        for (int i = 0; i < this.hash.length; i++) {
+            compare = Byte.compare(this.hash[i], that.hash[i]);
+            if (compare != 0)
+                return compare;
+        }
+        return compare;
+    }
+
+    public Multihash(Multihash toClone) {
+        this(toClone.type, toClone.hash); // N.B. despite being a byte[], hash is immutable
+    }
+
+    public Multihash(byte[] multihash) {
+        this(Type.lookup(multihash[0] & 0xff), Arrays.copyOfRange(multihash, 2, multihash.length));
     }
 
     public byte[] toBytes() {

--- a/src/peergos/shared/io/ipfs/multihash/Multihash.java
+++ b/src/peergos/shared/io/ipfs/multihash/Multihash.java
@@ -65,7 +65,7 @@ public class Multihash implements Comparable<Multihash> {
             if (compare != 0)
                 return compare;
         }
-        return compare;
+        return Integer.compare(type.index, that.type.index);
     }
 
     public byte[] toBytes() {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -160,7 +160,7 @@ public class UserContext {
                             crypto.random, crypto.signer, crypto.boxer, algorithm)
                             .thenCompose(userWithRoot ->
                                     login(username, userWithRoot, pair, network, crypto, progressCallback));
-                }).exceptionally(Futures::logError);
+                }).exceptionally(Futures::logAndThrow);
     }
 
     public static CompletableFuture<UserContext> signIn(String username, UserWithRoot userWithRoot, NetworkAccess network
@@ -168,7 +168,7 @@ public class UserContext {
         return getWriterDataCbor(network, username)
                 .thenCompose(pair -> {
                     return login(username, userWithRoot, pair, network, crypto, progressCallback);
-                }).exceptionally(Futures::logError);
+                }).exceptionally(Futures::logAndThrow);
     }
 
     private static CompletableFuture<UserContext> login(String username,
@@ -201,7 +201,7 @@ public class UserContext {
                                         .thenCompose(x -> {
                                             System.out.println("Initializing context..");
                                             return result.init(userWithRoot.getRoot(), progressCallback);
-                                        }).exceptionally(Futures::logError);
+                                        }).exceptionally(Futures::logAndThrow);
                             }));
         } catch (Throwable t) {
             throw new IllegalStateException("Incorrect password");
@@ -286,7 +286,7 @@ public class UserContext {
                                 context.sendInitialFollowRequest(PEERGOS_USERNAME) :
                                 CompletableFuture.completedFuture(true))
                         .thenApply(b -> context))
-                .exceptionally(Futures::logError);
+                .exceptionally(Futures::logAndThrow);
     }
 
     private CompletableFuture<UserContext> createSpecialDirectory(String dirName) {
@@ -1217,7 +1217,7 @@ public class UserContext {
                 .filter(e -> e.ownerName.equals(ourName))
                 .collect(Collectors.toList());
         return Futures.reduceAll(ourFileSystemEntries, root, (t, e) -> addEntryPoint(ourName, t, e, network, random, fragmenter), (a, b) -> a)
-                .exceptionally(Futures::logError);
+                .exceptionally(Futures::logAndThrow);
     }
 
     /**
@@ -1238,7 +1238,7 @@ public class UserContext {
 
         // need to to retrieve all the entry points of our friends
         return Futures.reduceAll(notOurFileSystemEntries, ourRoot, (t, e) -> addEntryPoint(ourName, t, e, network, random, fragmenter), (a, b) -> a)
-                .exceptionally(Futures::logError);
+                .exceptionally(Futures::logAndThrow);
     }
 
     private static CompletableFuture<TrieNode> addRetrievedEntryPoint(String ourName,
@@ -1284,7 +1284,7 @@ public class UserContext {
                         );
             }
             return CompletableFuture.completedFuture(root);
-        }).exceptionally(Futures::logError);
+        }).exceptionally(Futures::logAndThrow);
     }
 
     public static CompletableFuture<CommittedWriterData> getWriterData(NetworkAccess network, PublicKeyHash owner, PublicKeyHash writer) {

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -63,7 +63,13 @@ public class Futures {
         );
     }
 
-    public static <T> T logError(Throwable t) {
+    public static <T> T logAndThrow(Throwable t) {
+        return logAndThrow(t, Optional.empty());
+    }
+
+    public static <T> T logAndThrow(Throwable t, Optional<String> message) {
+        if (message.isPresent())
+            System.out.println(message);
         t.printStackTrace();
         throw new RuntimeException(t.getMessage(), t);
     }


### PR DESCRIPTION
Updated error message on username-claim renewal failure.

Updated  SpaceCheckingKeyFilter to store/load (username -> usage) state
to/from a local file, falling back to re-calculating it from scratch on
startup.

Note, for the shutdown-hook to be triggered either a kill signal with the
default level (or sending a ctrl-c) should be used to kill the process.