### PR TITLE
Relativise links to subsequent chunks of files

### DIFF
--- a/src/peergos/shared/user/fs/FileRetriever.java
+++ b/src/peergos/shared/user/fs/FileRetriever.java
@@ -11,7 +11,12 @@ import java.util.concurrent.*;
 
 public interface FileRetriever extends Cborable {
 
-    Optional<Location> getNext(SymmetricKey dataKey);
+    /**
+     *
+     * @param dataKey
+     * @return the map key of the next chunk in this file
+     */
+    Optional<byte[]> getNext(SymmetricKey dataKey);
 
     byte[] getNonce();
 
@@ -32,7 +37,7 @@ public interface FileRetriever extends Cborable {
                                                                          NetworkAccess network,
                                                                          ProgressConsumer<Long> monitor);
 
-    CompletableFuture<Optional<Location>> getLocationAt(Location startLocation,
+    CompletableFuture<Optional<byte[]>> getLocationAt(Location startLocation,
                                                         long offset,
                                                         SymmetricKey dataKey,
                                                         NetworkAccess network);

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -3,6 +3,7 @@ import java.util.logging.*;
 
 import jsinterop.annotations.*;
 import peergos.shared.*;
+import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.*;
@@ -119,7 +120,7 @@ public class FileUploader implements AutoCloseable {
             List<Fragment> fragments = encryptedChunk.generateFragments(fragmenter);
             LOG.info(StringUtils.format("Uploading chunk with %d fragments\n", fragments.size()));
             SymmetricKey chunkKey = chunk.chunk.key();
-            CipherText encryptedNextChunkLocation = CipherText.build(chunkKey, nextChunkLocation);
+            CipherText encryptedNextChunkLocation = CipherText.build(chunkKey, new CborObject.CborByteArray(nextChunkLocation.getMapKey()));
             return Transaction.call(chunk.location.owner, tid -> network
                             .uploadFragments(fragments, chunk.location.owner, writer, monitor, fragmenter.storageIncreaseFactor(), tid)
                             .thenCompose(hashes -> {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -629,7 +629,8 @@ public class FileWrapper {
                         child.getLocation(), child.pointer.fileAccess.committedHash(), monitor)
                         .thenCompose(currentLocation -> {
                                     CompletableFuture<Optional<Location>> locationAt = retriever
-                                            .getLocationAt(child.getLocation(), startIndex + Chunk.MAX_SIZE, dataKey, network);
+                                            .getLocationAt(child.getLocation(), startIndex + Chunk.MAX_SIZE, dataKey, network)
+                                            .thenApply(x -> x.map(m -> getLocation().withMapKey(m)));
                                     return locationAt.thenCompose(location ->
                                             CompletableFuture.completedFuture(new Pair<>(currentLocation, location)));
                                 }

--- a/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
+++ b/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
@@ -64,7 +64,7 @@ public class LazyInputStreamCombiner implements AsyncReader {
                 if (! (access instanceof FileAccess))
                     throw new IllegalStateException("File linked to a directory for its next chunk!");
                 FileRetriever nextRet = ((FileAccess) access).retriever();
-                Location newNextChunkPointer = nextRet.getNext(dataKey).orElse(null);
+                Location newNextChunkPointer = nextRet.getNext(dataKey).map(nextLocation::withMapKey).orElse(null);
                 return nextRet.getChunkInputStream(network, random, dataKey, 0, len, nextLocation, access.committedHash(), monitor)
                         .thenApply(x -> {
                             byte[] nextData = x.get().chunk.data();


### PR DESCRIPTION
These shouldn't include the owner or signer public key anymore. 

This is important when granting write access to avoid many unnecessary operations. 