### PR TITLE
Implement the write cryptree

### DIFF
--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -109,7 +109,7 @@ public class MultiUserTests {
 
         // check that the copied file has the correct contents
         UserTests.checkFileContents(data, copy, u2);
-        Assert.assertTrue("Different base key", ! copy.getPointer().capability.baseKey.equals(u1File.getPointer().capability.baseKey));
+        Assert.assertTrue("Different base key", ! copy.getPointer().capability.rBaseKey.equals(u1File.getPointer().capability.rBaseKey));
         Assert.assertTrue("Different metadata key", ! UserTests.getMetaKey(copy).equals(UserTests.getMetaKey(u1File)));
         Assert.assertTrue("Different data key", ! UserTests.getDataKey(copy).equals(UserTests.getDataKey(u1File)));
     }
@@ -242,7 +242,7 @@ public class MultiUserTests {
         AbsoluteCapability priorPointer = priorUnsharedView.get().getPointer().capability;
         Location priorLocation = priorPointer.getLocation();
         CryptreeNode priorFileAccess = network.getMetadata(priorLocation).get().get();
-        SymmetricKey priorMetaKey = priorFileAccess.getMetaKey(priorPointer.baseKey);
+        SymmetricKey priorMetaKey = priorFileAccess.getMetaKey(priorPointer.rBaseKey);
 
         // unshare with a single user
         u1.unShare(Paths.get(u1.username, filename), userToUnshareWith.username).get();
@@ -266,7 +266,7 @@ public class MultiUserTests {
             throw new IllegalStateException("We shouldn't be able to decrypt this after a rename! new name = " + props.name);
         } catch (TweetNaCl.InvalidCipherTextException e) {}
         try {
-            FileProperties freshProperties = fileAccess.getProperties(priorPointer.baseKey);
+            FileProperties freshProperties = fileAccess.getProperties(priorPointer.rBaseKey);
             throw new IllegalStateException("We shouldn't be able to decrypt this after a rename!");
         } catch (TweetNaCl.InvalidCipherTextException e) {}
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -771,18 +771,18 @@ public abstract class UserTests {
         FileWrapper subfolder = context.getByPath(home.resolve(foldername).toString()).get().get();
         FileWrapper parentDir = original.copyTo(subfolder, network, crypto.random, context.fragmenter()).get();
         FileWrapper copy = context.getByPath(home.resolve(foldername).resolve(filename).toString()).get().get();
-        Assert.assertTrue("Different base key", ! copy.getPointer().capability.baseKey.equals(original.getPointer().capability.baseKey));
+        Assert.assertTrue("Different base key", ! copy.getPointer().capability.rBaseKey.equals(original.getPointer().capability.rBaseKey));
         Assert.assertTrue("Different metadata key", ! getMetaKey(copy).equals(getMetaKey(original)));
         Assert.assertTrue("Same data key", getDataKey(copy).equals(getDataKey(original)));
         checkFileContents(data, copy, context);
     }
 
     public static SymmetricKey getDataKey(FileWrapper file) {
-        return ((FileAccess)file.getPointer().fileAccess).getDataKey(file.getPointer().capability.baseKey);
+        return ((FileAccess)file.getPointer().fileAccess).getDataKey(file.getPointer().capability.rBaseKey);
     }
 
     public static SymmetricKey getMetaKey(FileWrapper file) {
-        return file.getPointer().fileAccess.getMetaKey(file.getPointer().capability.baseKey);
+        return file.getPointer().fileAccess.getMetaKey(file.getPointer().capability.rBaseKey);
     }
 
     @Test

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -248,8 +248,7 @@ public class NetworkAccess {
 
     public CompletableFuture<Optional<FileWrapper>> retrieveEntryPoint(EntryPoint e) {
         return downloadEntryPoint(e)
-                .thenApply(faOpt ->faOpt.map(fa -> new FileWrapper(new RetrievedCapability(e.pointer, fa), e.ownerName,
-                        e.pointer.signer)))
+                .thenApply(faOpt ->faOpt.map(fa -> new FileWrapper(new RetrievedCapability(e.pointer, fa), e.ownerName)))
                 .exceptionally(t -> Optional.empty());
     }
 

--- a/src/peergos/shared/crypto/CipherText.java
+++ b/src/peergos/shared/crypto/CipherText.java
@@ -39,7 +39,7 @@ public class CipherText implements Cborable {
         return new CipherText(nonce, cipherText);
     }
 
-    public <T> T decrypt(SymmetricKey from, Function<Cborable, T> fromCbor) {
+    public <T> T decrypt(SymmetricKey from, Function<CborObject, T> fromCbor) {
         byte[] secret = from.decrypt(cipherText, nonce);
         return fromCbor.apply(CborObject.fromByteArray(secret));
     }

--- a/src/peergos/shared/crypto/PaddedCipherText.java
+++ b/src/peergos/shared/crypto/PaddedCipherText.java
@@ -40,7 +40,7 @@ public class PaddedCipherText implements Cborable {
         return new PaddedCipherText(new CipherText(nonce, cipherText));
     }
 
-    public <T> T decrypt(SymmetricKey from, Function<Cborable, T> fromCbor) {
+    public <T> T decrypt(SymmetricKey from, Function<CborObject, T> fromCbor) {
         return cipherText.decrypt(from, fromCbor);
     }
 }

--- a/src/peergos/shared/crypto/SigningPrivateKeyAndPublicHash.java
+++ b/src/peergos/shared/crypto/SigningPrivateKeyAndPublicHash.java
@@ -1,14 +1,34 @@
 package peergos.shared.crypto;
 
+import peergos.shared.cbor.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 
-public class SigningPrivateKeyAndPublicHash {
+import java.util.*;
+
+public class SigningPrivateKeyAndPublicHash implements Cborable {
     public final PublicKeyHash publicKeyHash;
     public final SecretSigningKey secret;
 
     public SigningPrivateKeyAndPublicHash(PublicKeyHash publicKeyHash, SecretSigningKey secret) {
         this.publicKeyHash = publicKeyHash;
         this.secret = secret;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        Map<String, CborObject> result = new TreeMap<>();
+        result.put("p", publicKeyHash.toCbor());
+        result.put("s", secret.toCbor());
+        return CborObject.CborMap.build(result);
+    }
+
+    public static SigningPrivateKeyAndPublicHash fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for SigningPrivateKeyAndPublicHash: " + cbor);
+        CborObject.CborMap map = (CborObject.CborMap) cbor;
+        PublicKeyHash publicKeyHash = PublicKeyHash.fromCbor(map.get("p"));
+        SecretSigningKey secretKey = SecretSigningKey.fromCbor(map.get("s"));
+        return new SigningPrivateKeyAndPublicHash(publicKeyHash, secretKey);
     }
 }

--- a/src/peergos/shared/crypto/SymmetricLinkToSigner.java
+++ b/src/peergos/shared/crypto/SymmetricLinkToSigner.java
@@ -1,0 +1,35 @@
+package peergos.shared.crypto;
+
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.symmetric.*;
+
+/** A symmetric link is a link from a symmetric key to a signing keypair, as defined in cryptree.
+ *
+ * This means the target keys are encrypted with the source key.
+ *
+ */
+public class SymmetricLinkToSigner implements Cborable
+{
+    private final CipherText cipherText;
+
+    public SymmetricLinkToSigner(CipherText cipherText) {
+        this.cipherText = cipherText;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        return cipherText.toCbor();
+    }
+
+    public SigningPrivateKeyAndPublicHash target(SymmetricKey from) {
+        return cipherText.decrypt(from, SigningPrivateKeyAndPublicHash::fromCbor);
+    }
+
+    public static SymmetricLinkToSigner fromCbor(Cborable cbor) {
+        return new SymmetricLinkToSigner(CipherText.fromCbor(cbor));
+    }
+
+    public static SymmetricLinkToSigner fromPair(SymmetricKey from, SigningPrivateKeyAndPublicHash to) {
+        return new SymmetricLinkToSigner(CipherText.build(from, to));
+    }
+}

--- a/src/peergos/shared/user/fs/AbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/AbsoluteCapability.java
@@ -18,21 +18,28 @@ public class AbsoluteCapability implements Cborable {
 
     public final PublicKeyHash owner, writer;
     private final byte[] mapKey;
-    public final SymmetricKey baseKey;
+    public final SymmetricKey rBaseKey;
+    public final Optional<SymmetricKey> wBaseKey;
     public final Optional<SecretSigningKey> signer;
 
-    public AbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, Optional<SecretSigningKey> signer) {
+    public AbsoluteCapability(PublicKeyHash owner,
+                              PublicKeyHash writer,
+                              byte[] mapKey,
+                              SymmetricKey rBaseKey,
+                              Optional<SymmetricKey> wBaseKey,
+                              Optional<SecretSigningKey> signer) {
         if (mapKey.length != Location.MAP_KEY_LENGTH)
             throw new IllegalStateException("Invalid map key length: " + mapKey.length);
         this.owner = owner;
         this.writer = writer;
         this.mapKey = mapKey;
-        this.baseKey = baseKey;
+        this.rBaseKey = rBaseKey;
+        this.wBaseKey = wBaseKey;
         this.signer = signer;
     }
 
-    public AbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey) {
-        this(owner, writer, mapKey, baseKey, Optional.empty());
+    public AbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey rBaseKey) {
+        this(owner, writer, mapKey, rBaseKey, Optional.empty(), Optional.empty());
     }
 
     @JsMethod
@@ -54,25 +61,17 @@ public class AbsoluteCapability implements Cborable {
         return signer.isPresent();
     }
 
-    public RelativeCapability relativise(AbsoluteCapability descendant) {
-        if (! Objects.equals(owner, descendant.owner))
-            throw new IllegalStateException("Files with different owners can't be descendant of each other!");
-        if (Objects.equals(writer, descendant.writer))
-            return new RelativeCapability(Optional.empty(), descendant.getMapKey(), descendant.baseKey, descendant.signer);
-        return new RelativeCapability(Optional.of(descendant.writer), descendant.getMapKey(), descendant.baseKey, descendant.signer);
-    }
-
-    public WritableAbsoluteCapability toWritable(SigningPrivateKeyAndPublicHash signer) {
+    public WritableAbsoluteCapability toWritable(SymmetricKey writeBaseKey, SigningPrivateKeyAndPublicHash signer) {
         if (! signer.publicKeyHash.equals(writer))
             throw new IllegalStateException("Incorrect signing keyPair to make this capability writable!");
-        return new WritableAbsoluteCapability(owner, writer, mapKey, baseKey, signer.secret);
+        return new WritableAbsoluteCapability(owner, writer, mapKey, rBaseKey, writeBaseKey, signer.secret);
     }
 
     public String toLink() {
         String encodedOwnerKey = Base58.encode(owner.serialize());
         String encodedWriterKey = Base58.encode(writer.serialize());
         String encodedMapKey = Base58.encode(mapKey);
-        String encodedBaseKey = Base58.encode(baseKey.serialize());
+        String encodedBaseKey = Base58.encode(rBaseKey.serialize());
         return Stream.of(encodedOwnerKey, encodedWriterKey, encodedMapKey, encodedBaseKey)
                 .collect(Collectors.joining("/", "#", ""));
     }
@@ -89,17 +88,17 @@ public class AbsoluteCapability implements Cborable {
         PublicKeyHash writer = PublicKeyHash.fromCbor(CborObject.fromByteArray(Base58.decode(split[1])));
         byte[] mapKey = Base58.decode(split[2]);
         SymmetricKey baseKey = SymmetricKey.fromByteArray(Base58.decode(split[3]));
-        return new AbsoluteCapability(owner, writer, mapKey, baseKey, Optional.empty());
+        return new AbsoluteCapability(owner, writer, mapKey, baseKey, Optional.empty(), Optional.empty());
     }
 
     public AbsoluteCapability readOnly() {
         if (!isWritable())
             return this;
-        return new AbsoluteCapability(owner, writer, mapKey, baseKey, Optional.empty());
+        return new AbsoluteCapability(owner, writer, mapKey, rBaseKey, Optional.empty(), Optional.empty());
     }
 
     public AbsoluteCapability withBaseKey(SymmetricKey newBaseKey) {
-        return new AbsoluteCapability(owner, writer, mapKey, newBaseKey, signer);
+        return new AbsoluteCapability(owner, writer, mapKey, newBaseKey, wBaseKey, signer);
     }
 
     public boolean isNull() {
@@ -107,7 +106,7 @@ public class AbsoluteCapability implements Cborable {
         return nullUser.equals(owner) &&
                 nullUser.equals(writer) &&
                 Arrays.equals(getMapKey(), new byte[32]) &&
-                baseKey.equals(SymmetricKey.createNull()) &&
+                rBaseKey.equals(SymmetricKey.createNull()) &&
                 ! signer.isPresent();
     }
 
@@ -121,7 +120,8 @@ public class AbsoluteCapability implements Cborable {
         cbor.put("o", owner.toCbor());
         cbor.put("w", writer.toCbor());
         cbor.put("m", new CborObject.CborByteArray(mapKey));
-        cbor.put("k", baseKey.toCbor());
+        cbor.put("k", rBaseKey.toCbor());
+        wBaseKey.ifPresent(wk -> cbor.put("b", wk.toCbor()));
         signer.ifPresent(secret -> cbor.put("s", secret.toCbor()));
         return CborObject.CborMap.build(cbor);
     }
@@ -129,15 +129,18 @@ public class AbsoluteCapability implements Cborable {
     public static AbsoluteCapability fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor for AbsoluteCapability: " + cbor);
-        SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
+        CborObject.CborMap map = ((CborObject.CborMap) cbor);
 
-        PublicKeyHash owner = PublicKeyHash.fromCbor(map.get(new CborObject.CborString("o")));
-        PublicKeyHash writer = PublicKeyHash.fromCbor(map.get(new CborObject.CborString("w")));
-        byte[] mapKey = ((CborObject.CborByteArray)map.get(new CborObject.CborString("m"))).value;
-        SymmetricKey baseKey = SymmetricKey.fromCbor(map.get(new CborObject.CborString("k")));
-        Optional<SecretSigningKey> signer = Optional.ofNullable(map.get(new CborObject.CborString("s")))
+        PublicKeyHash owner = PublicKeyHash.fromCbor(map.get("o"));
+        PublicKeyHash writer = PublicKeyHash.fromCbor(map.get("w"));
+        byte[] mapKey = ((CborObject.CborByteArray)map.get("m")).value;
+        SymmetricKey baseKey = SymmetricKey.fromCbor(map.get("k"));
+        Optional<SymmetricKey> writerBaseKey = Optional.ofNullable(map.get("b")).map(SymmetricKey::fromCbor);
+        Optional<SecretSigningKey> signer = Optional.ofNullable(map.get("s"))
                 .map(SecretSigningKey::fromCbor);
-        return new AbsoluteCapability(owner, writer, mapKey, baseKey, signer);
+        if (writerBaseKey.isPresent() && signer.isPresent())
+            return new WritableAbsoluteCapability(owner, writer, mapKey, baseKey, writerBaseKey.get(), signer.get());
+        return new AbsoluteCapability(owner, writer, mapKey, baseKey, writerBaseKey, signer);
     }
 
     @Override
@@ -148,13 +151,13 @@ public class AbsoluteCapability implements Cborable {
         return Objects.equals(owner, that.owner) &&
                 Objects.equals(writer, that.writer) &&
                 Arrays.equals(mapKey, that.mapKey) &&
-                Objects.equals(baseKey, that.baseKey) &&
+                Objects.equals(rBaseKey, that.rBaseKey) &&
                 Objects.equals(signer, that.signer);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(owner, writer, baseKey, signer);
+        int result = Objects.hash(owner, writer, rBaseKey, signer);
         result = 31 * result + Arrays.hashCode(mapKey);
         return result;
     }

--- a/src/peergos/shared/user/fs/EncryptedCapability.java
+++ b/src/peergos/shared/user/fs/EncryptedCapability.java
@@ -32,6 +32,6 @@ public class EncryptedCapability implements Cborable {
     }
 
     public static EncryptedCapability create(SymmetricKey from, SymmetricKey to, Optional<PublicKeyHash> writer, byte[] mapKey) {
-        return create(from, new RelativeCapability(writer, mapKey, to, Optional.empty()));
+        return create(from, new RelativeCapability(writer, mapKey, to, Optional.empty(), Optional.empty()));
     }
 }

--- a/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
@@ -9,8 +9,22 @@ import java.util.*;
 
 public class WritableAbsoluteCapability extends AbsoluteCapability {
 
-    public WritableAbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, SecretSigningKey signer) {
-        super(owner, writer, mapKey, baseKey, Optional.of(signer));
+    public WritableAbsoluteCapability(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey, SymmetricKey baseKey, SymmetricKey wBaseKey, SecretSigningKey signer) {
+        super(owner, writer, mapKey, baseKey, Optional.of(wBaseKey), Optional.of(signer));
+    }
+
+    public RelativeCapability relativise(WritableAbsoluteCapability descendant) {
+        if (! Objects.equals(owner, descendant.owner))
+            throw new IllegalStateException("Files with different owners can't be descendant of each other!");
+        SymmetricLink writerLink = SymmetricLink.fromPair(wBaseKey.get(), descendant.wBaseKey.get());
+        if (Objects.equals(writer, descendant.writer))
+            return new RelativeCapability(Optional.empty(), descendant.getMapKey(), descendant.rBaseKey, Optional.of(writerLink), descendant.signer);
+        return new RelativeCapability(Optional.of(descendant.writer), descendant.getMapKey(), descendant.rBaseKey, Optional.of(writerLink), descendant.signer);
+    }
+
+    @Override
+    public WritableAbsoluteCapability withBaseKey(SymmetricKey newBaseKey) {
+        return new WritableAbsoluteCapability(owner, writer, getMapKey(), newBaseKey, wBaseKey.get(), signer.get());
     }
 
     public SigningPrivateKeyAndPublicHash signer() {

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -8,7 +8,6 @@ import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.user.fs.*;
-import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -44,9 +43,8 @@ public interface CryptreeNode extends Cborable {
 
     CompletableFuture<? extends CryptreeNode> copyTo(AbsoluteCapability us,
                                                      SymmetricKey newBaseKey,
-                                                     Location newParentLocation,
+                                                     WritableAbsoluteCapability newParentCap,
                                                      SymmetricKey parentparentKey,
-                                                     SigningPrivateKeyAndPublicHash entryWriterKey,
                                                      byte[] newMapKey,
                                                      NetworkAccess network,
                                                      SafeRandom random);
@@ -60,7 +58,8 @@ public interface CryptreeNode extends Cborable {
             return CompletableFuture.completedFuture(null);
 
         RelativeCapability relCap = parentLink.toCapability(baseKey);
-        return network.retrieveAllMetadata(Arrays.asList(new AbsoluteCapability(owner, writer, relCap.getMapKey(), relCap.baseKey, relCap.signer))).thenApply(res -> {
+        return network.retrieveAllMetadata(Arrays.asList(new AbsoluteCapability(owner, writer, relCap.getMapKey(),
+                relCap.rBaseKey, Optional.empty(), Optional.empty()))).thenApply(res -> {
             RetrievedCapability retrievedCapability = res.stream().findAny().get();
             return retrievedCapability;
         });


### PR DESCRIPTION
This implements the write cryptree. 

This is much simpler than the read cryptree. Every folder or file gets a new symmetric key, the write base key. Then if a child has a different signing keypair than its parent then it will include a SymmetricLinkToSigner from its write base key to the signing key pair. 

Child links now include a new symmetric link from the dir base write key to the child base write key. 