### PR TITLE
Regularise writer data

### DIFF
--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -168,6 +168,7 @@ public class IpfsCoreNode implements CoreNode {
                                 PublicKeyHash owner = updatedChain.get(updatedChain.size() - 1).owner;
                                 reverseLookup.put(owner, username);
                                 chains.put(username, mergedChain);
+                                currentRoot = committed.hash;
                                 return true;
                             });
                 }

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -255,7 +255,8 @@ public class WriterData implements Cborable {
         publicData.ifPresent(rfp -> result.put("public", rfp.toCbor()));
         followRequestReceiver.ifPresent(boxer -> result.put("inbound", new CborObject.CborMerkleLink(boxer)));
         List<CborObject> ownedKeyStrings = ownedKeys.stream().map(CborObject.CborMerkleLink::new).collect(Collectors.toList());
-        result.put("owned", new CborObject.CborList(ownedKeyStrings));
+        if (! ownedKeyStrings.isEmpty())
+            result.put("owned", new CborObject.CborList(ownedKeyStrings));
         if (! namedOwnedKeys.isEmpty())
             result.put("named", new CborObject.CborMap(new TreeMap<>(namedOwnedKeys.entrySet()
                     .stream()
@@ -290,7 +291,9 @@ public class WriterData implements Cborable {
         Optional<FilePointer> publicData = extract.apply("public").map(FilePointer::fromCbor);
         Optional<PublicKeyHash> followRequestReceiver = extract.apply("inbound").map(PublicKeyHash::fromCbor);
         CborObject.CborList ownedList = (CborObject.CborList) map.values.get(new CborObject.CborString("owned"));
-        Set<PublicKeyHash> owned = ownedList.value.stream().map(PublicKeyHash::fromCbor).collect(Collectors.toSet());
+        Set<PublicKeyHash> owned = ownedList == null ?
+                Collections.emptySet() :
+                ownedList.value.stream().map(PublicKeyHash::fromCbor).collect(Collectors.toSet());
 
         CborObject.CborMap namedMap = (CborObject.CborMap) map.values.get(new CborObject.CborString("named"));
         Map<String, PublicKeyHash> named = namedMap == null ?


### PR DESCRIPTION
This removes the special case where the pki data was not wrapped in a WriterData. I think this was a premature optimisation, especially with the optimisaton of the WriterData cbor here.