### PR TITLE
Cleanup stale chunks on write access grant

### DIFF
--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -337,6 +337,15 @@ public class NetworkAccess {
                 .thenApply(res -> metadata.committedHash().get());
     }
 
+    public CompletableFuture<Multihash> deleteChunk(CryptreeNode metadata,
+                                                    PublicKeyHash owner,
+                                                    byte[] mapKey,
+                                                    SigningPrivateKeyAndPublicHash writer,
+                                                    TransactionId tid) {
+        return tree.remove(owner, writer, mapKey, metadata.committedHash(), tid)
+                .thenApply(res -> metadata.committedHash().get());
+    }
+
     public CompletableFuture<Optional<CryptreeNode>> getMetadata(Location loc) {
         if (loc == null)
             return CompletableFuture.completedFuture(Optional.empty());

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -951,7 +951,7 @@ public class FileWrapper {
                                 Optional<byte[]> nextChunkMapKey = chunk.getNextChunkLocation(currentCap.rBaseKey);
                                 if (! nextChunkMapKey.isPresent())
                                     return CompletableFuture.completedFuture(true);
-                                return copyAllChunks(true, currentCap.withMapKey(nextChunkMapKey.get()), targetSigner, tid, network);
+                                return deleteAllChunks(currentCap.withMapKey(nextChunkMapKey.get()), targetSigner, tid, network);
                             })
                             .thenCompose(b -> {
                                 if (! (mOpt.get() instanceof DirAccess))
@@ -959,7 +959,7 @@ public class FileWrapper {
                                 Set<AbsoluteCapability> childCaps = ((DirAccess) mOpt.get()).getChildrenCapabilities(currentCap);
                                 return Futures.reduceAll(childCaps,
                                         true,
-                                        (x, cap) -> copyAllChunks(true, cap, targetSigner, tid, network),
+                                        (x, cap) -> deleteAllChunks(cap, targetSigner, tid, network),
                                         (x, y) -> x && y);
                             });
                 });


### PR DESCRIPTION
Make sure we delete all the existing chunks of the subtree we are granting write access to after we have copied them to a new signing key. 