### PR TITLE
Make all locations relative

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -104,7 +104,7 @@ public class Main {
                     String pkiPassword = args.getArg("pki.keygen.password");
                     SigningKeyPair pkiKeys = UserUtil.generateUser(pkiUsername, pkiPassword, crypto.hasher, crypto.symmetricProvider,
                             crypto.random, crypto.signer, crypto.boxer, SecretGenerationAlgorithm.getDefault()).get().getUser();
-                    Transaction.run(peergosPublicHash,
+                    Transaction.call(peergosPublicHash,
                             tid -> dht.putSigningKey(peergosIdentityKeys.secretSigningKey.signatureOnly(
                                     pkiKeys.publicSigningKey.serialize()),
                                     peergosPublicHash,
@@ -163,7 +163,7 @@ public class Main {
                     if (!existingPkiKey.isPresent() || existingPkiKey.get().equals(pkiPublicHash)) {
                         context.addNamedOwnedKeyAndCommit("pki", pkiPublicHash).get();
                         // write pki public key to ipfs
-                        Transaction.run(peergosPublicHash,
+                        Transaction.call(peergosPublicHash,
                                 tid -> network.dhtClient.putSigningKey(peergosIdentityKeys.secretSigningKey
                                 .signatureOnly(pkiPublic.serialize()), peergosPublicHash, pkiPublic, tid),
                                 network.dhtClient).get();

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -148,7 +148,7 @@ public class IpfsCoreNode implements CoreNode {
 
                 ChampWrapper champ = currentTree.isPresent() ?
                         ChampWrapper.create(currentTree.get(), identityHash, ipfs).get() :
-                        Transaction.run(peergosIdentity,
+                        Transaction.call(peergosIdentity,
                                 tid -> ChampWrapper.create(signer.publicKeyHash, signer, identityHash, tid, ipfs),
                                 ipfs).get();
                 MaybeMultihash existing = champ.get(username.getBytes()).get();
@@ -168,11 +168,11 @@ public class IpfsCoreNode implements CoreNode {
                 CborObject.CborList mergedChainCbor = new CborObject.CborList(mergedChain.stream()
                         .map(Cborable::toCbor)
                         .collect(Collectors.toList()));
-                Multihash mergedChainHash = Transaction.run(peergosIdentity,
+                Multihash mergedChainHash = Transaction.call(peergosIdentity,
                         tid -> ipfs.put(peergosIdentity, signer, mergedChainCbor.toByteArray(), tid),
                         ipfs).get();
                 synchronized (this) {
-                    return Transaction.run(peergosIdentity,
+                    return Transaction.call(peergosIdentity,
                             tid -> champ.put(signer.publicKeyHash, signer, username.getBytes(), existing, mergedChainHash, tid)
                                     .thenCompose(newPkiRoot -> current.props.withChamp(newPkiRoot)
                                             .commit(peergosIdentity, signer, currentRoot, mutable, ipfs, c -> {}, tid)),

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -104,7 +104,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
         throw new IllegalStateException("Unimplemented");
     }
 
-    private Optional<Capability> mkdir(String name, FileWrapper node)  {
+    private Optional<RelativeCapability> mkdir(String name, FileWrapper node)  {
         boolean isSystemFolder = false;
         try {
             return Optional.of(node.mkdir(name, context.network, isSystemFolder, context.crypto.random).get());

--- a/src/peergos/server/net/MutationHandler.java
+++ b/src/peergos/server/net/MutationHandler.java
@@ -57,8 +57,6 @@ public class MutationHandler implements HttpHandler {
                     throw new IOException("Unknown method "+ method);
             }
 
-            dout.flush();
-            dout.close();
             byte[] b = bout.toByteArray();
             exchange.sendResponseHeaders(200, b.length);
             exchange.getResponseBody().write(b);

--- a/src/peergos/server/net/MutationHandler.java
+++ b/src/peergos/server/net/MutationHandler.java
@@ -12,6 +12,9 @@ import java.io.*;
 import java.util.*;
 import java.util.logging.*;
 
+/** This is the http endpoint for MutablePointer calls
+ *
+ */
 public class MutationHandler implements HttpHandler {
     private static final Logger LOG = Logging.LOG();
 

--- a/src/peergos/server/net/SocialHandler.java
+++ b/src/peergos/server/net/SocialHandler.java
@@ -13,6 +13,11 @@ import java.util.*;
 import java.util.function.*;
 import java.util.logging.*;
 
+/** This is the http endpoint for SocialNetwork
+ *
+ * This receives calls to send, retrieve and remove follow requests.
+ *
+ */
 public class SocialHandler implements HttpHandler {
     private static final Logger LOG = Logging.LOG();
 

--- a/src/peergos/server/tests/CorenodeTests.java
+++ b/src/peergos/server/tests/CorenodeTests.java
@@ -60,13 +60,13 @@ public class CorenodeTests {
                 SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
                 PublicKeyHash ownerHash = ContentAddressedStorage.hashKey(owner.publicSigningKey);
                 PublicKeyHash writerHash = ContentAddressedStorage.hashKey(owner.publicSigningKey);
-                Transaction.run(ownerHash,
+                Transaction.call(ownerHash,
                         tid -> network.dhtClient.putSigningKey(
                             owner.secretSigningKey.signatureOnly(owner.publicSigningKey.serialize()),
                                     ownerHash,
                             owner.publicSigningKey, tid),
                         network.dhtClient).get();
-                Transaction.run(ownerHash,
+                Transaction.call(ownerHash,
                         tid -> network.dhtClient.putSigningKey(
                         owner.secretSigningKey.signatureOnly(writer.publicSigningKey.serialize()),
                         ownerHash, writer.publicSigningKey, tid), network.dhtClient).get();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -239,7 +239,8 @@ public class MultiUserTests {
         String friendsPathToFile = u1.username + "/" + filename;
         Optional<FileWrapper> priorUnsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         Capability priorPointer = priorUnsharedView.get().getPointer().capability;
-        CryptreeNode priorFileAccess = network.getMetadata(priorPointer.getLocation()).get().get();
+        Location priorLocation = priorPointer.getLocation(priorUnsharedView.get().owner(), priorUnsharedView.get().writer());
+        CryptreeNode priorFileAccess = network.getMetadata(priorLocation).get().get();
         SymmetricKey priorMetaKey = priorFileAccess.getMetaKey(priorPointer.baseKey);
 
         // unshare with a single user
@@ -253,7 +254,7 @@ public class MultiUserTests {
         Optional<FileWrapper> unsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         String friendsNewPathToFile = u1.username + "/" + newname;
         Optional<FileWrapper> unsharedView2 = userToUnshareWith.getByPath(friendsNewPathToFile).get();
-        CryptreeNode fileAccess = network.getMetadata(priorPointer.getLocation()).get().get();
+        CryptreeNode fileAccess = network.getMetadata(priorLocation).get().get();
         try {
             // check we are trying to decrypt the correct thing
             PaddedCipherText priorPropsCipherText = PaddedCipherText.fromCbor(((CborObject.CborList) priorFileAccess.toCbor()).value.get(4));

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -238,8 +238,8 @@ public class MultiUserTests {
         UserContext userToUnshareWith = friends.stream().findFirst().get();
         String friendsPathToFile = u1.username + "/" + filename;
         Optional<FileWrapper> priorUnsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
-        Capability priorPointer = priorUnsharedView.get().getPointer().capability;
-        Location priorLocation = priorPointer.getLocation(priorUnsharedView.get().owner(), priorUnsharedView.get().writer());
+        AbsoluteCapability priorPointer = priorUnsharedView.get().getPointer().capability;
+        Location priorLocation = priorPointer.getLocation();
         CryptreeNode priorFileAccess = network.getMetadata(priorLocation).get().get();
         SymmetricKey priorMetaKey = priorFileAccess.getMetaKey(priorPointer.baseKey);
 

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -211,19 +211,21 @@ public class NetworkAccess {
         }
     }
 
-    public CompletableFuture<List<RetrievedCapability>> retrieveAllMetadata(List<Capability> links) {
+    public CompletableFuture<List<RetrievedCapability>> retrieveAllMetadata(List<Triple<PublicKeyHash, PublicKeyHash, Capability>> links) {
         List<CompletableFuture<Optional<RetrievedCapability>>> all = links.stream()
                 .map(link -> {
-                    Location loc = link.location;
-                    return tree.get(loc.owner, loc.writer, loc.getMapKey())
+                    PublicKeyHash owner = link.left;
+                    PublicKeyHash writer = link.right.writer.orElse(link.middle);
+                    byte[] mapKey = link.right.getMapKey();
+                    return tree.get(owner, writer, mapKey)
                             .thenCompose(key -> {
                                 if (key.isPresent())
                                     return dhtClient.get(key.get())
                                             .thenApply(dataOpt ->  dataOpt
                                                     .map(cbor -> new RetrievedCapability(
-                                                            link,
+                                                            link.right,
                                                             CryptreeNode.fromCbor(cbor, key.get()))));
-                                LOG.severe("Couldn't download link at: " + loc);
+                                LOG.severe("Couldn't download link at: " + new Location(owner, writer, mapKey));
                                 Optional<RetrievedCapability> result = Optional.empty();
                                 return CompletableFuture.completedFuture(result);
                             });
@@ -246,14 +248,14 @@ public class NetworkAccess {
 
     public CompletableFuture<Optional<FileWrapper>> retrieveEntryPoint(EntryPoint e) {
         return downloadEntryPoint(e)
-                .thenApply(faOpt ->faOpt.map(fa -> new FileWrapper(new RetrievedCapability(e.pointer, fa), e.owner,
-                        e.pointer.writer)))
+                .thenApply(faOpt ->faOpt.map(fa -> new FileWrapper(new RetrievedCapability(e.pointer, fa), e.ownerName,
+                        e.owner, e.pointer.writer.get(), e.pointer.signer)))
                 .exceptionally(t -> Optional.empty());
     }
 
     private CompletableFuture<Optional<CryptreeNode>> downloadEntryPoint(EntryPoint entry) {
         // download the metadata blob for this entry point
-        return tree.get(entry.pointer.location.owner, entry.pointer.location.writer, entry.pointer.location.getMapKey()).thenCompose(btreeValue -> {
+        return tree.get(entry.owner, entry.pointer.writer.get(), entry.pointer.getMapKey()).thenCompose(btreeValue -> {
             if (btreeValue.isPresent())
                 return dhtClient.get(btreeValue.get())
                         .thenApply(value -> value.map(cbor -> CryptreeNode.fromCbor(cbor,  btreeValue.get())));
@@ -310,15 +312,14 @@ public class NetworkAccess {
     }
 
     public CompletableFuture<Multihash> uploadChunk(CryptreeNode metadata,
-                                                    Location location,
+                                                    PublicKeyHash owner,
+                                                    byte[] mapKey,
                                                     SigningPrivateKeyAndPublicHash writer,
                                                     TransactionId tid) {
-        if (! writer.publicKeyHash.equals(location.writer))
-            throw new IllegalStateException("Non matching location writer and signing writer key!");
         try {
             byte[] metaBlob = metadata.serialize();
-            return dhtClient.put(location.owner, location.writer, writer.secret.signatureOnly(metaBlob), metaBlob, tid)
-                    .thenCompose(blobHash -> tree.put(location.owner, writer, location.getMapKey(), metadata.committedHash(), blobHash, tid)
+            return dhtClient.put(owner, writer.publicKeyHash, writer.secret.signatureOnly(metaBlob), metaBlob, tid)
+                    .thenCompose(blobHash -> tree.put(owner, writer, mapKey, metadata.committedHash(), blobHash, tid)
                             .thenApply(res -> blobHash));
         } catch (Exception e) {
             LOG.severe(e.getMessage());

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -247,7 +247,7 @@ public class NetworkAccess {
     public CompletableFuture<Optional<FileWrapper>> retrieveEntryPoint(EntryPoint e) {
         return downloadEntryPoint(e)
                 .thenApply(faOpt ->faOpt.map(fa -> new FileWrapper(new RetrievedCapability(e.pointer, fa), e.owner,
-                        e.readers, e.writers, e.pointer.writer)))
+                        e.pointer.writer)))
                 .exceptionally(t -> Optional.empty());
     }
 
@@ -286,7 +286,7 @@ public class NetworkAccess {
                                                               ProgressConsumer<Long> progressCounter,
                                                               double spaceIncreaseFactor,
                                                               TransactionId tid) {
-        // upload in groups of 10. This means in a browser we have 6 upload threads with erasure coding on, or 4 without
+        // upload one per query because IPFS doesn't support more than one
         int FRAGMENTs_PER_QUERY = 1;
         List<List<Fragment>> grouped = IntStream.range(0, (fragments.size() + FRAGMENTs_PER_QUERY - 1) / FRAGMENTs_PER_QUERY)
                 .mapToObj(i -> fragments.stream().skip(FRAGMENTs_PER_QUERY * i).limit(FRAGMENTs_PER_QUERY).collect(Collectors.toList()))

--- a/src/peergos/shared/crypto/SymmetricLink.java
+++ b/src/peergos/shared/crypto/SymmetricLink.java
@@ -3,6 +3,11 @@ package peergos.shared.crypto;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.symmetric.SymmetricKey;
 
+/** A symmetric link is a link from one symmetric key to another, as defined in cryptree.
+ *
+ * This means the target key is encrypted with the source key.
+ *
+ */
 public class SymmetricLink implements Cborable
 {
     private final CipherText cipherText;

--- a/src/peergos/shared/storage/Transaction.java
+++ b/src/peergos/shared/storage/Transaction.java
@@ -15,9 +15,9 @@ public class Transaction {
      * @param <V>
      * @return
      */
-    public static <V> CompletableFuture<V> run(PublicKeyHash owner,
-                                               Function<TransactionId, CompletableFuture<V>> processor,
-                                               ContentAddressedStorage ipfs) {
+    public static <V> CompletableFuture<V> call(PublicKeyHash owner,
+                                                Function<TransactionId, CompletableFuture<V>> processor,
+                                                ContentAddressedStorage ipfs) {
         CompletableFuture<V> res = new CompletableFuture<>();
         ipfs.startTransaction(owner).thenCompose(tid -> processor.apply(tid)
                 .thenCompose(v -> ipfs.closeTransaction(owner, tid)

--- a/src/peergos/shared/user/EntryPoint.java
+++ b/src/peergos/shared/user/EntryPoint.java
@@ -92,26 +92,20 @@ public class EntryPoint implements Cborable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         EntryPoint that = (EntryPoint) o;
-
-        if (pointer != null ? !pointer.equals(that.pointer) : that.pointer != null) return false;
-        if (ownerName != null ? !ownerName.equals(that.ownerName) : that.ownerName != null) return false;
-        if (readers != null ? !readers.equals(that.readers) : that.readers != null) return false;
-        return writers != null ? writers.equals(that.writers) : that.writers == null;
-
+        return Objects.equals(pointer, that.pointer) &&
+                Objects.equals(ownerName, that.ownerName) &&
+                Objects.equals(owner, that.owner) &&
+                Objects.equals(readers, that.readers) &&
+                Objects.equals(writers, that.writers);
     }
 
     @Override
     public int hashCode() {
-        int result = pointer != null ? pointer.hashCode() : 0;
-        result = 31 * result + (ownerName != null ? ownerName.hashCode() : 0);
-        result = 31 * result + (readers != null ? readers.hashCode() : 0);
-        result = 31 * result + (writers != null ? writers.hashCode() : 0);
-        return result;
+        return Objects.hash(pointer, ownerName, owner, readers, writers);
     }
 
-    static EntryPoint symmetricallyDecryptAndDeserialize(byte[] input, SymmetricKey key) throws IOException {
+    static EntryPoint symmetricallyDecryptAndDeserialize(byte[] input, SymmetricKey key) {
         byte[] nonce = Arrays.copyOfRange(input, 0, 24);
         byte[] raw = key.decrypt(Arrays.copyOfRange(input, 24, input.length), nonce);
         return fromCbor(CborObject.fromByteArray(raw));

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -52,7 +52,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                                                     e,
                                                     caps.getRetrievedCapabilities().stream()
                                                             .reduce(TrieNodeImpl.empty(),
-                                                                    (root, cap) -> root.put(trimOwner(cap.path), UserContext.convert(e.ownerName, cap)),
+                                                                    (root, cap) -> root.put(trimOwner(cap.path), new EntryPoint(cap.cap, e.ownerName)),
                                                                     (a, b) -> a),
                                                     caps.getRecordsRead(),
                                                     random, fragmenter)));
@@ -75,7 +75,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                                                             capCount += newCaps.getRecordsRead();
                                                             root = newCaps.getRetrievedCapabilities().stream()
                                                                     .reduce(root,
-                                                                            (root, cap) -> root.put(trimOwner(cap.path), UserContext.convert(ownerName, cap)),
+                                                                            (root, cap) -> root.put(trimOwner(cap.path), new EntryPoint(cap.cap, ownerName)),
                                                                             (a, b) -> a);
                                                             return true;
                                                         });

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -12,7 +12,6 @@ import java.util.function.*;
 public class FriendSourcedTrieNode implements TrieNode {
 
     private final String ownerName;
-    private final PublicKeyHash owner;
     private final Supplier<CompletableFuture<FileWrapper>> homeDirSupplier;
     private final EntryPoint sharedDir;
     private final SafeRandom random;
@@ -22,7 +21,6 @@ public class FriendSourcedTrieNode implements TrieNode {
 
     public FriendSourcedTrieNode(Supplier<CompletableFuture<FileWrapper>> homeDirSupplier,
                                  String ownerName,
-                                 PublicKeyHash owner,
                                  EntryPoint sharedDir,
                                  TrieNode root,
                                  long capCount,
@@ -30,7 +28,6 @@ public class FriendSourcedTrieNode implements TrieNode {
                                  Fragmenter fragmenter) {
         this.homeDirSupplier = homeDirSupplier;
         this.ownerName = ownerName;
-        this.owner = owner;
         this.sharedDir = sharedDir;
         this.root = root;
         this.capCount = capCount;
@@ -52,11 +49,10 @@ public class FriendSourcedTrieNode implements TrieNode {
                                     .thenApply(caps ->
                                             Optional.of(new FriendSourcedTrieNode(homeDirSupplier,
                                                     e.ownerName,
-                                                    e.owner,
                                                     e,
                                                     caps.getRetrievedCapabilities().stream()
                                                             .reduce(TrieNodeImpl.empty(),
-                                                                    (root, cap) -> root.put(trimOwner(cap.path), UserContext.convert(e.ownerName, e.owner, cap)),
+                                                                    (root, cap) -> root.put(trimOwner(cap.path), UserContext.convert(e.ownerName, cap)),
                                                                     (a, b) -> a),
                                                     caps.getRecordsRead(),
                                                     random, fragmenter)));
@@ -79,7 +75,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                                                             capCount += newCaps.getRecordsRead();
                                                             root = newCaps.getRetrievedCapabilities().stream()
                                                                     .reduce(root,
-                                                                            (root, cap) -> root.put(trimOwner(cap.path), UserContext.convert(ownerName, owner, cap)),
+                                                                            (root, cap) -> root.put(trimOwner(cap.path), UserContext.convert(ownerName, cap)),
                                                                             (a, b) -> a);
                                                             return true;
                                                         });

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -211,7 +211,7 @@ public class UserContext {
                             LOG.info("Couldn't register username");
                             throw new IllegalStateException("Couldn't register username: " + username);
                         }
-                        return Transaction.run(signerHash, tid -> network.dhtClient.putSigningKey(
+                        return Transaction.call(signerHash, tid -> network.dhtClient.putSigningKey(
                                 secretSigningKey.signatureOnly(publicSigningKey.serialize()),
                                 signerHash,
                                 publicSigningKey, tid).thenCompose(returnedSignerHash -> {
@@ -500,7 +500,7 @@ public class UserContext {
                                         .thenCompose(wd -> {
                                             PublicSigningKey newPublicSigningKey = updatedUser.getUser().publicSigningKey;
                                             PublicKeyHash existingOwner = ContentAddressedStorage.hashKey(existingUser.getUser().publicSigningKey);
-                                            return Transaction.run(existingOwner,
+                                            return Transaction.call(existingOwner,
                                                     tid -> network.dhtClient.putSigningKey(
                                                             existingUser.getUser().secretSigningKey.signatureOnly(newPublicSigningKey.serialize()),
                                                             existingOwner,
@@ -542,7 +542,7 @@ public class UserContext {
         long t1 = System.currentTimeMillis();
         SigningKeyPair writer = SigningKeyPair.random(crypto.random, crypto.signer);
         LOG.info("Random User generation took " + (System.currentTimeMillis()-t1) + " mS");
-        return Transaction.run(owner.publicKeyHash, tid -> network.dhtClient.putSigningKey(
+        return Transaction.call(owner.publicKeyHash, tid -> network.dhtClient.putSigningKey(
                 owner.secret.signatureOnly(writer.publicSigningKey.serialize()),
                 owner.publicKeyHash,
                 writer.publicSigningKey,
@@ -614,7 +614,7 @@ public class UserContext {
         return addToUserDataQueue(lock)
                 .thenCompose(wd -> {
                     WriterData writerData = wd.props.addNamedKey(keyName, owned);
-                    return Transaction.run(signer.publicKeyHash,
+                    return Transaction.call(signer.publicKeyHash,
                             tid -> writerData.commit(signer.publicKeyHash, signer, wd.hash, network, lock::complete, tid),
                             network.dhtClient);
                 });
@@ -924,7 +924,7 @@ public class UserContext {
                 entryPoints.add(entry);
                 return new UserStaticData(entryPoints, rootKey);
             });
-            return Transaction.run(signer.publicKeyHash,
+            return Transaction.call(signer.publicKeyHash,
                     tid -> wd.props.withStaticData(updated)
                             .commit(signer.publicKeyHash, signer, wd.hash, network, lock::complete, tid),
                     network.dhtClient

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -847,7 +847,7 @@ public class UserContext {
             return getByPath(path.getParent().toString())
                     .thenCompose(parent -> sharedWith(toUnshare)
                             .thenCompose(sharedWithUsers ->
-                                    toUnshare.makeDirty(network, crypto.random, parent.get(), readersToRemove)
+                                    toUnshare.makeDirty(network, crypto.random, parent.get())
                                             .thenCompose(markedDirty -> {
                                                 Set<String> existingEntries = sharedWithCache.getOrDefault("/" + pathString, new HashSet<>());
                                                 existingEntries.removeAll(readersToRemove);
@@ -1185,7 +1185,7 @@ public class UserContext {
                         // and the dir/file it points to
                         // first make it writable by combining with the root writing key
                         getByPath("/" + username).thenCompose(rootDir ->
-                                new FileWrapper(file.getPointer(), file.getOwner(), e.readers, e.writers, rootDir.get().getEntryWriterKey())
+                                new FileWrapper(file.getPointer(), file.getOwner(), rootDir.get().getEntryWriterKey())
                                         .remove(network, null)
                                         .thenApply(x -> removeFromStaticData(file)));
                         return true;

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -245,9 +245,9 @@ public class UserContext {
                             return ((DirAccess) userRoot.fileAccess).mkdir(
                                     SHARED_DIR_NAME,
                                     network,
-                                    userRoot.capability.getLocation().owner,
-                                    userRoot.capability.signer(),
-                                    userRoot.capability.location.getMapKey(),
+                                    signerHash,
+                                    userRoot.capability.signer(null),
+                                    userRoot.capability.getMapKey(),
                                     userRoot.capability.baseKey,
                                     null,
                                     true,
@@ -273,8 +273,9 @@ public class UserContext {
             invalidLink.completeExceptionally(e);
             return invalidLink;
         }
-        EntryPoint entry = new EntryPoint(entryPoint, "", Collections.emptySet(), Collections.emptySet());
-        WriterData empty = WriterData.createEmpty(entryPoint.location.owner);
+        PublicKeyHash owner = Capability.parseOwner(link);
+        EntryPoint entry = new EntryPoint(entryPoint, "", owner, Collections.emptySet(), Collections.emptySet());
+        WriterData empty = WriterData.createEmpty(owner);
         CommittedWriterData committed = new CommittedWriterData(MaybeMultihash.empty(), empty);
         CompletableFuture<CommittedWriterData> userData = CompletableFuture.completedFuture(committed);
         UserContext context = new UserContext(null, null, null, null, network.clear(), crypto, userData, TrieNodeImpl.empty());
@@ -557,16 +558,15 @@ public class UserContext {
 
             // and authorise the writer key
             SigningPrivateKeyAndPublicHash writerWithHash = new SigningPrivateKeyAndPublicHash(writerHash, writer.secretSigningKey);
-            Capability rootPointer = new Capability(this.signer.publicKeyHash, writerWithHash, rootMapKey, rootRKey);
-            EntryPoint entry = new EntryPoint(rootPointer, this.username, Collections.emptySet(), Collections.emptySet());
-            return addOwnedKeyAndCommit(entry.pointer.location.writer, tid)
+            Capability rootPointer = new Capability(writerWithHash, rootMapKey, rootRKey);
+            EntryPoint entry = new EntryPoint(rootPointer, this.username, signer.publicKeyHash, Collections.emptySet(), Collections.emptySet());
+            return addOwnedKeyAndCommit(entry.pointer.writer.get(), tid)
                     .thenCompose(x -> {
                         long t2 = System.currentTimeMillis();
                         DirAccess root = DirAccess.create(MaybeMultihash.empty(), rootRKey, new FileProperties(directoryName, "",
-                                0, LocalDateTime.now(), false, Optional.empty()), (Location) null, null, null);
-                        Location rootLocation = new Location(this.signer.publicKeyHash, writerHash, rootMapKey);
+                                0, LocalDateTime.now(), false, Optional.empty()), (Capability) null,null);
                         LOG.info("Uploading entry point directory");
-                        return network.uploadChunk(root, rootLocation, writerWithHash, tid).thenApply(chunkHash -> {
+                        return network.uploadChunk(root, this.signer.publicKeyHash, rootMapKey, writerWithHash, tid).thenApply(chunkHash -> {
                             long t3 = System.currentTimeMillis();
                             LOG.info("Uploading root dir metadata took " + (t3 - t2) + " mS");
 
@@ -662,7 +662,7 @@ public class UserContext {
             return wd.props.staticData.get()
                     .getEntryPoints(rootKey)
                     .stream()
-                    .map(e -> e.owner)
+                    .map(e -> e.ownerName)
                     .filter(name -> ! name.equals(username))
                     .collect(Collectors.toSet());
         });
@@ -687,18 +687,18 @@ public class UserContext {
 
     @JsMethod
     public CompletableFuture<Boolean> sendReplyFollowRequest(FollowRequest initialRequest, boolean accept, boolean reciprocate) {
-        String theirUsername = initialRequest.entry.get().owner;
+        String theirUsername = initialRequest.entry.get().ownerName;
         // if accept, create directory to share with them, note in entry points (they follow us)
         if (!accept && !reciprocate) {
             // send a null entry and null key (full rejection)
             DataSink dout = new DataSink();
             // write a null entry point
-            EntryPoint entry = new EntryPoint(Capability.createNull(), username, Collections.emptySet(), Collections.emptySet());
+            EntryPoint entry = new EntryPoint(Capability.createNull(), username, signer.publicKeyHash, Collections.emptySet(), Collections.emptySet());
             dout.writeArray(entry.serialize());
             dout.writeArray(new byte[0]); // tell them we're not reciprocating
             byte[] plaintext = dout.toByteArray();
 
-            return getPublicKeys(initialRequest.entry.get().owner).thenCompose(pair -> {
+            return getPublicKeys(initialRequest.entry.get().ownerName).thenCompose(pair -> {
                 PublicBoxingKey targetUser = pair.get().right;
                 // create a tmp keypair whose public key we can prepend to the request without leaking information
                 BoxingKeyPair tmp = BoxingKeyPair.random(crypto.random, crypto.boxer);
@@ -707,7 +707,7 @@ public class UserContext {
                 DataSink resp = new DataSink();
                 resp.writeArray(tmp.publicBoxingKey.serialize());
                 resp.writeArray(payload);
-                network.social.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
+                network.social.sendFollowRequest(initialRequest.entry.get().owner, resp.toByteArray());
                 // remove pending follow request from them
                 return network.social.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(initialRequest.rawCipher));
             });
@@ -720,7 +720,8 @@ public class UserContext {
                     return sharing.mkdir(theirUsername, network, initialRequest.key.get(), true, crypto.random)
                             .thenCompose(friendRoot -> {
                                 // add a note to our static data so we know who we sent the read access to
-                                EntryPoint entry = new EntryPoint(friendRoot.readOnly(), username, Collections.singleton(theirUsername), Collections.emptySet());
+                                EntryPoint entry = new EntryPoint(friendRoot.readOnly().withWritingKey(sharing.writer()),
+                                        username, signer.publicKeyHash, Collections.singleton(theirUsername), Collections.emptySet());
 
                                 return addToStaticDataAndCommit(entry).thenApply(trie -> {
                                     this.entrie = trie;
@@ -730,7 +731,7 @@ public class UserContext {
                             });
                 });
             } else {
-                EntryPoint entry = new EntryPoint(Capability.createNull(), username, Collections.emptySet(), Collections.emptySet());
+                EntryPoint entry = new EntryPoint(Capability.createNull(), username, signer.publicKeyHash, Collections.emptySet(), Collections.emptySet());
                 dout.writeArray(entry.serialize());
                 return CompletableFuture.completedFuture(dout);
             }
@@ -744,7 +745,7 @@ public class UserContext {
             }
             byte[] plaintext = dout.toByteArray();
 
-            return getPublicKeys(initialRequest.entry.get().owner).thenCompose(pair -> {
+            return getPublicKeys(initialRequest.entry.get().ownerName).thenCompose(pair -> {
                 PublicBoxingKey targetUser = pair.get().right;
                 // create a tmp keypair whose public key we can prepend to the request without leaking information
                 BoxingKeyPair tmp = BoxingKeyPair.random(crypto.random, crypto.boxer);
@@ -753,7 +754,7 @@ public class UserContext {
                 DataSink resp = new DataSink();
                 resp.writeArray(tmp.publicBoxingKey.serialize());
                 resp.writeArray(payload);
-                return network.social.sendFollowRequest(initialRequest.entry.get().pointer.location.owner, resp.toByteArray());
+                return network.social.sendFollowRequest(initialRequest.entry.get().owner, resp.toByteArray());
             });
         }).thenCompose(b -> {
             if (reciprocate)
@@ -788,7 +789,8 @@ public class UserContext {
                         return sharing.mkdir(targetUsername, network, null, true, crypto.random).thenCompose(friendRoot -> {
 
                             // if they accept the request we will add a note to our static data so we know who we sent the read access to
-                            EntryPoint entry = new EntryPoint(friendRoot.readOnly(), username, Collections.singleton(targetUsername), Collections.emptySet());
+                            EntryPoint entry = new EntryPoint(friendRoot.readOnly().withWritingKey(sharing.writer()),
+                                    username, signer.publicKeyHash, Collections.singleton(targetUsername), Collections.emptySet());
 
                             // send details to allow friend to follow us, and optionally let us follow them
                             // create a tmp keypair whose public key we can prepend to the request without leaking information
@@ -982,12 +984,12 @@ public class UserContext {
         return getSharingFolder().thenCompose(sharing ->
                 getFollowerRoots().thenCompose(followerRoots -> {
                     List<FollowRequest> replies = all.stream()
-                            .filter(freq -> followerRoots.containsKey(freq.entry.get().owner))
+                            .filter(freq -> followerRoots.containsKey(freq.entry.get().ownerName))
                             .collect(Collectors.toList());
 
                     BiFunction<TrieNode, FollowRequest, CompletableFuture<TrieNode>> addToStatic = (root, freq) -> {
                         if (!Arrays.equals(freq.entry.get().pointer.baseKey.serialize(), SymmetricKey.createNull().serialize())) {
-                            CompletableFuture<TrieNode> updatedRoot = freq.entry.get().owner.equals(username) ?
+                            CompletableFuture<TrieNode> updatedRoot = freq.entry.get().ownerName.equals(username) ?
                                     CompletableFuture.completedFuture(root) : // ignore responses claiming to be owned by us
                                     addToStaticDataAndCommit(root, freq.entry.get());
                             return updatedRoot.thenCompose(newRoot -> {
@@ -1002,7 +1004,7 @@ public class UserContext {
 
                     BiFunction<TrieNode, FollowRequest, CompletableFuture<TrieNode>> mozart = (trie, freq) -> {
                         // delete our folder if they didn't reciprocate
-                        FileWrapper ourDirForThem = followerRoots.get(freq.entry.get().owner);
+                        FileWrapper ourDirForThem = followerRoots.get(freq.entry.get().ownerName);
                         byte[] ourKeyForThem = ourDirForThem.getKey().serialize();
                         byte[] keyFromResponse = freq.key.map(k -> k.serialize()).orElse(null);
                         if (keyFromResponse == null || !Arrays.equals(keyFromResponse, ourKeyForThem)) {
@@ -1016,18 +1018,18 @@ public class UserContext {
                         } else if (freq.entry.get().pointer.isNull()) {
                             // They reciprocated, but didn't accept (they follow us, but we can't follow them)
                             // add entry point to static data to signify their acceptance
-                            EntryPoint entryWeSentToThem = new EntryPoint(ourDirForThem.getPointer().capability.readOnly(),
-                                    username, Collections.singleton(ourDirForThem.getName()), Collections.emptySet());
+                            EntryPoint entryWeSentToThem = new EntryPoint(ourDirForThem.getPointer().capability.readOnly().withWritingKey(ourDirForThem.writer()),
+                                    username, signer.publicKeyHash, Collections.singleton(ourDirForThem.getName()), Collections.emptySet());
                             return addToStaticDataAndCommit(trie, entryWeSentToThem);
                         } else {
                             // they accepted and reciprocated
                             // add entry point to static data to signify their acceptance
-                            EntryPoint entryWeSentToThem = new EntryPoint(ourDirForThem.getPointer().capability.readOnly(),
-                                    username, Collections.singleton(ourDirForThem.getName()), Collections.emptySet());
+                            EntryPoint entryWeSentToThem = new EntryPoint(ourDirForThem.getPointer().capability.readOnly().withWritingKey(ourDirForThem.writer()),
+                                    username, signer.publicKeyHash, Collections.singleton(ourDirForThem.getName()), Collections.emptySet());
 
                             // add new entry point to tree root
                             EntryPoint entry = freq.entry.get();
-                            if (entry.owner.equals(username))
+                            if (entry.ownerName.equals(username))
                                 throw new IllegalStateException("Received a follow request claiming to be owned by us!");
                             return addToStaticDataAndCommit(trie, entryWeSentToThem)
                                     .thenCompose(newRoot -> network.retrieveEntryPoint(entry)
@@ -1038,7 +1040,7 @@ public class UserContext {
                         }
                     };
                     List<FollowRequest> initialRequests = all.stream()
-                            .filter(freq -> !followerRoots.containsKey(freq.entry.get().owner))
+                            .filter(freq -> !followerRoots.containsKey(freq.entry.get().ownerName))
                             .collect(Collectors.toList());
                     return Futures.reduceAll(replies, entrie, mozart, (a, b) -> a)
                             .thenApply(newRoot -> {
@@ -1092,7 +1094,7 @@ public class UserContext {
         List<EntryPoint> ourFileSystemEntries = userData.staticData.get()
                 .getEntryPoints(rootKey)
                 .stream()
-                .filter(e -> e.owner.equals(ourName))
+                .filter(e -> e.ownerName.equals(ourName))
                 .collect(Collectors.toList());
         return Futures.reduceAll(ourFileSystemEntries, root, (t, e) -> addEntryPoint(ourName, null, t, e, network, random, fragmenter), (a, b) -> a)
                 .exceptionally(Futures::logError);
@@ -1112,7 +1114,7 @@ public class UserContext {
         List<EntryPoint> notOurFileSystemEntries = userData.staticData.get()
                 .getEntryPoints(rootKey)
                 .stream()
-                .filter(e -> ! e.owner.equals(ourName))
+                .filter(e -> ! e.ownerName.equals(ourName))
                 .collect(Collectors.toList());
 
         // need to to retrieve all the entry points of our friends
@@ -1120,8 +1122,8 @@ public class UserContext {
                 .exceptionally(Futures::logError);
     }
 
-    public static EntryPoint convert(String owner, CapabilityWithPath cap) {
-        return new EntryPoint(cap.cap, owner, Collections.emptySet(), Collections.emptySet());
+    public static EntryPoint convert(String ownerName, PublicKeyHash owner, CapabilityWithPath cap) {
+        return new EntryPoint(cap.cap, ownerName, owner, Collections.emptySet(), Collections.emptySet());
     }
 
     private static CompletableFuture<TrieNode> addRetrievedEntryPoint(String ourName,
@@ -1132,7 +1134,7 @@ public class UserContext {
                                                                       SafeRandom random,
                                                                       Fragmenter fragmenter) {
         // check entrypoint doesn't forge the owner
-        return  (fileCap.owner.equals(ourName) ? CompletableFuture.completedFuture(true) :
+        return  (fileCap.ownerName.equals(ourName) ? CompletableFuture.completedFuture(true) :
                 fileCap.isValid(path, network)).thenCompose(valid -> {
             String[] parts = path.split("/");
             if (parts.length < 3 || !parts[2].equals(SHARED_DIR_NAME))
@@ -1172,7 +1174,7 @@ public class UserContext {
     }
 
     private CompletableFuture<Boolean> cleanOurEntryPoint(EntryPoint e) {
-        if (! e.owner.equals(username))
+        if (! e.ownerName.equals(username))
             return CompletableFuture.completedFuture(false);
         return network.retrieveEntryPoint(e).thenCompose(fileOpt -> {
             if (! fileOpt.isPresent())
@@ -1185,7 +1187,7 @@ public class UserContext {
                         // and the dir/file it points to
                         // first make it writable by combining with the root writing key
                         getByPath("/" + username).thenCompose(rootDir ->
-                                new FileWrapper(file.getPointer(), file.getOwner(), rootDir.get().getEntryWriterKey())
+                                new FileWrapper(file.getPointer(), file.getOwner(), file.owner(), file.writer(), rootDir.get().getEntryWriterKey())
                                         .remove(network, null)
                                         .thenApply(x -> removeFromStaticData(file)));
                         return true;

--- a/src/peergos/shared/user/UserStaticData.java
+++ b/src/peergos/shared/user/UserStaticData.java
@@ -10,7 +10,7 @@ import java.util.stream.*;
 
 public class UserStaticData implements Cborable {
 	private static final Logger LOG = Logger.getGlobal();
-	private static final int PADDING = 8192;
+	private static final int PADDING_BLOCK_SIZE = 8192;
 
     private final PaddedCipherText allEntryPoints;
 
@@ -20,7 +20,7 @@ public class UserStaticData implements Cborable {
     }
 
     public UserStaticData(List<EntryPoint> staticData, SymmetricKey rootKey) {
-        this(PaddedCipherText.build(rootKey, new EntryPoints(EntryPoints.VERSION, staticData), PADDING));
+        this(PaddedCipherText.build(rootKey, new EntryPoints(EntryPoints.VERSION, staticData), PADDING_BLOCK_SIZE));
     }
 
     public UserStaticData(SymmetricKey rootKey) {

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -138,7 +138,7 @@ public class WriterData implements Cborable {
             boolean isRemoved = updated.size() < original.size();
 
             if (isRemoved) {
-                return Transaction.run(fileWrapper.owner(),
+                return Transaction.call(fileWrapper.owner(),
                         tid -> withStaticData(Optional.of(new UserStaticData(updated, rootKey)))
                                 .commit(fileWrapper.owner(), signer, currentHash, network, updater, tid),
                         network.dhtClient);
@@ -158,7 +158,7 @@ public class WriterData implements Cborable {
                                                              SecretGenerationAlgorithm newAlgorithm,
                                                              NetworkAccess network,
                                                              Consumer<CommittedWriterData> updater) {
-        return Transaction.run(oldSigner.publicKeyHash, tid -> {
+        return Transaction.call(oldSigner.publicKeyHash, tid -> {
             // auth new key by adding to existing writer data first
             WriterData tmp = addOwnedKey(signer.publicKeyHash);
             return tmp.commit(oldSigner.publicKeyHash, oldSigner, currentHash, network, x -> {}, tid)

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -28,7 +28,7 @@ public class WriterData implements Cborable {
     // publicly readable and present on owner keys
     public final Optional<SecretGenerationAlgorithm> generationAlgorithm;
     // accessible under IPFS address $hash/public
-    public final Optional<Capability> publicData;
+    public final Optional<RelativeCapability> publicData;
     // The public boxing key to encrypt follow requests to, accessible under IPFS address $hash/inbound
     public final Optional<PublicKeyHash> followRequestReceiver;
     // accessible under IPFS address $hash/owned
@@ -54,7 +54,7 @@ public class WriterData implements Cborable {
      */
     public WriterData(PublicKeyHash controller,
                       Optional<SecretGenerationAlgorithm> generationAlgorithm,
-                      Optional<Capability> publicData,
+                      Optional<RelativeCapability> publicData,
                       Optional<PublicKeyHash> followRequestReceiver,
                       Set<PublicKeyHash> ownedKeys,
                       Map<String, PublicKeyHash> namedOwnedKeys,
@@ -128,7 +128,7 @@ public class WriterData implements Cborable {
                                                                        MaybeMultihash currentHash,
                                                                        NetworkAccess network,
                                                                        Consumer<CommittedWriterData> updater) {
-        Capability pointer = fileWrapper.getPointer().capability;
+        AbsoluteCapability pointer = fileWrapper.getPointer().capability;
 
         return staticData.map(sd -> {
             List<EntryPoint> original = sd.getEntryPoints(rootKey);
@@ -264,7 +264,7 @@ public class WriterData implements Cborable {
 
         PublicKeyHash controller = extract.apply("controller").map(PublicKeyHash::fromCbor).get();
         Optional<SecretGenerationAlgorithm> algo  = extractUserGenerationAlgorithm(cbor);
-        Optional<Capability> publicData = extract.apply("public").map(Capability::fromCbor);
+        Optional<RelativeCapability> publicData = extract.apply("public").map(RelativeCapability::fromCbor);
         Optional<PublicKeyHash> followRequestReceiver = extract.apply("inbound").map(PublicKeyHash::fromCbor);
         CborObject.CborList ownedList = (CborObject.CborList) map.values.get(new CborObject.CborString("owned"));
         Set<PublicKeyHash> owned = ownedList == null ?

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -138,9 +138,9 @@ public class WriterData implements Cborable {
             boolean isRemoved = updated.size() < original.size();
 
             if (isRemoved) {
-                return Transaction.run(pointer.location.owner,
+                return Transaction.run(fileWrapper.owner(),
                         tid -> withStaticData(Optional.of(new UserStaticData(updated, rootKey)))
-                                .commit(pointer.location.owner, signer, currentHash, network, updater, tid),
+                                .commit(fileWrapper.owner(), signer, currentHash, network, updater, tid),
                         network.dhtClient);
             }
             CommittedWriterData committed = committed(currentHash);

--- a/src/peergos/shared/user/fs/AbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/AbsoluteCapability.java
@@ -1,0 +1,161 @@
+package peergos.shared.user.fs;
+
+import jsinterop.annotations.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.symmetric.*;
+import peergos.shared.io.ipfs.multibase.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+/** This a complete cryptographic capability to read a file or folder
+ *
+ */
+public class AbsoluteCapability implements Cborable {
+
+    public final PublicKeyHash owner, writer;
+    private final byte[] mapKey;
+    public final SymmetricKey baseKey;
+    public final Optional<SecretSigningKey> signer;
+
+    public AbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
+        if (mapKey.length != Location.MAP_KEY_LENGTH)
+            throw new IllegalStateException("Invalid map key length: " + mapKey.length);
+        this.owner = owner;
+        this.writer = writer;
+        this.mapKey = mapKey;
+        this.baseKey = baseKey;
+        this.signer = signer;
+    }
+
+    public AbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey) {
+        this(owner, writer, mapKey, baseKey, Optional.empty());
+    }
+
+    @JsMethod
+    public byte[] getMapKey() {
+        return Arrays.copyOf(mapKey, mapKey.length);
+    }
+
+    public Location getLocation() {
+        return new Location(owner, writer, mapKey);
+    }
+
+    public SigningPrivateKeyAndPublicHash getSigningPair() {
+        if (! signer.isPresent())
+            throw new IllegalStateException("Can't get a signing key pair from a read only capability!");
+        return new SigningPrivateKeyAndPublicHash(writer, signer.get());
+    }
+
+    public boolean isWritable() {
+        return signer.isPresent();
+    }
+
+    public RelativeCapability relativise(AbsoluteCapability descendant) {
+        if (! Objects.equals(owner, descendant.owner))
+            throw new IllegalStateException("Files with different owners can't be descendant of each other!");
+        if (Objects.equals(writer, descendant.writer))
+            return new RelativeCapability(Optional.empty(), descendant.getMapKey(), descendant.baseKey, descendant.signer);
+        return new RelativeCapability(Optional.of(descendant.writer), descendant.getMapKey(), descendant.baseKey, descendant.signer);
+    }
+
+    public WritableAbsoluteCapability toWritable(SigningPrivateKeyAndPublicHash signer) {
+        if (! signer.publicKeyHash.equals(writer))
+            throw new IllegalStateException("Incorrect signing keyPair to make this capability writable!");
+        return new WritableAbsoluteCapability(owner, writer, mapKey, baseKey, signer.secret);
+    }
+
+    public String toLink() {
+        String encodedOwnerKey = Base58.encode(owner.serialize());
+        String encodedWriterKey = Base58.encode(writer.serialize());
+        String encodedMapKey = Base58.encode(mapKey);
+        String encodedBaseKey = Base58.encode(baseKey.serialize());
+        return Stream.of(encodedOwnerKey, encodedWriterKey, encodedMapKey, encodedBaseKey)
+                .collect(Collectors.joining("/", "#", ""));
+    }
+
+    public static AbsoluteCapability fromLink(String keysString) {
+        if (keysString.startsWith("#"))
+            keysString = keysString.substring(1);
+
+        String[] split = keysString.split("/");
+        if (split.length != 4)
+            throw new IllegalStateException("Invalid public link "+ keysString);
+
+        PublicKeyHash owner = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[0])));
+        PublicKeyHash writer = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[1])));
+        byte[] mapKey = Base58.decode(split[2]);
+        SymmetricKey baseKey = SymmetricKey.fromByteArray(Base58.decode(split[3]));
+        return new AbsoluteCapability(owner, writer, mapKey, baseKey, Optional.empty());
+    }
+
+    public AbsoluteCapability readOnly() {
+        if (!isWritable())
+            return this;
+        return new AbsoluteCapability(owner, writer, mapKey, baseKey, Optional.empty());
+    }
+
+    public AbsoluteCapability withBaseKey(SymmetricKey newBaseKey) {
+        return new AbsoluteCapability(owner, writer, mapKey, newBaseKey, signer);
+    }
+
+    public boolean isNull() {
+        PublicKeyHash nullUser = PublicKeyHash.NULL;
+        return nullUser.equals(owner) &&
+                nullUser.equals(writer) &&
+                Arrays.equals(getMapKey(), new byte[32]) &&
+                baseKey.equals(SymmetricKey.createNull()) &&
+                ! signer.isPresent();
+    }
+
+    public static AbsoluteCapability createNull() {
+        return new AbsoluteCapability(PublicKeyHash.NULL, PublicKeyHash.NULL, new byte[32], SymmetricKey.createNull());
+    }
+
+    @Override
+    public CborObject toCbor() {
+        Map<String, CborObject> cbor = new TreeMap<>();
+        cbor.put("o", owner.toCbor());
+        cbor.put("w", writer.toCbor());
+        cbor.put("m", new CborObject.CborByteArray(mapKey));
+        cbor.put("k", baseKey.toCbor());
+        signer.ifPresent(secret -> cbor.put("s", secret.toCbor()));
+        return CborObject.CborMap.build(cbor);
+    }
+
+    public static AbsoluteCapability fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Incorrect cbor for AbsoluteCapability: " + cbor);
+        SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
+
+        PublicKeyHash owner = PublicKeyHash.fromCbor(map.get(new CborObject.CborString("o")));
+        PublicKeyHash writer = PublicKeyHash.fromCbor(map.get(new CborObject.CborString("w")));
+        byte[] mapKey = ((CborObject.CborByteArray)map.get(new CborObject.CborString("m"))).value;
+        SymmetricKey baseKey = SymmetricKey.fromCbor(map.get(new CborObject.CborString("k")));
+        Optional<SecretSigningKey> signer = Optional.ofNullable(map.get(new CborObject.CborString("s")))
+                .map(SecretSigningKey::fromCbor);
+        return new AbsoluteCapability(owner, writer, mapKey, baseKey, signer);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbsoluteCapability that = (AbsoluteCapability) o;
+        return Objects.equals(owner, that.owner) &&
+                Objects.equals(writer, that.writer) &&
+                Arrays.equals(mapKey, that.mapKey) &&
+                Objects.equals(baseKey, that.baseKey) &&
+                Objects.equals(signer, that.signer);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(owner, writer, baseKey, signer);
+        result = 31 * result + Arrays.hashCode(mapKey);
+        return result;
+    }
+}

--- a/src/peergos/shared/user/fs/Capability.java
+++ b/src/peergos/shared/user/fs/Capability.java
@@ -14,49 +14,68 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class Capability implements Cborable {
-    public final Location location;
+    // writer is only present when it is not implicit (an entry point, or a child link to a different writing key)
+    public final Optional<PublicKeyHash> writer;
+    private final byte[] mapKey;
     public final SymmetricKey baseKey;
-    public final Optional<SecretSigningKey> writer;
+    public final Optional<SecretSigningKey> signer;
 
     @JsConstructor
-    public Capability(Location location, Optional<SecretSigningKey> writer, SymmetricKey baseKey) {
-        this.location = location;
-        this.baseKey = baseKey;
+    public Capability(Optional<PublicKeyHash> writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
         this.writer = writer;
+        if (mapKey.length != Location.MAP_KEY_LENGTH)
+            throw new IllegalStateException("Invalid map key length: " + mapKey.length);
+        this.mapKey = mapKey;
+        this.baseKey = baseKey;
+        this.signer = signer;
     }
 
-    public Capability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey) {
-        this(new Location(owner, writer, mapKey), Optional.empty(), baseKey);
+    public Capability(byte[] mapKey, SymmetricKey baseKey) {
+        this(Optional.empty(), mapKey, baseKey, Optional.empty());
     }
 
-    public Capability(PublicKeyHash owner, SigningPrivateKeyAndPublicHash writer, byte[] mapKey, SymmetricKey baseKey) {
-        this(new Location(owner, writer.publicKeyHash, mapKey), Optional.of(writer.secret), baseKey);
+    public Capability(PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
+        this(Optional.of(writer), mapKey, baseKey, signer);
     }
 
-    public Location getLocation() {
-        return location;
+    public Capability(PublicKeyHash signer, byte[] mapKey, SymmetricKey baseKey) {
+        this(Optional.of(signer), mapKey, baseKey, Optional.empty());
     }
 
-    public SigningPrivateKeyAndPublicHash signer() {
-        if (! writer.isPresent())
+    public Capability(SigningPrivateKeyAndPublicHash signer, byte[] mapKey, SymmetricKey baseKey) {
+        this(Optional.of(signer.publicKeyHash), mapKey, baseKey, Optional.of(signer.secret));
+    }
+
+    @JsMethod
+    public byte[] getMapKey() {
+        return Arrays.copyOf(mapKey, mapKey.length);
+    }
+
+    public Location getLocation(PublicKeyHash owner, PublicKeyHash writer) {
+        return new Location(owner, this.writer.orElse(writer), mapKey);
+    }
+
+    public SigningPrivateKeyAndPublicHash signer(PublicKeyHash writer) {
+        if (! signer.isPresent())
             throw new IllegalStateException("Can't get signer for a read only pointer!");
-        return new SigningPrivateKeyAndPublicHash(location.writer, writer.get());
+        return new SigningPrivateKeyAndPublicHash(this.writer.orElse(writer), signer.get());
     }
 
     public Capability withBaseKey(SymmetricKey newBaseKey) {
-        return new Capability(location, writer, newBaseKey);
+        return new Capability(writer, mapKey, newBaseKey, signer);
     }
 
     public Capability withWritingKey(PublicKeyHash writingKey) {
-        return new Capability(location.withWriter(writingKey), Optional.empty(), baseKey);
+        return new Capability(Optional.of(writingKey), mapKey, baseKey, Optional.empty());
     }
 
     @Override
     public CborObject toCbor() {
         Map<String, CborObject> cbor = new TreeMap<>();
-        cbor.put("l", location.toCbor());
+        writer.ifPresent(w -> cbor.put("w", w.toCbor()));
+        cbor.put("m", new CborObject.CborByteArray(mapKey));
         cbor.put("k", baseKey.toCbor());
-        writer.ifPresent(secret -> cbor.put("s", secret.toCbor()));
+        signer.ifPresent(secret -> cbor.put("s", secret.toCbor()));
         return CborObject.CborMap.build(cbor);
     }
 
@@ -68,63 +87,63 @@ public class Capability implements Cborable {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor for Capability: " + cbor);
         SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
-        Location loc = Location.fromCbor(map.get(new CborObject.CborString("l")));
+
+        Optional<PublicKeyHash> writer = Optional.ofNullable(map.get(new CborObject.CborString("w")))
+                .map(PublicKeyHash::fromCbor);
+        byte[] mapKey = ((CborObject.CborByteArray)map.get(new CborObject.CborString("m"))).value;
         SymmetricKey baseKey = SymmetricKey.fromCbor(map.get(new CborObject.CborString("k")));
-        CborObject.CborString secretLabel = new CborObject.CborString("s");
-        Optional<SecretSigningKey> writer = map.containsKey(secretLabel) ? Optional.of(SecretSigningKey.fromCbor(map.get(secretLabel))) : Optional.empty();
-        return new Capability(loc, writer, baseKey);
+        Optional<SecretSigningKey> signer = Optional.ofNullable(map.get(new CborObject.CborString("s")))
+                .map(SecretSigningKey::fromCbor);
+        return new Capability(writer, mapKey, baseKey, signer);
     }
 
     public Capability readOnly() {
         if (!isWritable())
             return this;
-        return new Capability(this.location, Optional.empty(), this.baseKey);
+        return new Capability(writer, mapKey, baseKey, Optional.empty());
     }
 
     public boolean isWritable() {
-        return writer.isPresent();
-    }
-
-    public String toLink() {
-        String encodedWriterKey = Base58.encode(location.writer.serialize());
-        String encodedOwnerKey = Base58.encode(location.owner.serialize());
-        String encodedMapKey = Base58.encode(location.getMapKey());
-        String encodedBaseKey = Base58.encode(baseKey.serialize());
-        StringBuilder sb = new StringBuilder("#");
-        return Stream.of(encodedWriterKey, encodedOwnerKey, encodedMapKey, encodedBaseKey)
-                .collect(Collectors.joining("/", "#", ""));
+        return signer.isPresent();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         Capability that = (Capability) o;
-
-        if (location != null ? !location.equals(that.location) : that.location != null) return false;
-        return baseKey != null ? baseKey.equals(that.baseKey) : that.baseKey == null;
-
+        return Objects.equals(writer, that.writer) &&
+                Arrays.equals(mapKey, that.mapKey) &&
+                Objects.equals(baseKey, that.baseKey) &&
+                Objects.equals(signer, that.signer);
     }
 
     @Override
     public int hashCode() {
-        int result = location != null ? location.hashCode() : 0;
-        result = 31 * result + (baseKey != null ? baseKey.hashCode() : 0);
+        int result = Objects.hash(writer, baseKey, signer);
+        result = 31 * result + Arrays.hashCode(mapKey);
         return result;
     }
 
     @Override
     public String toString() {
-        return ArrayOps.bytesToHex(location.getMapKey());
+        return ArrayOps.bytesToHex(getMapKey());
     }
 
     public boolean isNull() {
         PublicKeyHash nullUser = PublicKeyHash.NULL;
-        return nullUser.equals(location.owner) &&
-                nullUser.equals(location.writer) &&
-                Arrays.equals(location.getMapKey(), new byte[32]) &&
+        return writer.map(w -> nullUser.equals(w)).orElse(true) &&
+                Arrays.equals(getMapKey(), new byte[32]) &&
                 baseKey.equals(SymmetricKey.createNull());
+    }
+
+    public String toLink(PublicKeyHash owner, PublicKeyHash writer) {
+        String encodedOwnerKey = Base58.encode(owner.serialize());
+        String encodedWriterKey = Base58.encode(writer.serialize());
+        String encodedMapKey = Base58.encode(getMapKey());
+        String encodedBaseKey = Base58.encode(baseKey.serialize());
+        return Stream.of(encodedOwnerKey, encodedWriterKey, encodedMapKey, encodedBaseKey)
+                .collect(Collectors.joining("/", "#", ""));
     }
 
     public static Capability fromLink(String keysString) {
@@ -135,14 +154,23 @@ public class Capability implements Cborable {
         if (split.length != 4)
             throw new IllegalStateException("Invalid public link "+ keysString);
 
-        PublicKeyHash writer = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[0])));
-        PublicKeyHash owner = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[1])));
+        PublicKeyHash writer = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[1])));
         byte[] mapKey = Base58.decode(split[2]);
         SymmetricKey baseKey = SymmetricKey.fromByteArray(Base58.decode(split[3]));
-        return new Capability(owner, writer, mapKey, baseKey);
+        return new Capability(writer, mapKey, baseKey);
+    }
+
+    public static PublicKeyHash parseOwner(String keysString) {
+        if (keysString.startsWith("#"))
+            keysString = keysString.substring(1);
+        String[] split = keysString.split("/");
+        if (split.length != 4)
+            throw new IllegalStateException("Invalid public link "+ keysString);
+
+        return PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[0])));
     }
 
     public static Capability createNull() {
-        return new Capability(PublicKeyHash.NULL, PublicKeyHash.NULL, new byte[32], SymmetricKey.createNull());
+        return new Capability(PublicKeyHash.NULL, new byte[32], SymmetricKey.createNull());
     }
 }

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -197,7 +197,7 @@ public class CapabilityStore {
                 currentPos.readIntoArray(serialisedFilePointer, 0, READ_CAPABILITY_SIZE)
                         .thenCompose(bytesRead -> {
                             AbsoluteCapability pointer = AbsoluteCapability.fromCbor(CborObject.fromByteArray(serialisedFilePointer));
-                            EntryPoint entry = new EntryPoint(pointer, ownerName, Collections.emptySet(), Collections.emptySet());
+                            EntryPoint entry = new EntryPoint(pointer, ownerName);
                             return network.retrieveEntryPoint(entry).thenCompose( optFTN -> {
                                 if(optFTN.isPresent()) {
                                     FileWrapper ftn = optFTN.get();

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -2,6 +2,7 @@ package peergos.shared.user.fs;
 
 import peergos.shared.NetworkAccess;
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.SafeRandom;
 import peergos.shared.user.EntryPoint;
 import peergos.shared.util.*;
@@ -24,9 +25,9 @@ import java.util.stream.*;
  * Each of these cache files is just a serialized CapabilitiesFromUser
  */
 public class CapabilityStore {
-    public static final int CAPABILITY_SIZE = 159; // fp.toCbor().toByteArray() DOESN'T INCLUDE .secret
+    public static final int READ_CAPABILITY_SIZE = 119; // fp.toCbor().toByteArray() DOESN'T INCLUDE .secret
     public static final int CAPS_PER_FILE = 10000;
-    public static final int SHARING_FILE_MAX_SIZE = CAPABILITY_SIZE * CAPS_PER_FILE;
+    public static final int SHARING_FILE_MAX_SIZE = READ_CAPABILITY_SIZE * CAPS_PER_FILE;
     public static final String CAPABILITY_CACHE_DIR = ".capabilitycache";
     public static final String READ_ONLY_SHARING_FILE_PREFIX = "sharing.r.";
     public static final String WRITE_SHARING_FILE_PREFIX = "sharing.w.";
@@ -69,11 +70,11 @@ public class CapabilityStore {
                         .sorted(indexOrder)
                         .collect(Collectors.toList());
                 return getCacheFile(friendName, homeDirSupplier, network, random).thenCompose(optCachedFile -> {
-                    long totalRecords = sharingFiles.stream().mapToLong(f -> f.getFileProperties().size).sum() / CAPABILITY_SIZE;
+                    long totalRecords = sharingFiles.stream().mapToLong(f -> f.getFileProperties().size).sum() / READ_CAPABILITY_SIZE;
                     if(! optCachedFile.isPresent() ) {
                         CompletableFuture<List<CapabilityWithPath>> allFiles = Futures.reduceAll(sharingFiles,
                                 Collections.emptyList(),
-                                (res, sharingFile) -> readSharingFile(friendSharedDir.getName(), sharingFile, network, random)
+                                (res, sharingFile) -> readSharingFile(friendSharedDir.getName(), friendSharedDir.owner(), sharingFile, network, random)
                                         .thenApply(retrievedCaps -> Stream.concat(res.stream(), retrievedCaps.stream()).collect(Collectors.toList())),
                                 (a, b) -> Stream.concat(a.stream(), b.stream()).collect(Collectors.toList())
                         );
@@ -90,17 +91,17 @@ public class CapabilityStore {
                         return readRetrievedCapabilityCache(cachedFile, network, random).thenCompose(cache -> {
                             if (totalRecords == cache.getRecordsRead())
                                 return CompletableFuture.completedFuture(cache);
-                            int shareFileIndex = (int)(cache.getRecordsRead() * CAPABILITY_SIZE) / SHARING_FILE_MAX_SIZE;
-                            int recordIndex = (int) ((cache.getRecordsRead() * CAPABILITY_SIZE) % SHARING_FILE_MAX_SIZE) / CAPABILITY_SIZE;
+                            int shareFileIndex = (int)(cache.getRecordsRead() * READ_CAPABILITY_SIZE) / SHARING_FILE_MAX_SIZE;
+                            int recordIndex = (int) ((cache.getRecordsRead() * READ_CAPABILITY_SIZE) % SHARING_FILE_MAX_SIZE) / READ_CAPABILITY_SIZE;
                             List<FileWrapper> sharingFilesToRead = sharingFiles.subList(shareFileIndex, sharingFiles.size());
                             CompletableFuture<List<CapabilityWithPath>> allFiles = Futures.reduceAll(sharingFilesToRead.subList(0, sharingFilesToRead.size() - 1),
                                     Collections.emptyList(),
-                                    (res, sharingFile) -> readSharingFile(friendSharedDir.getName(), sharingFile, network, random)
+                                    (res, sharingFile) -> readSharingFile(friendSharedDir.getName(), friendSharedDir.owner(), sharingFile, network, random)
                                             .thenApply(retrievedCaps -> Stream.concat(res.stream(), retrievedCaps.stream()).collect(Collectors.toList())),
                                     (a, b) -> Stream.concat(a.stream(), b.stream()).collect(Collectors.toList()));
                             return allFiles
                                     .thenCompose(res -> readSharingFile(recordIndex, friendSharedDir.getName(),
-                                            sharingFilesToRead.get(sharingFilesToRead.size() -1), network, random))
+                                            friendSharedDir.owner(), sharingFilesToRead.get(sharingFilesToRead.size() -1), network, random))
                                     .thenCompose(res -> {
                                         if (saveCache) {
                                             return saveRetrievedCapabilityCache(totalRecords, homeDirSupplier, friendName,
@@ -128,19 +129,19 @@ public class CapabilityStore {
                     List<FileWrapper> sharingFiles = files.stream()
                             .sorted(indexOrder)
                             .collect(Collectors.toList());
-                    long totalRecords = sharingFiles.stream().mapToLong(f -> f.getFileProperties().size).sum() / CAPABILITY_SIZE;
-                    int shareFileIndex = (int) (capIndex * CAPABILITY_SIZE) / SHARING_FILE_MAX_SIZE;
+                    long totalRecords = sharingFiles.stream().mapToLong(f -> f.getFileProperties().size).sum() / READ_CAPABILITY_SIZE;
+                    int shareFileIndex = (int) (capIndex * READ_CAPABILITY_SIZE) / SHARING_FILE_MAX_SIZE;
                     int recordIndex = (int) (capIndex % CAPS_PER_FILE);
                     List<FileWrapper> sharingFilesToRead = sharingFiles.subList(shareFileIndex, sharingFiles.size());
 
                     CompletableFuture<List<CapabilityWithPath>> allFiles = Futures.reduceAll(sharingFilesToRead.subList(0, sharingFilesToRead.size() - 1),
                             Collections.emptyList(),
-                            (res, sharingFile) -> readSharingFile(friendSharedDir.getName(), sharingFile, network, random)
+                            (res, sharingFile) -> readSharingFile(friendSharedDir.getName(), friendSharedDir.owner(), sharingFile, network, random)
                                     .thenApply(retrievedCaps -> Stream.concat(res.stream(), retrievedCaps.stream()).collect(Collectors.toList())),
                             (a, b) -> Stream.concat(a.stream(), b.stream()).collect(Collectors.toList()));
                     CompletableFuture<CapabilitiesFromUser> result = allFiles
                             .thenCompose(res -> readSharingFile(recordIndex, friendSharedDir.getName(),
-                                    sharingFilesToRead.get(sharingFilesToRead.size() - 1), network, random))
+                                    friendSharedDir.owner(), sharingFilesToRead.get(sharingFilesToRead.size() - 1), network, random))
                             .thenCompose(res -> {
                                 if (saveCache) {
                                     return saveRetrievedCapabilityCache(totalRecords - capIndex, homeDirSupplier, friendName,
@@ -156,25 +157,27 @@ public class CapabilityStore {
     public static CompletableFuture<Long> getCapabilityCount(FileWrapper friendSharedDir,
                                                              NetworkAccess network) {
         return friendSharedDir.getChildren(network)
-                .thenApply(capFiles -> capFiles.stream().mapToLong(f -> f.getFileProperties().size).sum() / CAPABILITY_SIZE);
+                .thenApply(capFiles -> capFiles.stream().mapToLong(f -> f.getFileProperties().size).sum() / READ_CAPABILITY_SIZE);
     }
 
     public static CompletableFuture<List<CapabilityWithPath>> readSharingFile(String ownerName,
+                                                                              PublicKeyHash owner,
                                                                               FileWrapper file,
                                                                               NetworkAccess network,
                                                                               SafeRandom random) {
-        return readSharingFile(0, ownerName, file, network, random);
+        return readSharingFile(0, ownerName, owner, file, network, random);
     }
     public static CompletableFuture<List<CapabilityWithPath>> readSharingFile(int offsetIndex,
                                                                               String ownerName,
+                                                                              PublicKeyHash owner,
                                                                               FileWrapper file,
                                                                               NetworkAccess network,
                                                                               SafeRandom random) {
         return file.getInputStream(network, random, x -> {}).thenCompose(reader -> {
             int currentFileSize = (int) file.getSize();
-            List<CompletableFuture<Optional<CapabilityWithPath>>> capabilities = IntStream.range(offsetIndex, currentFileSize / CAPABILITY_SIZE)
-                    .mapToObj(e -> e * CAPABILITY_SIZE)
-                    .map(offset -> readSharingRecord(ownerName, reader, offset, network))
+            List<CompletableFuture<Optional<CapabilityWithPath>>> capabilities = IntStream.range(offsetIndex, currentFileSize / READ_CAPABILITY_SIZE)
+                    .mapToObj(e -> e * READ_CAPABILITY_SIZE)
+                    .map(offset -> readSharingRecord(ownerName, owner, reader, offset, network))
                     .collect(Collectors.toList());
 
             return Futures.combineAllInOrder(capabilities).thenApply(optList -> optList.stream()
@@ -185,15 +188,16 @@ public class CapabilityStore {
     }
 
     private static CompletableFuture<Optional<CapabilityWithPath>> readSharingRecord(String ownerName,
+                                                                                     PublicKeyHash owner,
                                                                                      AsyncReader reader,
                                                                                      int offset,
                                                                                      NetworkAccess network) {
-        byte[] serialisedFilePointer = new byte[CAPABILITY_SIZE];
+        byte[] serialisedFilePointer = new byte[READ_CAPABILITY_SIZE];
         return reader.seek( 0, offset).thenCompose( currentPos ->
-                currentPos.readIntoArray(serialisedFilePointer, 0, CAPABILITY_SIZE)
+                currentPos.readIntoArray(serialisedFilePointer, 0, READ_CAPABILITY_SIZE)
                         .thenCompose(bytesRead -> {
                             Capability pointer = Capability.fromByteArray(serialisedFilePointer);
-                            EntryPoint entry = new EntryPoint(pointer, ownerName, Collections.emptySet(), Collections.emptySet());
+                            EntryPoint entry = new EntryPoint(pointer, ownerName, owner, Collections.emptySet(), Collections.emptySet());
                             return network.retrieveEntryPoint(entry).thenCompose( optFTN -> {
                                 if(optFTN.isPresent()) {
                                     FileWrapper ftn = optFTN.get();

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -25,7 +25,7 @@ import java.util.stream.*;
  * Each of these cache files is just a serialized CapabilitiesFromUser
  */
 public class CapabilityStore {
-    public static final int READ_CAPABILITY_SIZE = 119; // fp.toCbor().toByteArray() DOESN'T INCLUDE .secret
+    public static final int READ_CAPABILITY_SIZE = 162; // fp.toCbor().toByteArray() DOESN'T INCLUDE .secret
     public static final int CAPS_PER_FILE = 10000;
     public static final int SHARING_FILE_MAX_SIZE = READ_CAPABILITY_SIZE * CAPS_PER_FILE;
     public static final String CAPABILITY_CACHE_DIR = ".capabilitycache";
@@ -196,8 +196,8 @@ public class CapabilityStore {
         return reader.seek( 0, offset).thenCompose( currentPos ->
                 currentPos.readIntoArray(serialisedFilePointer, 0, READ_CAPABILITY_SIZE)
                         .thenCompose(bytesRead -> {
-                            Capability pointer = Capability.fromByteArray(serialisedFilePointer);
-                            EntryPoint entry = new EntryPoint(pointer, ownerName, owner, Collections.emptySet(), Collections.emptySet());
+                            AbsoluteCapability pointer = AbsoluteCapability.fromCbor(CborObject.fromByteArray(serialisedFilePointer));
+                            EntryPoint entry = new EntryPoint(pointer, ownerName, Collections.emptySet(), Collections.emptySet());
                             return network.retrieveEntryPoint(entry).thenCompose( optFTN -> {
                                 if(optFTN.isPresent()) {
                                     FileWrapper ftn = optFTN.get();

--- a/src/peergos/shared/user/fs/CapabilityWithPath.java
+++ b/src/peergos/shared/user/fs/CapabilityWithPath.java
@@ -8,9 +8,9 @@ import java.util.TreeMap;
 
 public class CapabilityWithPath implements Cborable {
     public String path;
-    public Capability cap;
+    public AbsoluteCapability cap;
 
-    public CapabilityWithPath(String path, Capability cap) {
+    public CapabilityWithPath(String path, AbsoluteCapability cap) {
         this.path = path;
         this.cap = cap;
     }
@@ -28,7 +28,7 @@ public class CapabilityWithPath implements Cborable {
             throw new IllegalStateException("Incorrect cbor for CapabilityWithPath: " + cbor);
         SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
         CborObject.CborString path = (CborObject.CborString)map.get(new CborObject.CborString("p"));
-        Capability fp = Capability.fromCbor(map.get(new CborObject.CborString("c")));
+        AbsoluteCapability fp = AbsoluteCapability.fromCbor(map.get(new CborObject.CborString("c")));
         return new CapabilityWithPath(path.value, fp);
     }
 

--- a/src/peergos/shared/user/fs/EncryptedCapability.java
+++ b/src/peergos/shared/user/fs/EncryptedCapability.java
@@ -2,6 +2,7 @@ package peergos.shared.user.fs;
 
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.SymmetricKey;
 
 import java.util.*;
@@ -30,7 +31,7 @@ public class EncryptedCapability implements Cborable {
         return new EncryptedCapability(CipherText.build(from, cap));
     }
 
-    public static EncryptedCapability create(SymmetricKey from, SymmetricKey to, Location location) {
-        return create(from, new Capability(location, Optional.empty(), to));
+    public static EncryptedCapability create(SymmetricKey from, SymmetricKey to, Optional<PublicKeyHash> writer, byte[] mapKey) {
+        return create(from, new Capability(writer, mapKey, to, Optional.empty()));
     }
 }

--- a/src/peergos/shared/user/fs/EncryptedCapability.java
+++ b/src/peergos/shared/user/fs/EncryptedCapability.java
@@ -14,8 +14,8 @@ public class EncryptedCapability implements Cborable {
         this.cipherText = cipherText;
     }
 
-    public Capability toCapability(SymmetricKey baseKey) {
-        return cipherText.decrypt(baseKey, Capability::fromCbor);
+    public RelativeCapability toCapability(SymmetricKey baseKey) {
+        return cipherText.decrypt(baseKey, RelativeCapability::fromCbor);
     }
 
     @Override
@@ -27,11 +27,11 @@ public class EncryptedCapability implements Cborable {
         return new EncryptedCapability(CipherText.fromCbor(cbor));
     }
 
-    public static EncryptedCapability create(SymmetricKey from, Capability cap) {
+    public static EncryptedCapability create(SymmetricKey from, RelativeCapability cap) {
         return new EncryptedCapability(CipherText.build(from, cap));
     }
 
     public static EncryptedCapability create(SymmetricKey from, SymmetricKey to, Optional<PublicKeyHash> writer, byte[] mapKey) {
-        return create(from, new Capability(writer, mapKey, to, Optional.empty()));
+        return create(from, new RelativeCapability(writer, mapKey, to, Optional.empty()));
     }
 }

--- a/src/peergos/shared/user/fs/FileAccess.java
+++ b/src/peergos/shared/user/fs/FileAccess.java
@@ -106,48 +106,43 @@ public class FileAccess implements CryptreeNode {
         return retriever;
     }
 
-    public CompletableFuture<FileAccess> updateProperties(PublicKeyHash owner,
-                                                          PublicKeyHash writer,
-                                                          Capability writableCapability,
+    @Override
+    public CompletableFuture<FileAccess> updateProperties(WritableAbsoluteCapability us,
                                                           FileProperties newProps,
                                                           NetworkAccess network) {
-        if (! writableCapability.isWritable())
-            throw new IllegalStateException("Need a writable pointer!");
-        SymmetricKey metaKey = this.getMetaKey(writableCapability.baseKey);
+        SymmetricKey metaKey = this.getMetaKey(us.baseKey);
         boolean isDirty = metaKey.isDirty();
         // if the meta key is dirty then we need to generate a new one to not expose the new metadata
         if (isDirty)
             metaKey = SymmetricKey.random();
         SymmetricLink toMeta = isDirty ?
-                SymmetricLink.fromPair(writableCapability.baseKey, metaKey) :
+                SymmetricLink.fromPair(us.baseKey, metaKey) :
                 this.parent2meta;
 
         PaddedCipherText encryptedProperties = PaddedCipherText.build(metaKey, newProps, META_DATA_PADDING_BLOCKSIZE);
         FileAccess fa = new FileAccess(lastCommittedHash, version, toMeta, this.parent2data, encryptedProperties,
                 this.retriever, this.parentLink);
-        return Transaction.run(owner, tid ->
-                network.uploadChunk(fa, owner, writableCapability.getMapKey(), writableCapability.signer(writer), tid)
+        return Transaction.run(us.owner, tid ->
+                network.uploadChunk(fa, us.owner, us.getMapKey(), us.signer(), tid)
                         .thenApply(b -> fa),
                 network.dhtClient);
     }
 
-    public CompletableFuture<FileAccess> markDirty(PublicKeyHash owner,
-                                                   PublicKeyHash writer,
-                                                   Capability writableCapability,
+    public CompletableFuture<FileAccess> markDirty(WritableAbsoluteCapability us,
                                                    SymmetricKey newBaseKey,
                                                    NetworkAccess network) {
         // keep the same metakey and data key, just marked as dirty
-        SymmetricKey metaKey = this.getMetaKey(writableCapability.baseKey).makeDirty();
+        SymmetricKey metaKey = this.getMetaKey(us.baseKey).makeDirty();
         SymmetricLink newParentToMeta = SymmetricLink.fromPair(newBaseKey, metaKey);
 
-        SymmetricKey dataKey = this.getDataKey(writableCapability.baseKey).makeDirty();
+        SymmetricKey dataKey = this.getDataKey(us.baseKey).makeDirty();
         SymmetricLink newParentToData = SymmetricLink.fromPair(newBaseKey, dataKey);
 
         EncryptedCapability newParentLink = EncryptedCapability.create(newBaseKey,
-                parentLink.toCapability(writableCapability.baseKey));
+                parentLink.toCapability(us.baseKey));
         FileAccess fa = new FileAccess(committedHash(), version, newParentToMeta, newParentToData, properties, this.retriever, newParentLink);
-        return Transaction.run(owner, tid ->
-                network.uploadChunk(fa, owner, writableCapability.getMapKey(), writableCapability.signer(writer), tid)
+        return Transaction.run(us.owner, tid ->
+                network.uploadChunk(fa, us.owner, us.getMapKey(), us.signer(), tid)
                         .thenApply(x -> fa),
                 network.dhtClient);
     }
@@ -158,9 +153,7 @@ public class FileAccess implements CryptreeNode {
     }
 
     @Override
-    public CompletableFuture<? extends FileAccess> copyTo(PublicKeyHash currentOwner,
-                                                          PublicKeyHash currentWriter,
-                                                          SymmetricKey baseKey,
+    public CompletableFuture<? extends FileAccess> copyTo(AbsoluteCapability us,
                                                           SymmetricKey newBaseKey,
                                                           Location newParentLocation,
                                                           SymmetricKey parentparentKey,
@@ -168,14 +161,13 @@ public class FileAccess implements CryptreeNode {
                                                           byte[] newMapKey,
                                                           NetworkAccess network,
                                                           SafeRandom random) {
-        FileProperties props = getProperties(baseKey);
+        FileProperties props = getProperties(us.baseKey);
         boolean isDirectory = isDirectory();
         FileAccess fa = FileAccess.create(MaybeMultihash.empty(), newBaseKey, SymmetricKey.random(),
-                isDirectory ? SymmetricKey.random() : getDataKey(baseKey),
+                isDirectory ? SymmetricKey.random() : getDataKey(us.baseKey),
                 props, this.retriever, newParentLocation, parentparentKey);
-        Location newLocation = new Location(newParentLocation.owner, entryWriterKey.publicKeyHash, newMapKey);
         return Transaction.run(newParentLocation.owner,
-                tid -> network.uploadChunk(fa, newParentLocation.owner, newLocation.getMapKey(), entryWriterKey, tid)
+                tid -> network.uploadChunk(fa, newParentLocation.owner, newMapKey, entryWriterKey, tid)
                         .thenApply(b -> fa),
                 network.dhtClient);
     }

--- a/src/peergos/shared/user/fs/FileAccess.java
+++ b/src/peergos/shared/user/fs/FileAccess.java
@@ -3,7 +3,6 @@ package peergos.shared.user.fs;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
-import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.io.ipfs.multihash.*;
@@ -122,7 +121,7 @@ public class FileAccess implements CryptreeNode {
         PaddedCipherText encryptedProperties = PaddedCipherText.build(metaKey, newProps, META_DATA_PADDING_BLOCKSIZE);
         FileAccess fa = new FileAccess(lastCommittedHash, version, toMeta, this.parent2data, encryptedProperties,
                 this.retriever, this.parentLink);
-        return Transaction.run(us.owner, tid ->
+        return Transaction.call(us.owner, tid ->
                 network.uploadChunk(fa, us.owner, us.getMapKey(), us.signer(), tid)
                         .thenApply(b -> fa),
                 network.dhtClient);
@@ -141,7 +140,7 @@ public class FileAccess implements CryptreeNode {
         EncryptedCapability newParentLink = EncryptedCapability.create(newBaseKey,
                 parentLink.toCapability(us.baseKey));
         FileAccess fa = new FileAccess(committedHash(), version, newParentToMeta, newParentToData, properties, this.retriever, newParentLink);
-        return Transaction.run(us.owner, tid ->
+        return Transaction.call(us.owner, tid ->
                 network.uploadChunk(fa, us.owner, us.getMapKey(), us.signer(), tid)
                         .thenApply(x -> fa),
                 network.dhtClient);
@@ -166,7 +165,7 @@ public class FileAccess implements CryptreeNode {
         FileAccess fa = FileAccess.create(MaybeMultihash.empty(), newBaseKey, SymmetricKey.random(),
                 isDirectory ? SymmetricKey.random() : getDataKey(us.baseKey),
                 props, this.retriever, newParentLocation, parentparentKey);
-        return Transaction.run(newParentLocation.owner,
+        return Transaction.call(newParentLocation.owner,
                 tid -> network.uploadChunk(fa, newParentLocation.owner, newMapKey, entryWriterKey, tid)
                         .thenApply(b -> fa),
                 network.dhtClient);

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -128,8 +128,8 @@ public class FileUploader implements AutoCloseable {
                                                 hashes, Optional.of(encryptedNextChunkLocation), fragmenter);
                                 FileAccess metaBlob = FileAccess.create(chunk.existingHash, baseKey, SymmetricKey.random(),
                                         chunkKey, props, retriever, parentLocation, parentparentKey);
-                                return network.uploadChunk(metaBlob, new Location(chunk.location.owner,
-                                        writer.publicKeyHash, chunk.chunk.mapKey()), writer, tid);
+                                return network.uploadChunk(metaBlob, chunk.location.owner,
+                                        chunk.chunk.mapKey(), writer, tid);
                             }),
                     network.dhtClient);
         });

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -120,7 +120,7 @@ public class FileUploader implements AutoCloseable {
             LOG.info(StringUtils.format("Uploading chunk with %d fragments\n", fragments.size()));
             SymmetricKey chunkKey = chunk.chunk.key();
             CipherText encryptedNextChunkLocation = CipherText.build(chunkKey, nextChunkLocation);
-            return Transaction.run(chunk.location.owner, tid -> network
+            return Transaction.call(chunk.location.owner, tid -> network
                             .uploadFragments(fragments, chunk.location.owner, writer, monitor, fragmenter.storageIncreaseFactor(), tid)
                             .thenCompose(hashes -> {
                                 FileRetriever retriever =

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -170,7 +170,7 @@ public class FileWrapper {
 
             // Create new DirAccess, but don't upload it
             DirAccess newDirAccess = DirAccess.create(existing.committedHash(), newSubfoldersKey, props,
-                    parent.pointer.capability.relativise(pointer.capability), newParentKey);
+                    pointer.capability.relativise(parent.pointer.capability), newParentKey);
             // re add children
 
             List<RelativeCapability> children = existing.getChildren(pointer.capability.baseKey);

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -534,7 +534,7 @@ public class FileWrapper {
                                         Location nextChunkLocation = new Location(getLocation().owner, getLocation().writer, mapKey);
                                         return chunks.upload(network, random, parentLocation.owner, getSigner(), nextChunkLocation)
                                                 .thenCompose(fileLocation -> {
-                                                    RelativeCapability relativeCapability = new RelativeCapability(fileLocation.writer, fileLocation.getMapKey(), fileKey, Optional.empty());
+                                                    RelativeCapability relativeCapability = new RelativeCapability(Optional.of(fileLocation.writer), fileLocation.getMapKey(), fileKey, Optional.empty());
                                                     return addChildPointer(filename, relativeCapability.toAbsolute(pointer.capability), network, random, 2);
                                                 });
                                     }))

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -33,8 +33,9 @@ import java.util.stream.*;
 public class FileWrapper {
 	private static final Logger LOG = Logger.getGlobal();
 
-    final static int THUMBNAIL_SIZE = 100;
-    private final NativeJSThumbnail thumbnail;
+    private final static int THUMBNAIL_SIZE = 100;
+    private static final NativeJSThumbnail thumbnail = new NativeJSThumbnail();
+
     private final RetrievedCapability pointer;
     private final FileProperties props;
     private final String ownername;
@@ -61,7 +62,6 @@ public class FileWrapper {
             SymmetricKey parentKey = this.getParentKey();
             props = pointer.fileAccess.getProperties(parentKey);
         }
-        thumbnail = new NativeJSThumbnail();
     }
 
     public FileWrapper(RetrievedCapability pointer, String ownername,

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -38,18 +38,6 @@ public class RelativeCapability implements Cborable {
         this(Optional.empty(), mapKey, baseKey, Optional.empty());
     }
 
-    public RelativeCapability(PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
-        this(Optional.of(writer), mapKey, baseKey, signer);
-    }
-
-    public RelativeCapability(PublicKeyHash signer, byte[] mapKey, SymmetricKey baseKey) {
-        this(Optional.of(signer), mapKey, baseKey, Optional.empty());
-    }
-
-    public RelativeCapability(SigningPrivateKeyAndPublicHash signer, byte[] mapKey, SymmetricKey baseKey) {
-        this(Optional.of(signer.publicKeyHash), mapKey, baseKey, Optional.of(signer.secret));
-    }
-
     @JsMethod
     public byte[] getMapKey() {
         return Arrays.copyOf(mapKey, mapKey.length);

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -6,14 +6,11 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.SymmetricKey;
-import peergos.shared.io.ipfs.multibase.*;
 import peergos.shared.util.*;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-/** This provides a relative crytographic capability for reading a file or folder. It is assumed the holder also has
+/** This provides a relative cryptographic capability for reading a file or folder. It is assumed the holder also has
  * the owner key, and possibly the writer key (if absent here) externally.
  *
  */

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -13,7 +13,11 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class Capability implements Cborable {
+/** This provides a relative crytographic capability for reading a file or folder. It is assumed the holder also has
+ * the owner key, and possibly the writer key (if absent here) externally.
+ *
+ */
+public class RelativeCapability implements Cborable {
     // writer is only present when it is not implicit (an entry point, or a child link to a different writing key)
     public final Optional<PublicKeyHash> writer;
     private final byte[] mapKey;
@@ -21,7 +25,7 @@ public class Capability implements Cborable {
     public final Optional<SecretSigningKey> signer;
 
     @JsConstructor
-    public Capability(Optional<PublicKeyHash> writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
+    public RelativeCapability(Optional<PublicKeyHash> writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
         this.writer = writer;
         if (mapKey.length != Location.MAP_KEY_LENGTH)
             throw new IllegalStateException("Invalid map key length: " + mapKey.length);
@@ -30,19 +34,19 @@ public class Capability implements Cborable {
         this.signer = signer;
     }
 
-    public Capability(byte[] mapKey, SymmetricKey baseKey) {
+    public RelativeCapability(byte[] mapKey, SymmetricKey baseKey) {
         this(Optional.empty(), mapKey, baseKey, Optional.empty());
     }
 
-    public Capability(PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
+    public RelativeCapability(PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
         this(Optional.of(writer), mapKey, baseKey, signer);
     }
 
-    public Capability(PublicKeyHash signer, byte[] mapKey, SymmetricKey baseKey) {
+    public RelativeCapability(PublicKeyHash signer, byte[] mapKey, SymmetricKey baseKey) {
         this(Optional.of(signer), mapKey, baseKey, Optional.empty());
     }
 
-    public Capability(SigningPrivateKeyAndPublicHash signer, byte[] mapKey, SymmetricKey baseKey) {
+    public RelativeCapability(SigningPrivateKeyAndPublicHash signer, byte[] mapKey, SymmetricKey baseKey) {
         this(Optional.of(signer.publicKeyHash), mapKey, baseKey, Optional.of(signer.secret));
     }
 
@@ -61,12 +65,16 @@ public class Capability implements Cborable {
         return new SigningPrivateKeyAndPublicHash(this.writer.orElse(writer), signer.get());
     }
 
-    public Capability withBaseKey(SymmetricKey newBaseKey) {
-        return new Capability(writer, mapKey, newBaseKey, signer);
+    public AbsoluteCapability toAbsolute(AbsoluteCapability source) {
+        return new AbsoluteCapability(source.owner, writer.orElse(source.writer), mapKey, baseKey, signer);
     }
 
-    public Capability withWritingKey(PublicKeyHash writingKey) {
-        return new Capability(Optional.of(writingKey), mapKey, baseKey, Optional.empty());
+    public RelativeCapability withBaseKey(SymmetricKey newBaseKey) {
+        return new RelativeCapability(writer, mapKey, newBaseKey, signer);
+    }
+
+    public RelativeCapability withWritingKey(PublicKeyHash writingKey) {
+        return new RelativeCapability(Optional.of(writingKey), mapKey, baseKey, Optional.empty());
     }
 
     @Override
@@ -79,13 +87,13 @@ public class Capability implements Cborable {
         return CborObject.CborMap.build(cbor);
     }
 
-    public static Capability fromByteArray(byte[] raw) {
+    public static RelativeCapability fromByteArray(byte[] raw) {
         return fromCbor(CborObject.fromByteArray(raw));
     }
 
-    public static Capability fromCbor(Cborable cbor) {
+    public static RelativeCapability fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
-            throw new IllegalStateException("Incorrect cbor for Capability: " + cbor);
+            throw new IllegalStateException("Incorrect cbor for RelativeCapability: " + cbor);
         SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
 
         Optional<PublicKeyHash> writer = Optional.ofNullable(map.get(new CborObject.CborString("w")))
@@ -94,13 +102,13 @@ public class Capability implements Cborable {
         SymmetricKey baseKey = SymmetricKey.fromCbor(map.get(new CborObject.CborString("k")));
         Optional<SecretSigningKey> signer = Optional.ofNullable(map.get(new CborObject.CborString("s")))
                 .map(SecretSigningKey::fromCbor);
-        return new Capability(writer, mapKey, baseKey, signer);
+        return new RelativeCapability(writer, mapKey, baseKey, signer);
     }
 
-    public Capability readOnly() {
+    public RelativeCapability readOnly() {
         if (!isWritable())
             return this;
-        return new Capability(writer, mapKey, baseKey, Optional.empty());
+        return new RelativeCapability(writer, mapKey, baseKey, Optional.empty());
     }
 
     public boolean isWritable() {
@@ -111,7 +119,7 @@ public class Capability implements Cborable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Capability that = (Capability) o;
+        RelativeCapability that = (RelativeCapability) o;
         return Objects.equals(writer, that.writer) &&
                 Arrays.equals(mapKey, that.mapKey) &&
                 Objects.equals(baseKey, that.baseKey) &&
@@ -128,49 +136,5 @@ public class Capability implements Cborable {
     @Override
     public String toString() {
         return ArrayOps.bytesToHex(getMapKey());
-    }
-
-    public boolean isNull() {
-        PublicKeyHash nullUser = PublicKeyHash.NULL;
-        return writer.map(w -> nullUser.equals(w)).orElse(true) &&
-                Arrays.equals(getMapKey(), new byte[32]) &&
-                baseKey.equals(SymmetricKey.createNull());
-    }
-
-    public String toLink(PublicKeyHash owner, PublicKeyHash writer) {
-        String encodedOwnerKey = Base58.encode(owner.serialize());
-        String encodedWriterKey = Base58.encode(writer.serialize());
-        String encodedMapKey = Base58.encode(getMapKey());
-        String encodedBaseKey = Base58.encode(baseKey.serialize());
-        return Stream.of(encodedOwnerKey, encodedWriterKey, encodedMapKey, encodedBaseKey)
-                .collect(Collectors.joining("/", "#", ""));
-    }
-
-    public static Capability fromLink(String keysString) {
-        if (keysString.startsWith("#"))
-            keysString = keysString.substring(1);
-
-        String[] split = keysString.split("/");
-        if (split.length != 4)
-            throw new IllegalStateException("Invalid public link "+ keysString);
-
-        PublicKeyHash writer = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[1])));
-        byte[] mapKey = Base58.decode(split[2]);
-        SymmetricKey baseKey = SymmetricKey.fromByteArray(Base58.decode(split[3]));
-        return new Capability(writer, mapKey, baseKey);
-    }
-
-    public static PublicKeyHash parseOwner(String keysString) {
-        if (keysString.startsWith("#"))
-            keysString = keysString.substring(1);
-        String[] split = keysString.split("/");
-        if (split.length != 4)
-            throw new IllegalStateException("Invalid public link "+ keysString);
-
-        return PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[0])));
-    }
-
-    public static Capability createNull() {
-        return new Capability(PublicKeyHash.NULL, new byte[32], SymmetricKey.createNull());
     }
 }

--- a/src/peergos/shared/user/fs/RetrievedCapability.java
+++ b/src/peergos/shared/user/fs/RetrievedCapability.java
@@ -3,7 +3,6 @@ package peergos.shared.user.fs;
 import peergos.shared.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
-import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
 import peergos.shared.user.fs.cryptree.*;
 
@@ -36,7 +35,7 @@ public class RetrievedCapability {
             return CompletableFuture.completedFuture(false);
         if (! fileAccess.isDirectory()) {
             CompletableFuture<Boolean> result = new CompletableFuture<>();
-            Transaction.run(capability.owner,
+            Transaction.call(capability.owner,
                     tid -> network.tree.remove(capability.owner, signer, capability.getMapKey(), fileAccess.committedHash(), tid).thenAccept(removed -> {
                         // remove from parent
                         if (parentRetrievedCapability != null)
@@ -50,7 +49,7 @@ public class RetrievedCapability {
             for (RetrievedCapability file : files)
                 file.remove(network, null, signer);
             CompletableFuture<Boolean> result = new CompletableFuture<>();
-            Transaction.run(capability.owner,
+            Transaction.call(capability.owner,
                     tid -> network.tree.remove(capability.owner, signer, capability.getMapKey(), fileAccess.committedHash(), tid).thenAccept(removed -> {
                         // remove from parent
                         if (parentRetrievedCapability != null)

--- a/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
@@ -1,0 +1,19 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.symmetric.*;
+
+import java.util.*;
+
+public class WritableAbsoluteCapability extends AbsoluteCapability {
+
+    public WritableAbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, SecretSigningKey signer) {
+        super(owner, writer, mapKey, baseKey, Optional.of(signer));
+    }
+
+    public SigningPrivateKeyAndPublicHash signer() {
+        return new SigningPrivateKeyAndPublicHash(writer, signer.get());
+    }
+}

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -36,17 +36,13 @@ public interface CryptreeNode extends Cborable {
 
     FileProperties getProperties(SymmetricKey parentKey);
 
-    CompletableFuture<? extends CryptreeNode> updateProperties(PublicKeyHash owner,
-                                                               PublicKeyHash writer,
-                                                               Capability writableCapability,
+    CompletableFuture<? extends CryptreeNode> updateProperties(WritableAbsoluteCapability us,
                                                                FileProperties newProps,
                                                                NetworkAccess network);
 
     boolean isDirty(SymmetricKey baseKey);
 
-    CompletableFuture<? extends CryptreeNode> copyTo(PublicKeyHash currentOwner,
-                                                     PublicKeyHash currentWriter,
-                                                     SymmetricKey baseKey,
+    CompletableFuture<? extends CryptreeNode> copyTo(AbsoluteCapability us,
                                                      SymmetricKey newBaseKey,
                                                      Location newParentLocation,
                                                      SymmetricKey parentparentKey,
@@ -63,7 +59,8 @@ public interface CryptreeNode extends Cborable {
         if (parentLink == null)
             return CompletableFuture.completedFuture(null);
 
-        return network.retrieveAllMetadata(Arrays.asList(new Triple<>(owner, writer, parentLink.toCapability(baseKey)))).thenApply(res -> {
+        RelativeCapability relCap = parentLink.toCapability(baseKey);
+        return network.retrieveAllMetadata(Arrays.asList(new AbsoluteCapability(owner, writer, relCap.getMapKey(), relCap.baseKey, relCap.signer))).thenApply(res -> {
             RetrievedCapability retrievedCapability = res.stream().findAny().get();
             return retrievedCapability;
         });


### PR DESCRIPTION
This makes all locations in Peergos relative. That means the owner and writer are no longer explicit in child links. Both are present in entry points and public links still. and the writer will be present on a child link to a file with a different writing key (or the reverse parent link).

This paves the way for granting write access. 

This is now the 5th pending PR. 
Review these before this, @cboddy, as this depends on them :
https://github.com/Peergos/Peergos/pull/350
https://github.com/Peergos/Peergos/pull/354
https://github.com/Peergos/Peergos/pull/357
https://github.com/Peergos/Peergos/pull/359