### PR TITLE
Fix recursive delete with write access

### DIFF
--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1156,6 +1156,10 @@ public class UserContext {
         return entrie.getChildren(path, network);
     }
 
+    public CompletableFuture<Optional<FileWrapper>> getByPath(Path path) {
+        return getByPath(path.toString());
+    }
+
     @JsMethod
     public CompletableFuture<Optional<FileWrapper>> getByPath(String path) {
         if (path.equals("/"))

--- a/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
@@ -28,6 +28,11 @@ public class WritableAbsoluteCapability extends AbsoluteCapability {
         return new WritableAbsoluteCapability(owner, writer, getMapKey(), newBaseKey, wBaseKey.get());
     }
 
+    @Override
+    public WritableAbsoluteCapability withMapKey(byte[] newMapKey) {
+        return new WritableAbsoluteCapability(owner, writer, newMapKey, rBaseKey, wBaseKey.get());
+    }
+
     public WritableAbsoluteCapability withSigner(PublicKeyHash newSigner) {
         return new WritableAbsoluteCapability(owner, newSigner, getMapKey(), rBaseKey, wBaseKey.get());
     }


### PR DESCRIPTION
Handle two extra cases in recursive delete when the signing key changes