### PR TITLE
Separate CoreNode and SocialNetwork

### DIFF
--- a/src/peergos/server/Playground.java
+++ b/src/peergos/server/Playground.java
@@ -29,7 +29,7 @@ public class Playground {
         Crypto crypto = Crypto.initJava();
         NetworkAccess source = NetworkAccess.buildJava(new URL("https://demo.peergos.net")).get();
 
-        ContentAddressedStorage nonWriteThroughIpfs = new NonWriteThroughStorage(source.dhtClient, new RAMStorage());
+        ContentAddressedStorage nonWriteThroughIpfs = new NonWriteThroughStorage(source.dhtClient);
         NonWriteThroughCoreNode nonWriteThroughCoreNode = new NonWriteThroughCoreNode(source.coreNode, nonWriteThroughIpfs);
         MutablePointers nonWriteThroughPointers = new NonWriteThroughMutablePointers(source.mutable, nonWriteThroughIpfs);
         MutableTreeImpl nonWriteThroughTree = new MutableTreeImpl(nonWriteThroughPointers, nonWriteThroughIpfs);

--- a/src/peergos/server/Playground.java
+++ b/src/peergos/server/Playground.java
@@ -2,6 +2,7 @@ package peergos.server;
 
 import peergos.server.corenode.*;
 import peergos.server.mutable.*;
+import peergos.server.social.*;
 import peergos.server.storage.*;
 import peergos.shared.*;
 import peergos.shared.crypto.*;
@@ -32,8 +33,10 @@ public class Playground {
         ContentAddressedStorage nonWriteThroughIpfs = new NonWriteThroughStorage(source.dhtClient);
         MutablePointers nonWriteThroughPointers = new NonWriteThroughMutablePointers(source.mutable, nonWriteThroughIpfs);
         NonWriteThroughCoreNode nonWriteThroughCoreNode = new NonWriteThroughCoreNode(source.coreNode, nonWriteThroughIpfs);
+        NonWriteThroughSocialNetwork nonWriteThroughSocial = new NonWriteThroughSocialNetwork(source.social, nonWriteThroughIpfs);
         MutableTreeImpl nonWriteThroughTree = new MutableTreeImpl(nonWriteThroughPointers, nonWriteThroughIpfs);
         NetworkAccess nonWriteThrough = new NetworkAccess(nonWriteThroughCoreNode,
+                nonWriteThroughSocial,
                 nonWriteThroughIpfs,
                 nonWriteThroughPointers,
                 nonWriteThroughTree, source.usernames, false);

--- a/src/peergos/server/Playground.java
+++ b/src/peergos/server/Playground.java
@@ -1,0 +1,63 @@
+package peergos.server;
+
+import peergos.server.corenode.*;
+import peergos.server.mutable.*;
+import peergos.server.storage.*;
+import peergos.shared.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.random.*;
+import peergos.shared.mutable.*;
+import peergos.shared.storage.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+/**
+ *  Use this class to experiment with existing data without committing any changes or writing any data to disk
+ */
+public class Playground {
+
+    public static void main(String[] args) throws Exception {
+        Crypto crypto = Crypto.initJava();
+        NetworkAccess source = NetworkAccess.buildJava(new URL("https://demo.peergos.net")).get();
+
+        ContentAddressedStorage nonWriteThroughIpfs = new NonWriteThroughStorage(source.dhtClient, new RAMStorage());
+        NonWriteThroughCoreNode nonWriteThroughCoreNode = new NonWriteThroughCoreNode(source.coreNode, nonWriteThroughIpfs);
+        MutablePointers nonWriteThroughPointers = new NonWriteThroughMutablePointers(source.mutable, nonWriteThroughIpfs);
+        MutableTreeImpl nonWriteThroughTree = new MutableTreeImpl(nonWriteThroughPointers, nonWriteThroughIpfs);
+        NetworkAccess nonWriteThrough = new NetworkAccess(nonWriteThroughCoreNode,
+                nonWriteThroughIpfs,
+                nonWriteThroughPointers,
+                nonWriteThroughTree, source.usernames, false);
+
+        String username = args[0];
+        Console console = System.console();
+        String password = new String(console.readPassword("Enter password for " + username + ":"));
+        UserContext context = UserContext.signIn(username, password, nonWriteThrough, crypto).get();
+        // Do something
+        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, nonWriteThroughCoreNode, nonWriteThroughPointers, nonWriteThroughIpfs);
+        for (PublicKeyHash ownedKey : ownedKeys) {
+            if (ownedKey.equals(context.signer.publicKeyHash))
+                continue; // only the writer has a tree
+            CommittedWriterData existing = WriterData.getWriterData(ownedKey, nonWriteThroughPointers, nonWriteThroughIpfs).get();
+            if (existing.props.tree.isPresent())
+                continue;
+            SecretSigningKey signingKey = context.getUserRoot().get().getEntryWriterKey().get();
+            SigningPrivateKeyAndPublicHash writer = new SigningPrivateKeyAndPublicHash(ownedKey, signingKey);
+            // invert the following two lines to actually commit the migration
+            existing.props.migrateToChamp(writer, existing.hash, nonWriteThrough, res -> {}).get();
+//            existing.props.migrateToChamp(writer, existing.hash, source, res -> {}).get();
+        }
+        // Can we still log in?
+        UserContext context2 = UserContext.signIn(username, password, nonWriteThrough, crypto).get();
+        System.out.println(context2.getUserRoot().get().getName());
+    }
+}

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -54,21 +54,6 @@ public class CorenodeEventPropagator implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
-        return this.target.sendFollowRequest(target, encryptedPermission);
-    }
-
-    @Override
-    public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner) {
-        return target.getFollowRequests(owner);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] data) {
-        return target.removeFollowRequest(owner, data);
-    }
-
-    @Override
     public void close() throws IOException {
 
     }

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -54,8 +54,8 @@ public class CorenodeEventPropagator implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
-        return this.target.addFollowRequest(target, encryptedPermission);
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
+        return this.target.sendFollowRequest(target, encryptedPermission);
     }
 
     @Override

--- a/src/peergos/server/corenode/HttpCoreNodeServer.java
+++ b/src/peergos/server/corenode/HttpCoreNodeServer.java
@@ -169,7 +169,7 @@ public class HttpCoreNodeServer
             PublicKeyHash target = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
             byte[] encodedSharingPublicKey = CoreNodeUtils.deserializeByteArray(din);
 
-            boolean followRequested = coreNode.addFollowRequest(target, encodedSharingPublicKey).get();
+            boolean followRequested = coreNode.sendFollowRequest(target, encodedSharingPublicKey).get();
             dout.writeBoolean(followRequested);
         }
         void getFollowRequests(DataInputStream din, DataOutputStream dout) throws Exception

--- a/src/peergos/server/corenode/HttpCoreNodeServer.java
+++ b/src/peergos/server/corenode/HttpCoreNodeServer.java
@@ -13,7 +13,6 @@ import java.util.concurrent.*;
 import java.util.zip.*;
 
 import com.sun.net.httpserver.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.api.*;
 import peergos.shared.mutable.*;
@@ -71,15 +70,6 @@ public class HttpCoreNodeServer
                         exchange.getResponseHeaders().set("Content-Encoding", "gzip");
                         exchange.getResponseHeaders().set("Content-Type", "application/json");
                         getAllUsernamesGzip(subComponents.length > 1 ? subComponents[1] : "", din, dout);
-                        break;
-                    case "followRequest":
-                        followRequest(din, dout);
-                        break;
-                    case "getFollowRequests":
-                        getFollowRequests(din, dout);
-                        break;
-                    case "removeFollowRequest":
-                        removeFollowRequest(din, dout);
                         break;
                     default:
                         throw new IOException("Unknown method "+ method);
@@ -161,32 +151,6 @@ public class HttpCoreNodeServer
             gout.flush();
             gout.close();
             dout.write(bout.toByteArray());
-        }
-
-        void followRequest(DataInputStream din, DataOutputStream dout) throws Exception
-        {
-            byte[] encodedKey = Serialize.deserializeByteArray(din, PublicSigningKey.MAX_SIZE);
-            PublicKeyHash target = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
-            byte[] encodedSharingPublicKey = CoreNodeUtils.deserializeByteArray(din);
-
-            boolean followRequested = coreNode.sendFollowRequest(target, encodedSharingPublicKey).get();
-            dout.writeBoolean(followRequested);
-        }
-        void getFollowRequests(DataInputStream din, DataOutputStream dout) throws Exception
-        {
-            byte[] encodedKey = Serialize.deserializeByteArray(din, PublicSigningKey.MAX_SIZE);
-            PublicKeyHash ownerPublicKey = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
-            byte[] res = coreNode.getFollowRequests(ownerPublicKey).get();
-            Serialize.serialize(res, dout);
-        }
-        void removeFollowRequest(DataInputStream din, DataOutputStream dout) throws Exception
-        {
-            byte[] encodedKey = Serialize.deserializeByteArray(din, PublicSigningKey.MAX_SIZE);
-            PublicKeyHash owner = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
-            byte[] signedFollowRequest = CoreNodeUtils.deserializeByteArray(din);
-
-            boolean isRemoved = coreNode.removeFollowRequest(owner, signedFollowRequest).get();
-            dout.writeBoolean(isRemoved);
         }
 
         public void close() throws IOException{

--- a/src/peergos/server/corenode/JDBCCoreNode.java
+++ b/src/peergos/server/corenode/JDBCCoreNode.java
@@ -2,13 +2,8 @@ package peergos.server.corenode;
 
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
-import peergos.shared.crypto.asymmetric.*;
-import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.io.ipfs.multihash.*;
-import peergos.shared.merklebtree.*;
-import peergos.shared.mutable.*;
-import peergos.shared.storage.*;
+import peergos.shared.social.*;
 import peergos.shared.util.*;
 
 import java.io.*;
@@ -577,7 +572,7 @@ public class JDBCCoreNode {
         byte[] dummy = null;
         FollowRequestData selector = new FollowRequestData(owner, dummy);
         RowData[] requests = selector.select();
-        if (requests != null && requests.length > CoreNode.MAX_PENDING_FOLLOWERS)
+        if (requests != null && requests.length > SocialNetwork.MAX_PENDING_FOLLOWERS)
             return CompletableFuture.completedFuture(false);
         // ToDo add a crypto currency transaction to prevent spam
 

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -1,0 +1,156 @@
+package peergos.server.corenode;
+
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.storage.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+
+public class NonWriteThroughCoreNode implements CoreNode {
+
+    private final CoreNode source;
+    private final CoreNode temp;
+    private final ContentAddressedStorage ipfs;
+
+    public NonWriteThroughCoreNode(CoreNode source, ContentAddressedStorage ipfs) {
+        this.source = source;
+        this.ipfs = ipfs;
+        try {
+            this.temp = UserRepository.buildSqlLite(":memory:", ipfs, 1000);
+        } catch (SQLException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<PublicKeyHash>> getPublicKeyHash(String username) {
+        try {
+            Optional<PublicKeyHash> modified = temp.getPublicKeyHash(username).get();
+            if (modified.isPresent())
+                return CompletableFuture.completedFuture(modified);
+            return source.getPublicKeyHash(username);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<String> getUsername(PublicKeyHash key) {
+        try {
+            String modified = temp.getUsername(key).get();
+            if (! modified.isEmpty())
+                return CompletableFuture.completedFuture(modified);
+            return source.getUsername(key);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<UserPublicKeyLink>> getChain(String username) {
+        try {
+            List<UserPublicKeyLink> modified = temp.getChain(username).get();
+            if (! modified.isEmpty())
+                return CompletableFuture.completedFuture(modified);
+            return source.getChain(username);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
+        try {
+            List<UserPublicKeyLink> modified = temp.getChain(username).get();
+            if (! modified.isEmpty())
+                return temp.updateChain(username, chain);
+            List<UserPublicKeyLink> existing = source.getChain(username).get();
+            temp.updateChain(username, existing).get();
+            return temp.updateChain(username, chain);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<String>> getUsernames(String prefix) {
+        try {
+            return CompletableFuture.completedFuture(
+                    Stream.concat(
+                            source.getUsernames(prefix).get().stream(),
+                            temp.getUsernames(prefix).get().stream())
+                            .distinct()
+                            .collect(Collectors.toList()));
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private final Map<PublicKeyHash, List<ByteArrayWrapper>> removedFollowRequests = new ConcurrentHashMap<>();
+    private final Map<PublicKeyHash, List<ByteArrayWrapper>> newFollowRequests = new ConcurrentHashMap<>();
+
+    @Override
+    public CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
+        newFollowRequests.putIfAbsent(target, new ArrayList<>());
+        ByteArrayWrapper wrappped = new ByteArrayWrapper(encryptedPermission);
+        newFollowRequests.get(target).add(wrappped);
+        removedFollowRequests.putIfAbsent(target, new ArrayList<>());
+        removedFollowRequests.get(target).remove(wrappped);
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner) {
+        try {
+            byte[] reqs = source.getFollowRequests(owner).get();
+            DataSource din = new DataSource(reqs);
+            List<byte[]> notDeleted = new ArrayList<>();
+            List<ByteArrayWrapper> removed = removedFollowRequests.get(owner);
+            int n = din.readInt();
+            for (int i = 0; i < n; i++) {
+                byte[] req = din.readArray();
+                ByteArrayWrapper wrapped = new ByteArrayWrapper(req);
+                if (! removed.contains(wrapped))
+                    notDeleted.add(req);
+            }
+            notDeleted.addAll(newFollowRequests.get(owner).stream()
+                    .map(w -> w.data)
+                    .collect(Collectors.toList()));
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DataOutput dout = new DataOutputStream(bout);
+            dout.writeInt(notDeleted.size());
+            for (byte[] req : notDeleted) {
+                Serialize.serialize(req, dout);
+            }
+            return CompletableFuture.completedFuture(bout.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] signedEncryptedPermission) {
+        try {
+            PublicSigningKey signer = ipfs.getSigningKey(owner).get().get();
+            byte[] unsigned = signer.unsignMessage(signedEncryptedPermission);
+
+            newFollowRequests.putIfAbsent(owner, new ArrayList<>());
+            ByteArrayWrapper wrappped = new ByteArrayWrapper(unsigned);
+            newFollowRequests.get(owner).remove(wrappped);
+            removedFollowRequests.putIfAbsent(owner, new ArrayList<>());
+            removedFollowRequests.get(owner).add(wrappped);
+            return CompletableFuture.completedFuture(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {}
+}

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -1,10 +1,8 @@
 package peergos.server.corenode;
 
 import peergos.shared.corenode.*;
-import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
-import peergos.shared.util.*;
 
 import java.io.*;
 import java.sql.*;
@@ -16,11 +14,9 @@ public class NonWriteThroughCoreNode implements CoreNode {
 
     private final CoreNode source;
     private final CoreNode temp;
-    private final ContentAddressedStorage ipfs;
 
     public NonWriteThroughCoreNode(CoreNode source, ContentAddressedStorage ipfs) {
         this.source = source;
-        this.ipfs = ipfs;
         try {
             this.temp = UserRepository.buildSqlLite(":memory:", ipfs, 1000);
         } catch (SQLException e) {
@@ -87,65 +83,6 @@ public class NonWriteThroughCoreNode implements CoreNode {
                             temp.getUsernames(prefix).get().stream())
                             .distinct()
                             .collect(Collectors.toList()));
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
-        }
-    }
-
-    private final Map<PublicKeyHash, List<ByteArrayWrapper>> removedFollowRequests = new ConcurrentHashMap<>();
-    private final Map<PublicKeyHash, List<ByteArrayWrapper>> newFollowRequests = new ConcurrentHashMap<>();
-
-    @Override
-    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
-        newFollowRequests.putIfAbsent(target, new ArrayList<>());
-        ByteArrayWrapper wrappped = new ByteArrayWrapper(encryptedPermission);
-        newFollowRequests.get(target).add(wrappped);
-        removedFollowRequests.putIfAbsent(target, new ArrayList<>());
-        removedFollowRequests.get(target).remove(wrappped);
-        return CompletableFuture.completedFuture(true);
-    }
-
-    @Override
-    public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner) {
-        try {
-            byte[] reqs = source.getFollowRequests(owner).get();
-            DataSource din = new DataSource(reqs);
-            List<byte[]> notDeleted = new ArrayList<>();
-            List<ByteArrayWrapper> removed = removedFollowRequests.get(owner);
-            int n = din.readInt();
-            for (int i = 0; i < n; i++) {
-                byte[] req = din.readArray();
-                ByteArrayWrapper wrapped = new ByteArrayWrapper(req);
-                if (! removed.contains(wrapped))
-                    notDeleted.add(req);
-            }
-            notDeleted.addAll(newFollowRequests.get(owner).stream()
-                    .map(w -> w.data)
-                    .collect(Collectors.toList()));
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            DataOutput dout = new DataOutputStream(bout);
-            dout.writeInt(notDeleted.size());
-            for (byte[] req : notDeleted) {
-                Serialize.serialize(req, dout);
-            }
-            return CompletableFuture.completedFuture(bout.toByteArray());
-        } catch (Exception e) {
-            throw new RuntimeException(e.getMessage(), e);
-        }
-    }
-
-    @Override
-    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] signedEncryptedPermission) {
-        try {
-            PublicSigningKey signer = ipfs.getSigningKey(owner).get().get();
-            byte[] unsigned = signer.unsignMessage(signedEncryptedPermission);
-
-            newFollowRequests.putIfAbsent(owner, new ArrayList<>());
-            ByteArrayWrapper wrappped = new ByteArrayWrapper(unsigned);
-            newFollowRequests.get(owner).remove(wrappped);
-            removedFollowRequests.putIfAbsent(owner, new ArrayList<>());
-            removedFollowRequests.get(owner).add(wrappped);
-            return CompletableFuture.completedFuture(true);
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -96,7 +96,7 @@ public class NonWriteThroughCoreNode implements CoreNode {
     private final Map<PublicKeyHash, List<ByteArrayWrapper>> newFollowRequests = new ConcurrentHashMap<>();
 
     @Override
-    public CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
         newFollowRequests.putIfAbsent(target, new ArrayList<>());
         ByteArrayWrapper wrappped = new ByteArrayWrapper(encryptedPermission);
         newFollowRequests.get(target).add(wrappped);

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -1,13 +1,11 @@
 package peergos.server.corenode;
 
-import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.io.ipfs.multihash.*;
-import peergos.shared.merklebtree.*;
 import peergos.shared.mutable.*;
+import peergos.shared.social.*;
 import peergos.shared.storage.*;
 
 import java.io.*;
@@ -16,8 +14,7 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-public class UserRepository implements CoreNode, MutablePointers {
-    public static final boolean LOGGING = false;
+public class UserRepository implements CoreNode, SocialNetwork, MutablePointers {
 
     private final ContentAddressedStorage ipfs;
     private final JDBCCoreNode store;

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -72,7 +72,7 @@ public class UserRepository implements CoreNode, MutablePointers {
     }
 
     @Override
-    public CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
         return store.addFollowRequest(target, encryptedPermission);
     }
 

--- a/src/peergos/server/mutable/NonWriteThroughMutablePointers.java
+++ b/src/peergos/server/mutable/NonWriteThroughMutablePointers.java
@@ -1,0 +1,53 @@
+package peergos.server.mutable;
+
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.mutable.*;
+import peergos.shared.storage.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class NonWriteThroughMutablePointers implements MutablePointers {
+
+    private final MutablePointers source;
+    private final ContentAddressedStorage storage;
+    private final Map<PublicKeyHash, byte[]> modifications;
+
+    public NonWriteThroughMutablePointers(MutablePointers source, ContentAddressedStorage storage) {
+        this.source = source;
+        this.storage = storage;
+        this.modifications = new HashMap<>();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPointer(PublicKeyHash owner, PublicKeyHash writer, byte[] writerSignedBtreeRootHash) {
+        try {
+            if (! modifications.containsKey(writer)) {
+                Optional<byte[]> existing = source.getPointer(writer).get();
+                existing.map(val -> modifications.put(writer, val));
+            }
+            Optional<PublicSigningKey> opt = storage.getSigningKey(writer).get();
+            if (! opt.isPresent())
+                throw new IllegalStateException("Couldn't retrieve signing key!");
+            boolean validUpdate = MutablePointers.isValidUpdate(opt.get(), Optional.ofNullable(modifications.get(writer)), writerSignedBtreeRootHash);
+            if (! validUpdate)
+                return CompletableFuture.completedFuture(false);
+            modifications.put(writer, writerSignedBtreeRootHash);
+            return CompletableFuture.completedFuture(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writer) {
+        try {
+            if (modifications.containsKey(writer))
+                return CompletableFuture.completedFuture(Optional.of(modifications.get(writer)));
+            return source.getPointer(writer);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/peergos/server/social/HttpSocialNetworkServer.java
+++ b/src/peergos/server/social/HttpSocialNetworkServer.java
@@ -1,0 +1,163 @@
+package peergos.server.social;
+
+import com.sun.net.httpserver.*;
+import peergos.server.mutable.*;
+import peergos.shared.cbor.*;
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.api.*;
+import peergos.shared.mutable.*;
+import peergos.shared.social.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.zip.*;
+
+public class HttpSocialNetworkServer
+{
+    private static final boolean LOGGING = true;
+    private static final int CONNECTION_BACKLOG = 100;
+    private static final int HANDLER_THREAD_COUNT = 100;
+
+    public static final String SOCIAL_URL = "social/";
+    public static final int PORT = 7777;
+
+    public static class SocialHandler implements HttpHandler
+    {
+        private final SocialNetwork social;
+
+        public SocialHandler(SocialNetwork social) {
+            this.social = social;
+        }
+
+        public void handle(HttpExchange exchange) throws IOException
+        {
+            long t1 = System.currentTimeMillis();
+            DataInputStream din = new DataInputStream(exchange.getRequestBody());
+
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DataOutputStream dout = new DataOutputStream(bout);
+
+            String path = exchange.getRequestURI().getPath();
+            if (path.startsWith("/"))
+                path = path.substring(1);
+            String[] subComponents = path.substring(SOCIAL_URL.length()).split("/");
+            String method = subComponents[0];
+//            System.out.println("core method "+ method +" from path "+ path);
+
+            try {
+                switch (method)
+                {
+                    case "followRequest":
+                        followRequest(din, dout);
+                        break;
+                    case "getFollowRequests":
+                        getFollowRequests(din, dout);
+                        break;
+                    case "removeFollowRequest":
+                        removeFollowRequest(din, dout);
+                        break;
+                    default:
+                        throw new IOException("Unknown method "+ method);
+                }
+
+                dout.flush();
+                dout.close();
+                byte[] b = bout.toByteArray();
+                exchange.sendResponseHeaders(200, b.length);
+                exchange.getResponseBody().write(b);
+            } catch (Exception e) {
+                Throwable cause = e.getCause();
+                if (cause != null)
+                    exchange.getResponseHeaders().set("Trailer", cause.getMessage());
+                else
+                    exchange.getResponseHeaders().set("Trailer", e.getMessage());
+
+                exchange.sendResponseHeaders(400, 0);
+            } finally {
+                exchange.close();
+                long t2 = System.currentTimeMillis();
+                if (LOGGING)
+                    System.out.println("Corenode server handled " + method + " request in: " + (t2 - t1) + " mS");
+            }
+
+        }
+
+        void followRequest(DataInputStream din, DataOutputStream dout) throws Exception
+        {
+            byte[] encodedKey = Serialize.deserializeByteArray(din, PublicSigningKey.MAX_SIZE);
+            PublicKeyHash target = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
+            byte[] encodedSharingPublicKey = CoreNodeUtils.deserializeByteArray(din);
+
+            boolean followRequested = social.sendFollowRequest(target, encodedSharingPublicKey).get();
+            dout.writeBoolean(followRequested);
+        }
+        void getFollowRequests(DataInputStream din, DataOutputStream dout) throws Exception
+        {
+            byte[] encodedKey = Serialize.deserializeByteArray(din, PublicSigningKey.MAX_SIZE);
+            PublicKeyHash ownerPublicKey = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
+            byte[] res = social.getFollowRequests(ownerPublicKey).get();
+            Serialize.serialize(res, dout);
+        }
+        void removeFollowRequest(DataInputStream din, DataOutputStream dout) throws Exception
+        {
+            byte[] encodedKey = Serialize.deserializeByteArray(din, PublicSigningKey.MAX_SIZE);
+            PublicKeyHash owner = PublicKeyHash.fromCbor(CborObject.fromByteArray(encodedKey));
+            byte[] signedFollowRequest = CoreNodeUtils.deserializeByteArray(din);
+
+            boolean isRemoved = social.removeFollowRequest(owner, signedFollowRequest).get();
+            dout.writeBoolean(isRemoved);
+        }
+    }
+
+    private final HttpServer server;
+    private final InetSocketAddress address;
+    private final SocialHandler ch;
+
+    public HttpSocialNetworkServer(SocialNetwork social, MutablePointers mutable, InetSocketAddress address) throws IOException
+    {
+
+        this.address = address;
+        if (address.getHostName().contains("local"))
+            server = HttpServer.create(address, CONNECTION_BACKLOG);
+        else
+            server = HttpServer.create(new InetSocketAddress(InetAddress.getLocalHost(), address.getPort()), CONNECTION_BACKLOG);
+        ch = new SocialHandler(social);
+        server.createContext("/" + SOCIAL_URL, ch);
+        server.createContext("/" + HttpMutablePointerServer.MUTABLE_POINTERS_URL, new HttpMutablePointerServer.MutationHandler(mutable));
+        server.setExecutor(Executors.newFixedThreadPool(HANDLER_THREAD_COUNT));
+    }
+
+    public void start() throws IOException
+    {
+        server.start();
+    }
+    
+    public InetSocketAddress getAddress(){return address;}
+
+    public void close() throws IOException
+    {   
+        server.stop(5);
+    }
+
+
+    public static void createAndStart(String keyfile, char[] passphrase, int port, SocialNetwork social, MutablePointers mutable, Args args)
+    {
+        // eventually will need our own keypair to sign traffic to other core nodes
+        try {
+            String hostname = args.getArg("domain", "localhost");
+            System.out.println("Starting social network server listening on: " + hostname+":"+port +" proxying to "+social);
+            InetSocketAddress address = new InetSocketAddress(hostname, port);
+            HttpSocialNetworkServer server = new HttpSocialNetworkServer(social, mutable, address);
+            server.start();
+        } catch (Exception e)
+        {
+            e.printStackTrace();
+            System.out.println("Couldn't start Corenode server!");
+        }
+    }
+}

--- a/src/peergos/server/social/NonWriteThroughSocialNetwork.java
+++ b/src/peergos/server/social/NonWriteThroughSocialNetwork.java
@@ -1,0 +1,82 @@
+package peergos.server.social;
+
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.social.*;
+import peergos.shared.storage.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+
+public class NonWriteThroughSocialNetwork implements SocialNetwork {
+
+    private final SocialNetwork source;
+    private final ContentAddressedStorage ipfs;
+
+    public NonWriteThroughSocialNetwork(SocialNetwork source, ContentAddressedStorage ipfs) {
+        this.source = source;
+        this.ipfs = ipfs;
+    }
+
+    private final Map<PublicKeyHash, List<ByteArrayWrapper>> removedFollowRequests = new ConcurrentHashMap<>();
+    private final Map<PublicKeyHash, List<ByteArrayWrapper>> newFollowRequests = new ConcurrentHashMap<>();
+
+    @Override
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
+        newFollowRequests.putIfAbsent(target, new ArrayList<>());
+        ByteArrayWrapper wrappped = new ByteArrayWrapper(encryptedPermission);
+        newFollowRequests.get(target).add(wrappped);
+        removedFollowRequests.putIfAbsent(target, new ArrayList<>());
+        removedFollowRequests.get(target).remove(wrappped);
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner) {
+        try {
+            byte[] reqs = source.getFollowRequests(owner).get();
+            DataSource din = new DataSource(reqs);
+            List<byte[]> notDeleted = new ArrayList<>();
+            List<ByteArrayWrapper> removed = removedFollowRequests.get(owner);
+            int n = din.readInt();
+            for (int i = 0; i < n; i++) {
+                byte[] req = din.readArray();
+                ByteArrayWrapper wrapped = new ByteArrayWrapper(req);
+                if (! removed.contains(wrapped))
+                    notDeleted.add(req);
+            }
+            notDeleted.addAll(newFollowRequests.get(owner).stream()
+                    .map(w -> w.data)
+                    .collect(Collectors.toList()));
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DataOutput dout = new DataOutputStream(bout);
+            dout.writeInt(notDeleted.size());
+            for (byte[] req : notDeleted) {
+                Serialize.serialize(req, dout);
+            }
+            return CompletableFuture.completedFuture(bout.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] signedEncryptedPermission) {
+        try {
+            PublicSigningKey signer = ipfs.getSigningKey(owner).get().get();
+            byte[] unsigned = signer.unsignMessage(signedEncryptedPermission);
+
+            newFollowRequests.putIfAbsent(owner, new ArrayList<>());
+            ByteArrayWrapper wrappped = new ByteArrayWrapper(unsigned);
+            newFollowRequests.get(owner).remove(wrappped);
+            removedFollowRequests.putIfAbsent(owner, new ArrayList<>());
+            removedFollowRequests.get(owner).add(wrappped);
+            return CompletableFuture.completedFuture(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -1,0 +1,93 @@
+package peergos.server.storage;
+
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multiaddr.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.storage.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class NonWriteThroughStorage implements ContentAddressedStorage {
+    private final ContentAddressedStorage source;
+    private final ContentAddressedStorage modifications;
+
+    public NonWriteThroughStorage(ContentAddressedStorage source, ContentAddressedStorage modifications) {
+        this.source = source;
+        this.modifications = modifications;
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return modifications.put(writer, signatures, blocks);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks) {
+        return modifications.putRaw(writer, signatures, blocks);
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Multihash object) {
+        try {
+            Optional<byte[]> modified = modifications.getRaw(object).get();
+            if ( modified.isPresent())
+                return CompletableFuture.completedFuture(modified);
+            return source.getRaw(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(Multihash hash) {
+        try {
+            Optional<CborObject> modified = modifications.get(hash).get();
+            if ( modified.isPresent())
+                return CompletableFuture.completedFuture(modified);
+            return source.get(hash);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursivePin(Multihash h) {
+        return modifications.recursivePin(h);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursiveUnpin(Multihash h) {
+        return modifications.recursiveUnpin(h);
+    }
+
+    @Override
+    public CompletableFuture<List<MultiAddress>> pinUpdate(Multihash existing, Multihash updated) {
+        return modifications.pinUpdate(existing, updated);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> getLinks(Multihash root) {
+        try {
+            Optional<CborObject> modified = modifications.get(root).get();
+            if (modified.isPresent())
+                return CompletableFuture.completedFuture(modified.get().links());
+            return source.getLinks(root);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
+        try {
+            Optional<CborObject> modified = modifications.get(block).get();
+            if (modified.isPresent())
+                return CompletableFuture.completedFuture(modified.map(cbor -> cbor.toByteArray().length));
+            return source.getSize(block);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -13,9 +13,9 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     private final ContentAddressedStorage source;
     private final ContentAddressedStorage modifications;
 
-    public NonWriteThroughStorage(ContentAddressedStorage source, ContentAddressedStorage modifications) {
+    public NonWriteThroughStorage(ContentAddressedStorage source) {
         this.source = source;
-        this.modifications = modifications;
+        this.modifications = new RAMStorage();
     }
 
     @Override

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -45,7 +45,9 @@ public class RAMStorage implements ContentAddressedStorage {
 
     @Override
     public CompletableFuture<Optional<byte[]>> getRaw(Multihash object) {
-        return CompletableFuture.completedFuture(Optional.of(storage.getOrDefault(object, new byte[0])));
+        return CompletableFuture.completedFuture(storage.containsKey(object) ?
+                Optional.of(storage.get(object)) :
+                Optional.empty());
     }
 
     @Override

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -35,11 +35,17 @@ public class MultiUserTests {
         int portRange = 2000;
         int webPort = portMin + r.nextInt(portRange);
         int corePort = portMin + portRange + r.nextInt(portRange);
+        int socialPort = portMin + portRange + r.nextInt(portRange);
         this.userCount = userCount;
         if (userCount  < 2)
             throw new IllegalStateException();
 
-        Args args = Args.parse(new String[]{"useIPFS", ""+useIPFS.equals("IPFS"), "-port", Integer.toString(webPort), "-corenodePort", Integer.toString(corePort)});
+        Args args = Args.parse(new String[]{
+                "useIPFS", ""+useIPFS.equals("IPFS"),
+                "-port", Integer.toString(webPort),
+                "-corenodePort", Integer.toString(corePort),
+                "-socialnodePort", Integer.toString(socialPort)
+        });
         Start.LOCAL.main(args);
         this.network = NetworkAccess.buildJava(new URL("http://localhost:" + webPort)).get();
         this.crypto = crypto;

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -40,7 +40,13 @@ public abstract class UserTests {
         int portRange = 4000;
         int webPort = portMin + r.nextInt(portRange);
         int corePort = portMin + portRange + r.nextInt(portRange);
-        Args args = Args.parse(new String[]{"useIPFS", ""+useIPFS.equals("IPFS"), "-port", Integer.toString(webPort), "-corenodePort", Integer.toString(corePort)});
+        int socialPort = portMin + portRange + r.nextInt(portRange);
+        Args args = Args.parse(new String[]{
+                "useIPFS", ""+useIPFS.equals("IPFS"),
+                "-port", Integer.toString(webPort),
+                "-corenodePort", Integer.toString(corePort),
+                "-socialnodePort", Integer.toString(socialPort)
+        });
         Start.LOCAL.main(args);
         this.network = NetworkAccess.buildJava(new URL("http://localhost:" + webPort)).get();
         // use insecure random otherwise tests take ages

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -37,7 +37,7 @@ public abstract class UserTests {
 
     public UserTests(String useIPFS, Random r) throws Exception {
         int portMin = 9000;
-        int portRange = 4000;
+        int portRange = 8000;
         int webPort = portMin + r.nextInt(portRange);
         int corePort = portMin + portRange + r.nextInt(portRange);
         int socialPort = portMin + portRange + r.nextInt(portRange);

--- a/src/peergos/server/tests/slow/MkdirSpeed.java
+++ b/src/peergos/server/tests/slow/MkdirSpeed.java
@@ -39,7 +39,7 @@ public class MkdirSpeed {
         ContentAddressedStorage dht = RAMStorage.getSingleton();
         UserRepository core = UserRepository.buildSqlLite(":memory:", dht, CoreNode.MAX_USERNAME_COUNT);
         MutableTree btree = new MutableTreeImpl(core, dht);
-        return new NetworkAccess(core, dht, core, btree, Collections.emptyList());
+        return new NetworkAccess(core, core, dht, core, btree, Collections.emptyList());
     }
 
     private static NetworkAccess buildHttpNetworkAccess(boolean useIpfs, Random r) throws Exception {

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -1,22 +1,16 @@
 package peergos.shared.corenode;
 
 import peergos.shared.crypto.hash.*;
+import peergos.shared.social.*;
 
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-public interface CoreNode {
+public interface CoreNode extends SocialNetwork {
     int MAX_PENDING_FOLLOWERS = 100;
     int MAX_USERNAME_SIZE = 100;
     int MAX_USERNAME_COUNT = 1024;
-
-    /**
-     *
-     * @param key
-     * @return the username claimed by a given public key
-     */
-    CompletableFuture<String> getUsername(PublicKeyHash key);
 
     /**
      *
@@ -35,6 +29,20 @@ public interface CoreNode {
 
     /**
      *
+     * @param key
+     * @return the username claimed by a given public key
+     */
+    CompletableFuture<String> getUsername(PublicKeyHash key);
+
+    /**
+     *
+     * @param prefix
+     * @return All usernames starting with prefix
+     */
+    CompletableFuture<List<String>> getUsernames(String prefix);
+
+    /**
+     *
      * @param username
      * @return the public key for a username, if present
      */
@@ -46,36 +54,6 @@ public interface CoreNode {
                 return Optional.of(chain.get(chain.size() - 1).owner);
         });
     }
-
-    /**
-     *
-     * @param prefix
-     * @return All usernames starting with prefix
-     */
-    CompletableFuture<List<String>> getUsernames(String prefix);
-
-    /** Send a follow request to the target public key
-     *
-     * @param target
-     * @param encryptedPermission
-     * @return
-     */
-    CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission);
-
-    /**
-     *
-     * @param owner
-     * @return all the pending follow requests for the given public key
-     */
-    CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner);
-
-    /** Delete a follow request for a given public key
-     *
-     * @param owner
-     * @param data
-     * @return
-     */
-    CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] data);
 
     void close() throws IOException;
 }

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -7,8 +7,7 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-public interface CoreNode extends SocialNetwork {
-    int MAX_PENDING_FOLLOWERS = 100;
+public interface CoreNode {
     int MAX_USERNAME_SIZE = 100;
     int MAX_USERNAME_COUNT = 1024;
 

--- a/src/peergos/shared/corenode/HTTPCoreNode.java
+++ b/src/peergos/shared/corenode/HTTPCoreNode.java
@@ -17,7 +17,6 @@ import java.util.concurrent.*;
 
 public class HTTPCoreNode implements CoreNode
 {
-    private static final boolean LOGGING = true;
     private final HttpPoster poster;
 
     public static CoreNode getInstance(URL coreURL) throws IOException {
@@ -30,7 +29,8 @@ public class HTTPCoreNode implements CoreNode
         this.poster = poster;
     }
 
-    @Override public CompletableFuture<Optional<PublicKeyHash>> getPublicKeyHash(String username)
+    @Override
+    public CompletableFuture<Optional<PublicKeyHash>> getPublicKeyHash(String username)
     {
         try {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -85,7 +85,8 @@ public class HTTPCoreNode implements CoreNode
         }
     }
 
-    @Override public CompletableFuture<List<UserPublicKeyLink>> getChain(String username) {
+    @Override
+    public CompletableFuture<List<UserPublicKeyLink>> getChain(String username) {
         try
         {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -113,7 +114,8 @@ public class HTTPCoreNode implements CoreNode
         }
     }
 
-    @Override public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
+    @Override
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
         try
         {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -140,87 +142,10 @@ public class HTTPCoreNode implements CoreNode
         }
     }
 
-    @Override
-    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission)
-    {
-        try
-        {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            DataOutputStream dout = new DataOutputStream(bout);
-
-            Serialize.serialize(target.serialize(), dout);
-            Serialize.serialize(encryptedPermission, dout);
-            dout.flush();
-
-            return poster.postUnzip("core/followRequest", bout.toByteArray()).thenApply(res -> {
-                DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
-                try {
-                    return din.readBoolean();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } catch (IOException ioe) {
-            ioe.printStackTrace();
-            return CompletableFuture.completedFuture(false);
-        }
-    }
-
     @Override public CompletableFuture<List<String>> getUsernames(String prefix)
     {
         return poster.postUnzip("core/getUsernamesGzip/"+prefix, new byte[0])
                 .thenApply(raw -> (List) JSONParser.parse(new String(raw)));
-    }
-
-    @Override public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner)
-    {
-        try
-        {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            DataOutputStream dout = new DataOutputStream(bout);
-
-
-            Serialize.serialize(owner.serialize(), dout);
-            dout.flush();
-
-            return poster.postUnzip("core/getFollowRequests", bout.toByteArray()).thenApply(res -> {
-                DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
-                try {
-                    return CoreNodeUtils.deserializeByteArray(din);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } catch (IOException ioe) {
-            ioe.printStackTrace();
-            return null;
-        }
-    }
-    
-    @Override
-    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] signedRequest)
-    {
-        try
-        {
-            ByteArrayOutputStream bout = new ByteArrayOutputStream();
-            DataOutputStream dout = new DataOutputStream(bout);
-
-            Serialize.serialize(owner.serialize(), dout);
-            Serialize.serialize(signedRequest, dout);
-            dout.flush();
-
-            return poster.postUnzip("core/removeFollowRequest", bout.toByteArray()).thenApply(res -> {
-                DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
-                try {
-                    return din.readBoolean();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        } catch (IOException ioe) {
-            ioe.printStackTrace();
-            return CompletableFuture.completedFuture(false);
-        }
     }
 
     @Override public void close() {}

--- a/src/peergos/shared/corenode/HTTPCoreNode.java
+++ b/src/peergos/shared/corenode/HTTPCoreNode.java
@@ -141,7 +141,7 @@ public class HTTPCoreNode implements CoreNode
     }
 
     @Override
-    public CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission)
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission)
     {
         try
         {

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -110,20 +110,5 @@ public class TofuCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
-        return source.sendFollowRequest(target, encryptedPermission);
-    }
-
-    @Override
-    public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner) {
-        return source.getFollowRequests(owner);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] data) {
-        return source.removeFollowRequest(owner, data);
-    }
-
-    @Override
     public void close() throws IOException {}
 }

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -110,8 +110,8 @@ public class TofuCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> addFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
-        return source.addFollowRequest(target, encryptedPermission);
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission) {
+        return source.sendFollowRequest(target, encryptedPermission);
     }
 
     @Override

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -1,7 +1,9 @@
 package peergos.shared.mutable;
 
 import peergos.shared.cbor.CborObject;
+import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.merklebtree.HashCasPair;
 import peergos.shared.merklebtree.MaybeMultihash;
 import peergos.shared.storage.ContentAddressedStorage;
@@ -46,4 +48,16 @@ public interface MutablePointers {
                 );
     }
 
+    static boolean isValidUpdate(PublicSigningKey writerKey, Optional<byte[]> current, byte[] writerSignedBtreeRootHash) {
+        byte[] bothHashes = writerKey.unsignMessage(writerSignedBtreeRootHash);
+        // check CAS [current hash, new hash]
+        HashCasPair cas = HashCasPair.fromCbor(CborObject.fromByteArray(bothHashes));
+        MaybeMultihash claimedCurrentHash = cas.original;
+        Multihash newHash = cas.updated.get();
+
+        MaybeMultihash existing = current
+                .map(signed -> HashCasPair.fromCbor(CborObject.fromByteArray(writerKey.unsignMessage(signed))).updated)
+                .orElse(MaybeMultihash.empty());
+        return existing.equals(claimedCurrentHash);
+    }
 }

--- a/src/peergos/shared/social/HttpSocialNetwork.java
+++ b/src/peergos/shared/social/HttpSocialNetwork.java
@@ -1,0 +1,103 @@
+package peergos.shared.social;
+
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.user.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.concurrent.*;
+
+public class HttpSocialNetwork implements SocialNetwork {
+
+    private final HttpPoster poster;
+
+    public static SocialNetwork getInstance(URL coreURL) throws IOException {
+        return new HttpSocialNetwork(new JavaPoster(coreURL));
+    }
+
+    public HttpSocialNetwork(HttpPoster poster)
+    {
+        System.out.println("Creating HTTP SocialNetwork API at " + poster);
+        this.poster = poster;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission)
+    {
+        try
+        {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DataOutputStream dout = new DataOutputStream(bout);
+
+            Serialize.serialize(target.serialize(), dout);
+            Serialize.serialize(encryptedPermission, dout);
+            dout.flush();
+
+            return poster.postUnzip("social/followRequest", bout.toByteArray()).thenApply(res -> {
+                DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
+                try {
+                    return din.readBoolean();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+            return CompletableFuture.completedFuture(false);
+        }
+    }
+
+    @Override
+    public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner)
+    {
+        try
+        {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DataOutputStream dout = new DataOutputStream(bout);
+
+
+            Serialize.serialize(owner.serialize(), dout);
+            dout.flush();
+
+            return poster.postUnzip("social/getFollowRequests", bout.toByteArray()).thenApply(res -> {
+                DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
+                try {
+                    return CoreNodeUtils.deserializeByteArray(din);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] signedRequest)
+    {
+        try
+        {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            DataOutputStream dout = new DataOutputStream(bout);
+
+            Serialize.serialize(owner.serialize(), dout);
+            Serialize.serialize(signedRequest, dout);
+            dout.flush();
+
+            return poster.postUnzip("social/removeFollowRequest", bout.toByteArray()).thenApply(res -> {
+                DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
+                try {
+                    return din.readBoolean();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+            return CompletableFuture.completedFuture(false);
+        }
+    }
+}

--- a/src/peergos/shared/social/SocialNetwork.java
+++ b/src/peergos/shared/social/SocialNetwork.java
@@ -6,6 +6,8 @@ import java.util.concurrent.*;
 
 public interface SocialNetwork {
 
+    int MAX_PENDING_FOLLOWERS = 100;
+
     /** Send a follow request to the target public key
      *
      * @param target

--- a/src/peergos/shared/social/SocialNetwork.java
+++ b/src/peergos/shared/social/SocialNetwork.java
@@ -1,0 +1,31 @@
+package peergos.shared.social;
+
+import peergos.shared.crypto.hash.*;
+
+import java.util.concurrent.*;
+
+public interface SocialNetwork {
+
+    /** Send a follow request to the target public key
+     *
+     * @param target
+     * @param encryptedPermission
+     * @return
+     */
+    CompletableFuture<Boolean> sendFollowRequest(PublicKeyHash target, byte[] encryptedPermission);
+
+    /**
+     *
+     * @param owner
+     * @return all the pending follow requests for the given public key
+     */
+    CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner);
+
+    /** Delete a follow request for a given public key
+     *
+     * @param owner
+     * @param data
+     * @return
+     */
+    CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] data);
+}

--- a/src/peergos/shared/user/JavaPoster.java
+++ b/src/peergos/shared/user/JavaPoster.java
@@ -54,7 +54,7 @@ public class JavaPoster implements HttpPoster {
             if (conn != null){
                 String trailer = conn.getHeaderField("Trailer");
                 System.err.println("Trailer:" + trailer);
-                res.completeExceptionally(new RuntimeException(trailer));
+                res.completeExceptionally(trailer == null ? e : new RuntimeException(trailer));
             } else
                 res.completeExceptionally(e);
         } finally {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -585,9 +585,9 @@ public class UserContext {
                 DataSink resp = new DataSink();
                 resp.writeArray(tmp.publicBoxingKey.serialize());
                 resp.writeArray(payload);
-                network.coreNode.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
+                network.social.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
                 // remove pending follow request from them
-                return network.coreNode.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(initialRequest.rawCipher));
+                return network.social.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(initialRequest.rawCipher));
             });
         }
 
@@ -631,7 +631,7 @@ public class UserContext {
                 DataSink resp = new DataSink();
                 resp.writeArray(tmp.publicBoxingKey.serialize());
                 resp.writeArray(payload);
-                return network.coreNode.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
+                return network.social.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
             });
         }).thenCompose(b -> {
             if (reciprocate)
@@ -640,7 +640,7 @@ public class UserContext {
         }).thenCompose(trie -> {
             // remove original request
             entrie = trie;
-            return network.coreNode.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(initialRequest.rawCipher));
+            return network.social.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(initialRequest.rawCipher));
         });
     }
 
@@ -681,7 +681,7 @@ public class UserContext {
                             res.writeArray(tmp.publicBoxingKey.serialize());
                             res.writeArray(payload);
                             PublicKeyHash targetSigner = targetUserOpt.get().left;
-                            return network.coreNode.sendFollowRequest(targetSigner, res.toByteArray());
+                            return network.social.sendFollowRequest(targetSigner, res.toByteArray());
                         });
                     });
                 });
@@ -864,7 +864,7 @@ public class UserContext {
      * @return initial follow requests
      */
     public CompletableFuture<List<FollowRequest>> processFollowRequests() {
-        return network.coreNode.getFollowRequests(signer.publicKeyHash).thenCompose(reqs -> {
+        return network.social.getFollowRequests(signer.publicKeyHash).thenCompose(reqs -> {
             DataSource din = new DataSource(reqs);
             List<FollowRequest> all;
             try {
@@ -902,7 +902,7 @@ public class UserContext {
                             return updatedRoot.thenCompose(newRoot -> {
                                 entrie = newRoot;
                                 // clear their response follow req too
-                                return network.coreNode.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(freq.rawCipher))
+                                return network.social.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(freq.rawCipher))
                                         .thenApply(b -> newRoot);
                             });
                         }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -585,7 +585,7 @@ public class UserContext {
                 DataSink resp = new DataSink();
                 resp.writeArray(tmp.publicBoxingKey.serialize());
                 resp.writeArray(payload);
-                network.coreNode.addFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
+                network.coreNode.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
                 // remove pending follow request from them
                 return network.coreNode.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(initialRequest.rawCipher));
             });
@@ -631,7 +631,7 @@ public class UserContext {
                 DataSink resp = new DataSink();
                 resp.writeArray(tmp.publicBoxingKey.serialize());
                 resp.writeArray(payload);
-                return network.coreNode.addFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
+                return network.coreNode.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
             });
         }).thenCompose(b -> {
             if (reciprocate)
@@ -681,7 +681,7 @@ public class UserContext {
                             res.writeArray(tmp.publicBoxingKey.serialize());
                             res.writeArray(payload);
                             PublicKeyHash targetSigner = targetUserOpt.get().left;
-                            return network.coreNode.addFollowRequest(targetSigner, res.toByteArray());
+                            return network.coreNode.sendFollowRequest(targetSigner, res.toByteArray());
                         });
                     });
                 });
@@ -705,7 +705,7 @@ public class UserContext {
                 // create a tmp keypair whose public key we can append to the request without leaking information
                 User tmp = User.random(random, signer, boxer);
                 byte[] payload = entry.serializeAndEncrypt(tmp, targetUser);
-                return corenodeClient.addFollowRequest(targetUser, ArrayOps.concat(tmp.publicBoxingKey.toByteArray(), payload));
+                return corenodeClient.sendFollowRequest(targetUser, ArrayOps.concat(tmp.publicBoxingKey.toByteArray(), payload));
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
Ignore the branch name, this is a precursor to moving the corenode PKI stuff into IPFS. 
Also, this PR builds on https://github.com/Peergos/Peergos/pull/318 so review that first. 

This PR removes the follow request calls from CoreNode into SocialNetwork, and changes the http path of the social calls. 