### PR TITLE
Don't calculate and store a file's hash in upload transactions.

### DIFF
--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 public class FileUploadTransaction implements Transaction {
     private final long startTimeEpochMillis;
     private final String path;
-    private final Multihash fileHash;
     //  common to whole file
     private final PublicKeyHash owner;
     private final SigningPrivateKeyAndPublicHash writer;
@@ -28,14 +27,12 @@ public class FileUploadTransaction implements Transaction {
 
     public FileUploadTransaction(long startTimeEpochMillis,
                                  String path,
-                                 Multihash fileHash,
                                  SigningPrivateKeyAndPublicHash writer,
                                  List<Location> locations) {
         ensureValid(locations, writer);
 
         this.startTimeEpochMillis = startTimeEpochMillis;
         this.path = path;
-        this.fileHash = fileHash;
         this.writer = writer;
         this.locations = locations;
         this.owner = locations.get(0).owner;
@@ -93,7 +90,6 @@ public class FileUploadTransaction implements Transaction {
         Map<String, Cborable> map = new HashMap<>();
         map.put("type", new CborObject.CborString(Type.FILE_UPLOAD.name()));
         map.put("path", new CborObject.CborString(path));
-        map.put("hash", new CborObject.CborByteArray(fileHash.toBytes()));
         map.put("startTimeEpochMs", new CborObject.CborLong(startTimeEpochMillis()));
         map.put("owner", owner);
         map.put("writer", writer);
@@ -113,7 +109,6 @@ public class FileUploadTransaction implements Transaction {
             throw new IllegalStateException("Cannot parse transaction: wrong type " + type);
 
         PublicKeyHash owner = map.getObject("owner", PublicKeyHash::fromCbor);
-        Multihash fileHash = map.getObject("hash", c -> Multihash.decode(((CborObject.CborByteArray) c).value));
         SigningPrivateKeyAndPublicHash writer = map.getObject("writer", SigningPrivateKeyAndPublicHash::fromCbor);
         List<byte[]> mapKeys = map.getList("mapKeys", (cborable -> ((CborObject.CborByteArray) cborable).value));
 
@@ -124,7 +119,6 @@ public class FileUploadTransaction implements Transaction {
         return new FileUploadTransaction(
                 map.getLong("startTimeEpochMs"),
                 map.getString("path"),
-                fileHash,
                 writer,
                 locations);
     }

--- a/src/peergos/shared/user/fs/transaction/Transaction.java
+++ b/src/peergos/shared/user/fs/transaction/Transaction.java
@@ -55,8 +55,6 @@ public interface Transaction extends Cborable {
                                                                                AsyncReader fileData,
                                                                                SigningPrivateKeyAndPublicHash writer,
                                                                                List<Location> locations) {
-        return Hash.sha256(fileData, fileSize)
-                .thenApply(hash -> new FileUploadTransaction(System.currentTimeMillis(), path,
-                        new Multihash(Multihash.Type.sha2_256, hash), writer, locations));
+        return CompletableFuture.completedFuture(new FileUploadTransaction(System.currentTimeMillis(), path, writer, locations));
     }
 }


### PR DESCRIPTION
This explodes the ram usage in the browser with the recursive hash
calculation.