### PR TITLE
Give all users a list of storage nodes in their PKI data.

### DIFF
--- a/src/peergos/server/tests/JDBCCoreNodeTests.java
+++ b/src/peergos/server/tests/JDBCCoreNodeTests.java
@@ -44,9 +44,9 @@ public class JDBCCoreNodeTests {
 
     Function<String, Boolean> signup  = username -> {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
-        UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(
-            username, user.secretSigningKey, LocalDate.now().plusYears(2));
         try {
+            UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.create(
+                    username, user.secretSigningKey, LocalDate.now().plusYears(2), Arrays.asList(STORAGE.id().get()));
             PublicKeyHash owner = STORAGE.putSigningKey(
                     user.secretSigningKey.signatureOnly(user.publicSigningKey.serialize()),
                     ContentAddressedStorage.hashKey(user.publicSigningKey),

--- a/src/peergos/server/tests/JDBCCoreNodeTests.java
+++ b/src/peergos/server/tests/JDBCCoreNodeTests.java
@@ -45,7 +45,7 @@ public class JDBCCoreNodeTests {
     Function<String, Boolean> signup  = username -> {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
         try {
-            UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.create(
+            UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.build(
                     username, user.secretSigningKey, LocalDate.now().plusYears(2), Arrays.asList(STORAGE.id().get()));
             PublicKeyHash owner = STORAGE.putSigningKey(
                     user.secretSigningKey.signatureOnly(user.publicSigningKey.serialize()),

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -30,7 +30,7 @@ public class UserPublicKeyLinkTests {
     }
 
     @BeforeClass
-    public static void init() throws Exception {
+    public static void init() {
         PublicSigningKey.addProvider(PublicSigningKey.Type.Ed25519, new Ed25519.Java());
     }
 
@@ -44,7 +44,7 @@ public class UserPublicKeyLinkTests {
     @Test
     public void createInitial() throws Exception {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
-        UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2));
+        UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2), id);
 
         PublicKeyHash owner = putPublicSigningKey(user);
         UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
@@ -69,7 +69,7 @@ public class UserPublicKeyLinkTests {
         SigningPrivateKeyAndPublicHash oldSigner = new SigningPrivateKeyAndPublicHash(oldHash, oldUser.secretSigningKey);
         SigningPrivateKeyAndPublicHash newSigner = new SigningPrivateKeyAndPublicHash(newHash, newUser.secretSigningKey);
 
-        List<UserPublicKeyLink> links = UserPublicKeyLink.createChain(oldSigner, newSigner, "someuser", LocalDate.now().plusYears(2));
+        List<UserPublicKeyLink> links = UserPublicKeyLink.createChain(oldSigner, newSigner, "someuser", LocalDate.now().plusYears(2), id);
         links.forEach(link -> testSerialization(link));
     }
 
@@ -80,7 +80,7 @@ public class UserPublicKeyLinkTests {
         String username = "someuser";
 
         // register the username
-        UserPublicKeyLink.UsernameClaim node = UserPublicKeyLink.UsernameClaim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2));
+        UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2), id);
         PublicKeyHash userHash = putPublicSigningKey(user);
         UserPublicKeyLink upl = new UserPublicKeyLink(userHash, node);
         boolean success = core.updateChain(username, Arrays.asList(upl)).get();
@@ -89,7 +89,7 @@ public class UserPublicKeyLinkTests {
             throw new IllegalStateException("Retrieved chain element different "+chain +" != "+Arrays.asList(upl));
 
         // now change the expiry
-        UserPublicKeyLink.UsernameClaim node2 = UserPublicKeyLink.UsernameClaim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(3));
+        UserPublicKeyLink.Claim node2 = UserPublicKeyLink.Claim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(3), id);
         UserPublicKeyLink upl2 = new UserPublicKeyLink(userHash, node2);
         boolean success2 = core.updateChain(username, Arrays.asList(upl2)).get();
         List<UserPublicKeyLink> chain2 = core.getChain(username).get();
@@ -101,14 +101,14 @@ public class UserPublicKeyLinkTests {
         PublicKeyHash user2Hash = putPublicSigningKey(user2);
         SigningPrivateKeyAndPublicHash oldUser = new SigningPrivateKeyAndPublicHash(userHash, user.secretSigningKey);
         SigningPrivateKeyAndPublicHash newUser = new SigningPrivateKeyAndPublicHash(user2Hash, user2.secretSigningKey);
-        List<UserPublicKeyLink> chain3 = UserPublicKeyLink.createChain(oldUser, newUser, username, LocalDate.now().plusWeeks(1));
+        List<UserPublicKeyLink> chain3 = UserPublicKeyLink.createChain(oldUser, newUser, username, LocalDate.now().plusWeeks(1), id);
         boolean success3 = core.updateChain(username, chain3).get();
         List<UserPublicKeyLink> chain3Retrieved = core.getChain(username).get();
         if (!chain3.equals(chain3Retrieved))
             throw new IllegalStateException("Retrieved chain element different");
 
         // update the expiry at the end of the chain
-        UserPublicKeyLink.UsernameClaim node4 = UserPublicKeyLink.UsernameClaim.create(username, user2.secretSigningKey, LocalDate.now().plusWeeks(2));
+        UserPublicKeyLink.Claim node4 = UserPublicKeyLink.Claim.create(username, user2.secretSigningKey, LocalDate.now().plusWeeks(2), id);
         UserPublicKeyLink upl4 = new UserPublicKeyLink(user2Hash, node4);
         List<UserPublicKeyLink> chain4 = Arrays.asList(upl4);
         boolean success4 = core.updateChain(username, chain4).get();
@@ -124,7 +124,7 @@ public class UserPublicKeyLinkTests {
         // try to claim the same username with a different key
         SigningKeyPair user3 = SigningKeyPair.insecureRandom();
         PublicKeyHash user3Hash = putPublicSigningKey(user3);
-        UserPublicKeyLink.UsernameClaim node3 = UserPublicKeyLink.UsernameClaim.create(username, user3.secretSigningKey, LocalDate.now().plusMonths(2));
+        UserPublicKeyLink.Claim node3 = UserPublicKeyLink.Claim.create(username, user3.secretSigningKey, LocalDate.now().plusMonths(2), id);
         UserPublicKeyLink upl3 = new UserPublicKeyLink(user3Hash, node3);
         try {
             boolean shouldFail = core.updateChain(username, Arrays.asList(upl3)).get();

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -44,7 +44,7 @@ public class UserPublicKeyLinkTests {
     @Test
     public void createInitial() throws Exception {
         SigningKeyPair user = SigningKeyPair.random(new SafeRandom.Java(), new Ed25519.Java());
-        UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.create("someuser", user.secretSigningKey, LocalDate.now().plusYears(2), id);
+        UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.build("someuser", user.secretSigningKey, LocalDate.now().plusYears(2), id);
 
         PublicKeyHash owner = putPublicSigningKey(user);
         UserPublicKeyLink upl = new UserPublicKeyLink(owner, node);
@@ -80,7 +80,7 @@ public class UserPublicKeyLinkTests {
         String username = "someuser";
 
         // register the username
-        UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(2), id);
+        UserPublicKeyLink.Claim node = UserPublicKeyLink.Claim.build(username, user.secretSigningKey, LocalDate.now().plusMonths(2), id);
         PublicKeyHash userHash = putPublicSigningKey(user);
         UserPublicKeyLink upl = new UserPublicKeyLink(userHash, node);
         boolean success = core.updateChain(username, Arrays.asList(upl)).get();
@@ -89,7 +89,7 @@ public class UserPublicKeyLinkTests {
             throw new IllegalStateException("Retrieved chain element different "+chain +" != "+Arrays.asList(upl));
 
         // now change the expiry
-        UserPublicKeyLink.Claim node2 = UserPublicKeyLink.Claim.create(username, user.secretSigningKey, LocalDate.now().plusMonths(3), id);
+        UserPublicKeyLink.Claim node2 = UserPublicKeyLink.Claim.build(username, user.secretSigningKey, LocalDate.now().plusMonths(3), id);
         UserPublicKeyLink upl2 = new UserPublicKeyLink(userHash, node2);
         boolean success2 = core.updateChain(username, Arrays.asList(upl2)).get();
         List<UserPublicKeyLink> chain2 = core.getChain(username).get();
@@ -108,7 +108,7 @@ public class UserPublicKeyLinkTests {
             throw new IllegalStateException("Retrieved chain element different");
 
         // update the expiry at the end of the chain
-        UserPublicKeyLink.Claim node4 = UserPublicKeyLink.Claim.create(username, user2.secretSigningKey, LocalDate.now().plusWeeks(2), id);
+        UserPublicKeyLink.Claim node4 = UserPublicKeyLink.Claim.build(username, user2.secretSigningKey, LocalDate.now().plusWeeks(2), id);
         UserPublicKeyLink upl4 = new UserPublicKeyLink(user2Hash, node4);
         List<UserPublicKeyLink> chain4 = Arrays.asList(upl4);
         boolean success4 = core.updateChain(username, chain4).get();
@@ -124,7 +124,7 @@ public class UserPublicKeyLinkTests {
         // try to claim the same username with a different key
         SigningKeyPair user3 = SigningKeyPair.insecureRandom();
         PublicKeyHash user3Hash = putPublicSigningKey(user3);
-        UserPublicKeyLink.Claim node3 = UserPublicKeyLink.Claim.create(username, user3.secretSigningKey, LocalDate.now().plusMonths(2), id);
+        UserPublicKeyLink.Claim node3 = UserPublicKeyLink.Claim.build(username, user3.secretSigningKey, LocalDate.now().plusMonths(2), id);
         UserPublicKeyLink upl3 = new UserPublicKeyLink(user3Hash, node3);
         try {
             boolean shouldFail = core.updateChain(username, Arrays.asList(upl3)).get();

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -87,14 +87,14 @@ public class UserPublicKeyLink implements Cborable{
                                                       LocalDate expiry,
                                                       List<Multihash> storageProviders) {
         // sign new claim to username, with provided expiry
-        Claim newClaim = Claim.create(username, newUser.secret, expiry, storageProviders);
+        Claim newClaim = Claim.build(username, newUser.secret, expiry, storageProviders);
 
         // sign new key with old
         byte[] link = oldUser.secret.signMessage(newUser.publicKeyHash.serialize());
 
         // create link from old that never expires
         UserPublicKeyLink fromOld = new UserPublicKeyLink(oldUser.publicKeyHash,
-                Claim.create(username, oldUser.secret, LocalDate.MAX, Collections.emptyList()),
+                Claim.build(username, oldUser.secret, LocalDate.MAX, Collections.emptyList()),
                 Optional.of(link));
 
         return Arrays.asList(fromOld, new UserPublicKeyLink(newUser.publicKeyHash, newClaim));
@@ -103,6 +103,7 @@ public class UserPublicKeyLink implements Cborable{
     public static class Claim implements Cborable {
         public final String username;
         public final LocalDate expiry;
+        // a list of storage-node ids
         public final List<Multihash> storageProviders;
         private final byte[] signedContents;
 
@@ -138,7 +139,7 @@ public class UserPublicKeyLink implements Cborable{
             return new Claim(username, expiry, storageProviders, signedContents);
         }
 
-        public static Claim create(String username, SecretSigningKey from, LocalDate expiryDate, List<Multihash> storageProviders) {
+        public static Claim build(String username, SecretSigningKey from, LocalDate expiryDate, List<Multihash> storageProviders) {
             try {
                 ByteArrayOutputStream bout = new ByteArrayOutputStream();
                 DataOutputStream dout = new DataOutputStream(bout);
@@ -198,7 +199,7 @@ public class UserPublicKeyLink implements Cborable{
                                                         String username,
                                                         LocalDate expiry,
                                                         List<Multihash> storageProviders) {
-        Claim newClaim = Claim.create(username, signer.secret, expiry, storageProviders);
+        Claim newClaim = Claim.build(username, signer.secret, expiry, storageProviders);
 
         return Collections.singletonList(new UserPublicKeyLink(signer.publicKeyHash, newClaim));
     }

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -119,7 +119,7 @@ public class UserPublicKeyLink implements Cborable{
                     new CborObject.CborString(username),
                     new CborObject.CborString(expiry.toString()),
                     new CborObject.CborList(storageProviders.stream()
-                            .map(CborObject.CborMerkleLink::new)
+                            .map(id -> new CborObject.CborByteArray(id.toBytes()))
                             .collect(Collectors.toList())),
                     new CborObject.CborByteArray(signedContents)));
         }
@@ -132,7 +132,7 @@ public class UserPublicKeyLink implements Cborable{
             LocalDate expiry = LocalDate.parse(((CborObject.CborString) contents.get(1)).value);
             List<Multihash> storageProviders = ((CborObject.CborList)contents.get(2))
                     .value.stream()
-                    .map(x -> ((CborObject.CborMerkleLink)x).target)
+                    .map(x -> Multihash.decode(((CborObject.CborByteArray)x).value))
                     .collect(Collectors.toList());
             byte[] signedContents = ((CborObject.CborByteArray) contents.get(3)).value;
             return new Claim(username, expiry, storageProviders, signedContents);

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -161,7 +161,7 @@ public class UserPublicKeyLink implements Cborable{
             ByteArrayInputStream bin = new ByteArrayInputStream(contents);
             DataInputStream din = new DataInputStream(bin);
             String username = Serialize.deserializeString(din, MAX_USERNAME_SIZE);
-            LocalDate expiry = LocalDate.parse(Serialize.deserializeString(din, 10));
+            LocalDate expiry = LocalDate.parse(Serialize.deserializeString(din, 16));
             int nStorageProviders = din.readInt();
             List<Multihash> storageProviders = new ArrayList<>();
             for (int i=0; i < nStorageProviders; i++) {

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -161,7 +161,7 @@ public class UserPublicKeyLink implements Cborable{
             ByteArrayInputStream bin = new ByteArrayInputStream(contents);
             DataInputStream din = new DataInputStream(bin);
             String username = Serialize.deserializeString(din, MAX_USERNAME_SIZE);
-            LocalDate expiry = LocalDate.parse(Serialize.deserializeString(din, 8));
+            LocalDate expiry = LocalDate.parse(Serialize.deserializeString(din, 10));
             int nStorageProviders = din.readInt();
             List<Multihash> storageProviders = new ArrayList<>();
             for (int i=0; i < nStorageProviders; i++) {
@@ -282,9 +282,8 @@ public class UserPublicKeyLink implements Cborable{
         return ipfs.getSigningKey(from.owner).thenApply(ownerKeyOpt -> {
             if (!ownerKeyOpt.isPresent())
                 return false;
-            byte[] unsignedClaim = ownerKeyOpt.get().unsignMessage(from.claim.signedContents);
             try {
-                return from.claim.equals(Claim.deserialize(unsignedClaim, ownerKeyOpt.get()));
+                return from.claim.equals(Claim.deserialize(from.claim.signedContents, ownerKeyOpt.get()));
             } catch (Exception e) {
                 e.printStackTrace();
                 return false;

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -106,10 +106,10 @@ public class UserPublicKeyLink implements Cborable{
         public final List<Multihash> storageProviders;
         private final byte[] signedContents;
 
-        public Claim(String username, LocalDate expiry, List<Multihash> storagePRoviders, byte[] signedContents) {
+        public Claim(String username, LocalDate expiry, List<Multihash> storageProviders, byte[] signedContents) {
             this.username = username;
             this.expiry = expiry;
-            this.storageProviders = storagePRoviders;
+            this.storageProviders = storageProviders;
             this.signedContents = signedContents;
         }
 


### PR DESCRIPTION
This is signed along with the username claim,
and allows users to bootstrap from nothing but the pki.

N.B. This is a breaking change.