### PR TITLE
Key owner proofs, inline public keys and generalize capability store

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -54,41 +54,6 @@
     <mkdir dir="${test.reports}"/>
   </target>
 
-  <target name="install_ipfs">
-    <exec executable="/bin/bash">
-      <arg value="./data.service.sh"/>
-      <arg value="install"/>
-      <arg value="v0.4.15"/>
-      <arg value="."/>
-      <arg value="."/>
-    </exec>
-  </target>
-
-  <target name="start_ipfs">
-    <exec executable="/bin/bash">
-      <arg value="./data.service.sh"/>
-      <arg value="restart"/>
-      <arg value="."/>
-      <arg value="."/>
-    </exec>
-  </target>
-
-  <target name="stop_ipfs">
-    <exec executable="/bin/bash">
-      <arg value="./data.service.sh"/>
-      <arg value="stop"/>
-    </exec>
-  </target>
-
-  <target name="uninstall_ipfs">
-    <exec executable="/bin/bash">
-      <arg value="./data.service.sh"/>
-      <arg value="uninstall"/>
-      <arg value="."/>
-      <arg value="."/>
-    </exec>
-  </target>
-
   <target name="compile" depends="clean, init"
         description="compile the source">
     <javac includeantruntime="false" destdir="${build}" debug="true" debuglevel="lines,vars,source">
@@ -145,7 +110,7 @@
     </pathconvert>
     <!-- run one particular test -->
     <junit fork="true" printsummary="true" haltonfailure="yes">
-      <jvmarg value="-Xmx3g"/>
+      <jvmarg value="-Xmx2g"/>
       <classpath>
 	<pathelement location="lib/jnr-fuse-0.3-all.jar" />
 	<pathelement location="lib/sqlite-jdbc-3.7.2.jar" />

--- a/src/peergos/server/Playground.java
+++ b/src/peergos/server/Playground.java
@@ -55,11 +55,13 @@ public class Playground {
                                    UserContext context,
                                    NetworkAccess network) throws Exception {
         // Do something dangerous (you only live once)
-        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, network.coreNode, network.mutable, network.dhtClient);
+        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, network.coreNode,
+                network.mutable, network.dhtClient).join();
         for (PublicKeyHash ownedKey : ownedKeys) {
             if (ownedKey.equals(context.signer.publicKeyHash))
                 continue; // only the writer has a tree
-            CommittedWriterData existing = WriterData.getWriterData(context.signer.publicKeyHash, ownedKey, network.mutable, network.dhtClient).get();
+            CommittedWriterData existing = WriterData.getWriterData(context.signer.publicKeyHash, ownedKey,
+                    network.mutable, network.dhtClient).get();
             if (existing.props.tree.isPresent())
                 continue;
             // Do something risky

--- a/src/peergos/server/RegisteredUserKeyFilter.java
+++ b/src/peergos/server/RegisteredUserKeyFilter.java
@@ -38,7 +38,7 @@ public class RegisteredUserKeyFilter {
             List<String> usernames = core.getUsernames("").get();
             Set<PublicKeyHash> updated = new HashSet<>();
             for (String username : usernames) {
-                updated.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht));
+                updated.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht).join());
             }
             Set<PublicKeyHash> toRemove = new HashSet<>();
             for (PublicKeyHash hash : allowedKeys.keySet())

--- a/src/peergos/server/SpaceCheckingKeyFilter.java
+++ b/src/peergos/server/SpaceCheckingKeyFilter.java
@@ -282,7 +282,7 @@ public class SpaceCheckingKeyFilter {
                     long updatedSize = dht.getRecursiveBlockSize(rootHash.get()).get();
                     long deltaUsage = updatedSize - stat.directRetainedStorage;
                     state.usage.get(stat.owner).confirmUsage(ownerKey, deltaUsage); //NB: ownerKey is a dummy value
-                    Set<PublicKeyHash> directOwnedKeys = WriterData.getDirectOwnedKeys(ownerKey, ownerKey, mutable, dht);
+                    Set<PublicKeyHash> directOwnedKeys = WriterData.getDirectOwnedKeys(ownerKey, ownerKey, mutable, dht).join();
                     List<PublicKeyHash> newOwnedKeys = directOwnedKeys.stream()
                             .filter(key -> !stat.ownedKeys.contains(key))
                             .collect(Collectors.toList());
@@ -376,7 +376,7 @@ public class SpaceCheckingKeyFilter {
     public void processCorenodeEvent(String username, PublicKeyHash owner) {
         try {
             state.usage.putIfAbsent(username, new Usage(0));
-            Set<PublicKeyHash> childrenKeys = WriterData.getDirectOwnedKeys(owner, owner, mutable, dht);
+            Set<PublicKeyHash> childrenKeys = WriterData.getDirectOwnedKeys(owner, owner, mutable, dht).join();
             state.currentView.computeIfAbsent(owner, k -> new Stat(username, MaybeMultihash.empty(), 0, childrenKeys));
             Stat current = state.currentView.get(owner);
             MaybeMultihash updatedRoot = mutable.getPointerTarget(owner, owner, dht).get();

--- a/src/peergos/server/UserStats.java
+++ b/src/peergos/server/UserStats.java
@@ -22,7 +22,8 @@ public class UserStats {
                 UserPublicKeyLink last = chain.get(chain.size() - 1);
                 LocalDate expiry = last.claim.expiry;
                 PublicKeyHash owner = last.owner;
-                Set<PublicKeyHash> ownedKeysRecursive = WriterData.getOwnedKeysRecursive(username, network.coreNode, network.mutable, network.dhtClient);
+                Set<PublicKeyHash> ownedKeysRecursive =
+                        WriterData.getOwnedKeysRecursive(username, network.coreNode, network.mutable, network.dhtClient).join();
                 long total = 0;
                 for (PublicKeyHash writer : ownedKeysRecursive) {
                     MaybeMultihash target = network.mutable.getPointerTarget(owner, writer, network.dhtClient).get();

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -48,7 +48,7 @@ public class MirrorCoreNode implements CoreNode {
 
     private PublicKeyHash getPkiKey() throws Exception {
         CommittedWriterData current = WriterData.getWriterData(pkiOwnerIdentity, pkiOwnerIdentity, mutable, ipfs).get();
-        PublicKeyHash pki = current.props.namedOwnedKeys.get("pki");
+        PublicKeyHash pki = current.props.namedOwnedKeys.get("pki").ownedKey;
         if (pki == null)
             throw new IllegalStateException("No pki key on owner: " + pkiOwnerIdentity);
         return pki;

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -522,7 +522,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             return Optional.of(data);
 
         try (AsyncReader asyncReader = stat.treeNode.getInputStream(context.network, context.crypto.random, actualSize, (l) -> {}).get()){
-            AsyncReader seeked = asyncReader.seek((int) (offset >> 32), (int) offset).get();
+            AsyncReader seeked = asyncReader.seekJS((int) (offset >> 32), (int) offset).get();
 
             // N.B. Fuse seems to assume that a file must be an integral number of disk sectors,
             // so need to tolerate EOFs up end of last sector (4KiB)

--- a/src/peergos/server/mutable/UserBasedBlacklist.java
+++ b/src/peergos/server/mutable/UserBasedBlacklist.java
@@ -80,7 +80,7 @@ public class UserBasedBlacklist implements PublicKeyBlackList {
     private Set<PublicKeyHash> buildBlackList(Set<String> usernames) {
         Set<PublicKeyHash> res = new HashSet<>();
         for (String username : usernames) {
-            res.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht));
+            res.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht).join());
         }
         return res;
     }

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -92,7 +92,7 @@ public class DHTHandler implements HttpHandler {
                     // against the core node)
                     Supplier<PublicSigningKey> fromDht = () -> {
                         try {
-                            return PublicSigningKey.fromCbor(dht.get(writerHash.multihash).get().get());
+                            return dht.getSigningKey(writerHash).get().get();
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }

--- a/src/peergos/server/storage/ResetableFileInputStream.java
+++ b/src/peergos/server/storage/ResetableFileInputStream.java
@@ -18,7 +18,7 @@ public class ResetableFileInputStream implements AsyncReader {
     }
 
     @Override
-    public CompletableFuture<AsyncReader> seek(int high32, int low32) {
+    public CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
         try {
             raf.seek((low32 & 0xFFFFFFFFL) + (high32 & 0xFFFFFFFFL) << 32);
             return CompletableFuture.completedFuture(this);

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -286,7 +286,8 @@ public class MultiUserTests {
         Assert.assertTrue("Following parent link results in read only parent",
                 ! metaOnlyParent.isWritable() && ! metaOnlyParent.isReadable());
 
-        Set<PublicKeyHash> keysOwnedByRootSigner = WriterData.getDirectOwnedKeys(theFile.owner(), parentFolder.writer(), network.mutable, network.dhtClient);
+        Set<PublicKeyHash> keysOwnedByRootSigner = WriterData.getDirectOwnedKeys(theFile.owner(), parentFolder.writer(),
+                network.mutable, network.dhtClient).join();
         Assert.assertTrue("New writer key present", keysOwnedByRootSigner.contains(theFile.writer()));
 
         parentFolder.remove(u1.getUserRoot().get(), network, crypto.hasher).get();
@@ -297,7 +298,8 @@ public class MultiUserTests {
             Optional<FileWrapper> sharedFile = userContext.getByPath(filePath).get();
             Assert.assertTrue("shared file removed", ! sharedFile.isPresent());
         }
-        Set<PublicKeyHash> updatedKeysOwnedByRootSigner = WriterData.getDirectOwnedKeys(theFile.owner(), parentFolder.writer(), network.mutable, network.dhtClient);
+        Set<PublicKeyHash> updatedKeysOwnedByRootSigner = WriterData.getDirectOwnedKeys(theFile.owner(),
+                parentFolder.writer(), network.mutable, network.dhtClient).join();
         Assert.assertTrue("New writer key not present", ! updatedKeysOwnedByRootSigner.contains(theFile.writer()));
     }
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -515,7 +515,7 @@ public abstract class UserTests {
         }
 
         @Override
-        public CompletableFuture<AsyncReader> seek(int high32, int low32) {
+        public CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
             if (high32 != 0)
                 throw new IllegalArgumentException("Cannot have arrays larger than 4GiB!");
             if (index + low32 > throwAtIndex)

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -146,9 +146,15 @@ public abstract class UserTests {
     public void randomSignup() throws Exception {
         String username = generateUsername();
         String password = "password";
-        PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         InstanceAdmin.VersionInfo version = network.instanceAdmin.getVersionInfo().join();
         Assert.assertTrue(! version.version.isBefore(Version.parse("0.0.0")));
+
+        FileWrapper userRoot = context.getUserRoot().join();
+        Assert.assertTrue("owner uses identity multihash", userRoot.getPointer().capability.owner.isIdentity());
+        Assert.assertTrue("signer uses identity multihash", userRoot.getPointer().capability.writer.isIdentity());
+        Assert.assertTrue("user root does not have a retrievable parent",
+                ! userRoot.retrieveParent(network).join().isPresent());
     }
 
     @Test

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -603,6 +603,8 @@ public class PeergosNetworkUtils {
         FileWrapper file = context.getByPath(path).get().get();
         String link = file.toLink();
         UserContext linkContext = UserContext.fromPublicLink(link, readerNode, crypto).get();
+        String entryPath = linkContext.getEntryPath().join();
+        Assert.assertTrue("Correct entry path", entryPath.equals("/" + username));
         Optional<FileWrapper> fileThroughLink = linkContext.getByPath(path).get();
         Assert.assertTrue("File present through link", fileThroughLink.isPresent());
     }

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -410,26 +410,4 @@ public class NetworkAccess {
         return Futures.combineAllInOrder(futures)
                 .thenApply(optList -> optList.stream().filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList()));
     }
-
-    /**
-     * Pin all files associated with all the keys of a user. For
-     * self-hosting.
-     *
-     * @param username
-     */
-    public void pinAllUserFiles(String username) throws ExecutionException, InterruptedException {
-        pinAllUserFiles(username, coreNode, mutable, dhtClient);
-    }
-
-    public static void pinAllUserFiles(String username, CoreNode coreNode, MutablePointers mutable, ContentAddressedStorage dhtClient) throws ExecutionException, InterruptedException {
-        Set<PublicKeyHash> ownedKeysRecursive = WriterData.getOwnedKeysRecursive(username, coreNode, mutable, dhtClient);
-        Optional<PublicKeyHash> ownerOpt = coreNode.getPublicKeyHash(username).get();
-        if (! ownerOpt.isPresent())
-            throw new IllegalStateException("Couldn't retrieve public key for " + username);
-        PublicKeyHash owner = ownerOpt.get();
-        for (PublicKeyHash keyHash: ownedKeysRecursive) {
-            Multihash casKeyHash = mutable.getPointerTarget(owner, keyHash, dhtClient).get().get();
-            dhtClient.recursivePin(owner, casKeyHash).get();
-        }
-    }
 }

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -35,6 +35,10 @@ public interface CborObject extends Cborable {
         return deserialize(new CborDecoder(new ByteArrayInputStream(cbor)), cbor.length);
     }
 
+    static CborObject read(InputStream in, int maxBytes) {
+        return deserialize(new CborDecoder(in), maxBytes);
+    }
+
     static CborObject deserialize(CborDecoder decoder, int maxGroupSize) {
         try {
             CborType type = decoder.peekType();

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -75,7 +75,7 @@ public class FragmentedPaddedCipherText implements Cborable {
 
         byte[][] split = split(cipherText, maxFragmentSize);
 
-        List<FragmentWithHash> frags = Arrays.asList(split).stream()
+        List<FragmentWithHash> frags = Arrays.stream(split)
                 .map(d -> new FragmentWithHash(new Fragment(d), hasher.hash(d, true)))
                 .collect(Collectors.toList());
         List<Multihash> hashes = frags.stream()

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -13,7 +13,7 @@ import java.util.concurrent.*;
 import java.util.function.*;
 import java.util.stream.*;
 
-/** This class pads the secret up to a multiple of the given block size before encrypting and splits the data into
+/** This class pads the secret up to a multiple of the given block size before encrypting and splits the ciphertext into
  * fragments which are referenced by merkle links in the serialization.
  *
  */

--- a/src/peergos/shared/crypto/OwnerProof.java
+++ b/src/peergos/shared/crypto/OwnerProof.java
@@ -1,0 +1,64 @@
+package peergos.shared.crypto;
+
+import peergos.shared.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.storage.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class OwnerProof implements Cborable {
+    public final PublicKeyHash ownedKey;
+    public final byte[] signedOwner;
+
+    public OwnerProof(PublicKeyHash ownedKey, byte[] signedOwner) {
+        this.ownedKey = ownedKey;
+        this.signedOwner = signedOwner;
+    }
+
+    public CompletableFuture<PublicKeyHash> getOwner(ContentAddressedStorage ipfs) {
+        return ipfs.getSigningKey(ownedKey)
+                .thenApply(signer -> signer
+                        .map(k -> PublicKeyHash.fromCbor(CborObject.fromByteArray(k.unsignMessage(signedOwner))))
+                        .orElseThrow(() -> new IllegalStateException("Couldn't retrieve owned key: " + ownedKey)));
+    }
+
+    public static OwnerProof build(SigningPrivateKeyAndPublicHash ownedKeypair, PublicKeyHash owner) {
+        return new OwnerProof(ownedKeypair.publicKeyHash, ownedKeypair.secret.signMessage(owner.serialize()));
+    }
+
+    @Override
+    public CborObject toCbor() {
+        Map<String, CborObject> result = new TreeMap<>();
+        result.put("o", new CborObject.CborMerkleLink(ownedKey));
+        result.put("p", new CborObject.CborByteArray(signedOwner));
+        return CborObject.CborMap.build(result);
+    }
+
+    public static OwnerProof fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Incorrect cbor for OwnerProof: " + cbor);
+
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        PublicKeyHash ownedKey = m.get("o", PublicKeyHash::fromCbor);
+        byte[] proof = m.get("p", c -> (CborObject.CborByteArray) c).value;
+        return new OwnerProof(ownedKey, proof);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        OwnerProof that = (OwnerProof) o;
+        return Objects.equals(ownedKey, that.ownedKey) &&
+                Arrays.equals(signedOwner, that.signedOwner);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(ownedKey);
+        result = 31 * result + Arrays.hashCode(signedOwner);
+        return result;
+    }
+}

--- a/src/peergos/shared/crypto/hash/PublicKeyHash.java
+++ b/src/peergos/shared/crypto/hash/PublicKeyHash.java
@@ -20,7 +20,7 @@ public class PublicKeyHash extends Multihash implements Cborable {
     }
 
     public static boolean isSafe(Multihash h) {
-        return h.type == Type.sha2_256; // we can add other hashes later
+        return h.type == Type.sha2_256 || h.type == Type.id; // we can add other hashes later
     }
 
     @Override

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -160,8 +160,7 @@ public interface ContentAddressedStorage {
                                                            PublicKeyHash writer,
                                                            PublicSigningKey newKey,
                                                            TransactionId tid) {
-        return put(owner, writer, signature, newKey.toCbor().toByteArray(), tid)
-                .thenApply(PublicKeyHash::new);
+        return CompletableFuture.completedFuture(hashKey(newKey));
     }
 
     static PublicKeyHash hashKey(PublicSigningKey key) {

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -32,6 +32,10 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
                     return result.get();
 
                 throw new IllegalStateException("Incorrect hash! Are you under attack? Expected: " + claimed + " actual: " + computed);
+            case id:
+                if (Arrays.equals(data, claimed.getHash()))
+                    return result.get();
+                throw new IllegalStateException("Incorrect identity hash! This shouldn't ever  happen.");
             default: throw new IllegalStateException("Unimplemented hash algorithm: " + claimed.type);
         }
     }

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -97,8 +97,8 @@ public class FriendSourcedTrieNode implements TrieNode {
 
     private synchronized CompletableFuture<Boolean> addEditableCapabilities(Optional<FileWrapper> sharedDirOpt, NetworkAccess network) {
         return CapabilityStore.getEditableCapabilityFileSize(sharedDirOpt.get(), network)
-                .thenCompose(editCount -> {
-                    if (editCount == byteOffsetWrite)
+                .thenCompose(editFilesize -> {
+                    if (editFilesize == byteOffsetWrite)
                         return CompletableFuture.completedFuture(true);
                     return CapabilityStore.loadWriteAccessSharingLinksFromIndex(homeDirSupplier, sharedDirOpt.get(),
                             ownerName, network, random, hasher, byteOffsetWrite, true)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -134,14 +134,12 @@ public class UserContext {
     }
 
     @JsMethod
-    public static CompletableFuture<UserContext> signIn(String username, String password, NetworkAccess network
-            , Crypto crypto, Consumer<String> progressCallback) {
+    public static CompletableFuture<UserContext> signIn(String username, String password, NetworkAccess network,
+                                                        Crypto crypto, Consumer<String> progressCallback) {
         return getWriterDataCbor(network, username)
                 .thenCompose(pair -> {
-                    Optional<SecretGenerationAlgorithm> algorithmOpt = WriterData.extractUserGenerationAlgorithm(pair.right);
-                    if (!algorithmOpt.isPresent())
-                        throw new IllegalStateException("No login algorithm specified in user data!");
-                    SecretGenerationAlgorithm algorithm = algorithmOpt.get();
+                    SecretGenerationAlgorithm algorithm = WriterData.fromCbor(pair.right).generationAlgorithm
+                            .orElseThrow(() -> new IllegalStateException("No login algorithm specified in user data!"));
                     progressCallback.accept("Generating keys");
                     return UserUtil.generateUser(username, password, crypto.hasher, crypto.symmetricProvider,
                             crypto.random, crypto.signer, crypto.boxer, algorithm)
@@ -153,9 +151,8 @@ public class UserContext {
     public static CompletableFuture<UserContext> signIn(String username, UserWithRoot userWithRoot, NetworkAccess network
             , Crypto crypto, Consumer<String> progressCallback) {
         return getWriterDataCbor(network, username)
-                .thenCompose(pair -> {
-                    return login(username, userWithRoot, pair, network, crypto, progressCallback);
-                }).exceptionally(Futures::logAndThrow);
+                .thenCompose(pair -> login(username, userWithRoot, pair, network, crypto, progressCallback))
+                .exceptionally(Futures::logAndThrow);
     }
 
     private static CompletableFuture<UserContext> login(String username,
@@ -461,7 +458,7 @@ public class UserContext {
                         .thenCompose(cwd -> {
                             CompletableFuture<Long> subtree = Futures.reduceAll(cwd.props.ownedKeys
                                             .stream()
-                                            .map(writer -> getTotalSpaceUsed(ownerHash, writer))
+                                            .map(writer -> getTotalSpaceUsed(ownerHash, writer.ownedKey))
                                             .collect(Collectors.toList()),
                                     0L, (t, fut) -> fut.thenApply(x -> x + t), (a, b) -> a + b);
                             return subtree.thenCompose(ownedSize -> network.dhtClient.getRecursiveBlockSize(cwd.hash.get())
@@ -470,31 +467,21 @@ public class UserContext {
     }
 
     public CompletableFuture<SecretGenerationAlgorithm> getKeyGenAlgorithm() {
-        return getWriterDataCbor(this.network, this.username)
-                .thenApply(pair -> {
-                    Optional<SecretGenerationAlgorithm> algorithmOpt = WriterData.extractUserGenerationAlgorithm(pair.right);
-                    if (!algorithmOpt.isPresent())
-                        throw new IllegalStateException("No login algorithm specified in user data!");
-                    return algorithmOpt.get();
-                });
+        return getWriterData(network, signer.publicKeyHash, signer.publicKeyHash)
+                .thenApply(wd -> wd.props.generationAlgorithm
+                        .orElseThrow(() -> new IllegalStateException("No login algorithm specified in user data!")));
     }
 
     public CompletableFuture<Optional<PublicKeyHash>> getNamedKey(String name) {
-        return getWriterDataCbor(this.network, this.username)
-                .thenApply(p -> Optional.ofNullable(WriterData.fromCbor(p.right).namedOwnedKeys.get(name)));
+        return getWriterData(network, signer.publicKeyHash, signer.publicKeyHash)
+                .thenApply(wd -> wd.props.namedOwnedKeys.get(name))
+                .thenApply(res -> Optional.ofNullable(res).map(p -> p.ownedKey));
     }
 
     @JsMethod
     public CompletableFuture<UserContext> changePassword(String oldPassword, String newPassword) {
 
-        return getWriterDataCbor(this.network, this.username)
-                .thenCompose(pair -> {
-                    Optional<SecretGenerationAlgorithm> algorithmOpt = WriterData.extractUserGenerationAlgorithm(pair.right);
-                    if (!algorithmOpt.isPresent())
-                        throw new IllegalStateException("No login algorithm specified in user data!");
-                    SecretGenerationAlgorithm algorithm = algorithmOpt.get();
-                    return changePassword(oldPassword, newPassword, algorithm, algorithm);
-                });
+        return getKeyGenAlgorithm().thenCompose(alg -> changePassword(oldPassword, newPassword, alg, alg));
     }
 
     public CompletableFuture<UserContext> changePassword(String oldPassword,
@@ -567,7 +554,7 @@ public class UserContext {
             SigningPrivateKeyAndPublicHash writerWithHash = new SigningPrivateKeyAndPublicHash(writerHash, writer.secretSigningKey);
             WritableAbsoluteCapability rootPointer = new WritableAbsoluteCapability(owner.publicKeyHash, writerHash, rootMapKey, rootRKey, rootWKey);
             EntryPoint entry = new EntryPoint(rootPointer, this.username);
-            return addOwnedKeyAndCommit(entry.pointer.writer, tid)
+            return addOwnedKeyAndCommit(writerWithHash, tid)
                     .thenCompose(x -> {
                         long t2 = System.currentTimeMillis();
                         RelativeCapability nextChunk = RelativeCapability.buildSubsequentChunk(crypto.random.randomBytes(32), rootRKey);
@@ -605,11 +592,12 @@ public class UserContext {
                                         .thenApply(boxer -> Optional.of(new Pair<>(signerOpt.get(), boxer))))));
     }
 
-    private CompletableFuture<CommittedWriterData> addOwnedKeyAndCommit(PublicKeyHash owned, TransactionId tid) {
+    private CompletableFuture<CommittedWriterData> addOwnedKeyAndCommit(SigningPrivateKeyAndPublicHash owned,
+                                                                        TransactionId tid) {
         return userData.runWithLock(wd -> {
-            Set<PublicKeyHash> updated = Stream.concat(
+            Set<OwnerProof> updated = Stream.concat(
                     wd.props.ownedKeys.stream(),
-                    Stream.of(owned)
+                    Stream.of(OwnerProof.build(owned, signer.publicKeyHash))
             ).collect(Collectors.toSet());
 
             WriterData writerData = wd.props.withOwnedKeys(updated);
@@ -617,9 +605,10 @@ public class UserContext {
         });
     }
 
-    public CompletableFuture<CommittedWriterData> addNamedOwnedKeyAndCommit(String keyName, PublicKeyHash owned) {
+    public CompletableFuture<CommittedWriterData> addNamedOwnedKeyAndCommit(String keyName,
+                                                                            SigningPrivateKeyAndPublicHash owned) {
         return userData.runWithLock(wd -> {
-            WriterData writerData = wd.props.addNamedKey(keyName, owned);
+            WriterData writerData = wd.props.addNamedKey(keyName, OwnerProof.build(owned, signer.publicKeyHash));
             return IpfsTransaction.call(signer.publicKeyHash,
                     tid -> writerData.commit(signer.publicKeyHash, signer, wd.hash, network, tid),
                     network.dhtClient);
@@ -977,13 +966,14 @@ public class UserContext {
                         owner, parentSigner.publicKeyHash, newSignerPair.publicSigningKey, tid).thenCompose(newSignerHash ->
                         WriterData.getWriterData(owner, parentSigner.publicKeyHash, network.mutable, network.dhtClient)
                                 .thenCompose(wd -> {
-                                    Set<PublicKeyHash> ownedKeys = new HashSet<>(wd.props.ownedKeys);
-                                    ownedKeys.add(newSignerHash);
+                                    SigningPrivateKeyAndPublicHash newSigner =
+                                            new SigningPrivateKeyAndPublicHash(newSignerHash, newSignerPair.secretSigningKey);
+                                    Set<OwnerProof> ownedKeys = new HashSet<>(wd.props.ownedKeys);
+                                    ownedKeys.add(OwnerProof.build(newSigner, parentSigner.publicKeyHash));
                                     WriterData updatedParentWD = wd.props.withOwnedKeys(ownedKeys);
                                     return updatedParentWD.commit(owner,
                                             parentSigner, wd.hash, network, tid)
-                                            .thenApply(x -> new SigningPrivateKeyAndPublicHash(newSignerHash,
-                                                    newSignerPair.secretSigningKey));
+                                            .thenApply(x -> newSigner);
                                 })), network.dhtClient);
     }
 
@@ -1002,9 +992,11 @@ public class UserContext {
         return IpfsTransaction.call(owner,
                 tid -> WriterData.getWriterData(owner, parentSigner.publicKeyHash, network.mutable, network.dhtClient)
                         .thenCompose(wd -> {
-                            Set<PublicKeyHash> ownedKeys = new HashSet<>(wd.props.ownedKeys);
-                            ownedKeys.remove(toRemove);
-                            WriterData updatedParentWD = wd.props.withOwnedKeys(ownedKeys);
+                            Set<OwnerProof> ownedKeys = wd.props.ownedKeys;
+                            Set<OwnerProof> updatedOwnedKeys = ownedKeys.stream()
+                                    .filter(p -> !p.ownedKey.equals(toRemove))
+                                    .collect(Collectors.toSet());
+                            WriterData updatedParentWD = wd.props.withOwnedKeys(updatedOwnedKeys);
                             return updatedParentWD.commit(owner,
                                     parentSigner, wd.hash, network, tid);
                         }), network.dhtClient);

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -319,7 +319,8 @@ public class UserContext {
                         return CompletableFuture.completedFuture(file.getName());
                     FileWrapper child = children.stream().findAny().get();
                     if (child.isReadable()) // case where a directory was shared with exactly one direct child
-                        return CompletableFuture.completedFuture(file.getName() + "/" + child.getName());
+                        return CompletableFuture.completedFuture(file.getName() + (child.isDirectory() ?
+                                "/" + child.getName() : ""));
                     return getLinkPath(child)
                             .thenApply(p -> file.getName() + (p.length() > 0 ? "/" + p : ""));
                 });

--- a/src/peergos/shared/user/fs/AsyncReader.java
+++ b/src/peergos/shared/user/fs/AsyncReader.java
@@ -64,7 +64,6 @@ public interface AsyncReader extends AutoCloseable {
                             accumulator.accept(fromCbor.apply(readObject));
                             localOffset += readObject.toByteArray().length;
                         } catch (RuntimeException e) {
-                            e.printStackTrace();
                             int fromThisChunk = localOffset;
                             return parseStream(Arrays.copyOfRange(buf, localOffset, bytesRead), fromCbor, accumulator,
                                     maxBytesToRead - bytesRead)

--- a/src/peergos/shared/user/fs/AsyncReader.java
+++ b/src/peergos/shared/user/fs/AsyncReader.java
@@ -1,14 +1,21 @@
 package peergos.shared.user.fs;
 
 import jsinterop.annotations.*;
+import peergos.shared.cbor.*;
 
+import java.io.*;
+import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.*;
 
 @JsType
 public interface AsyncReader extends AutoCloseable {
 
     CompletableFuture<AsyncReader> seek(int high32, int low32);
+
+    default CompletableFuture<AsyncReader> seek(long offset) {
+        return seek((int)(offset >> 32), (int)offset);
+    }
 
     /**
      *
@@ -29,6 +36,45 @@ public interface AsyncReader extends AutoCloseable {
      * Close and dispose of any resources
      */
     void close();
+
+    default <T> CompletableFuture<Long> parseStream(Function<Cborable, T> fromCbor, Consumer<T> accumulator, long maxBytesToRead) {
+        return parseStream(new byte[0], fromCbor, accumulator, maxBytesToRead);
+    }
+
+    /** Convert reader into a stream of CborObjects
+     *
+     * @param prefix any bytes from a partial object read that will form the prefix of this read
+     * @param fromCbor The cbor converter
+     * @param accumulator The results consumer
+     * @param maxBytesToRead There must be at least this many bytes left in this stream or an EOF will result
+     * @param <T>
+     * @return
+     */
+    default <T> CompletableFuture<Long> parseStream(byte[] prefix, Function<Cborable, T> fromCbor, Consumer<T> accumulator, long maxBytesToRead) {
+        if (maxBytesToRead == 0)
+            return CompletableFuture.completedFuture(0L);
+        byte[] buf = new byte[Chunk.MAX_SIZE];
+        System.arraycopy(prefix, 0, buf, 0, prefix.length);
+        ByteArrayInputStream in = new ByteArrayInputStream(buf);
+        return readIntoArray(buf, prefix.length, (int) Math.min((long)(buf.length - prefix.length), maxBytesToRead))
+                .thenCompose(bytesRead -> {
+                    for (int localOffset = 0; localOffset < bytesRead;) {
+                        try {
+                            CborObject readObject = CborObject.read(in, bytesRead);
+                            accumulator.accept(fromCbor.apply(readObject));
+                            localOffset += readObject.toByteArray().length;
+                        } catch (RuntimeException e) {
+                            e.printStackTrace();
+                            int fromThisChunk = localOffset;
+                            return parseStream(Arrays.copyOfRange(buf, localOffset, bytesRead), fromCbor, accumulator,
+                                    maxBytesToRead - bytesRead)
+                                    .thenApply(rest -> rest + fromThisChunk);
+                        }
+                    }
+                    return parseStream(fromCbor, accumulator, maxBytesToRead - bytesRead)
+                            .thenApply(rest -> rest + bytesRead);
+                });
+    }
 
     class ArrayBacked implements AsyncReader {
         private final byte[] data;

--- a/src/peergos/shared/user/fs/BrowserFileReader.java
+++ b/src/peergos/shared/user/fs/BrowserFileReader.java
@@ -13,7 +13,7 @@ public class BrowserFileReader implements AsyncReader {
         this.reader = reader;
     }
 
-    public CompletableFuture<AsyncReader> seek(int high32, int low32) {
+    public CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
         return reader.seek(high32, low32).thenApply(x -> this);
     }
 

--- a/src/peergos/shared/user/fs/CapabilitiesFromUser.java
+++ b/src/peergos/shared/user/fs/CapabilitiesFromUser.java
@@ -27,7 +27,7 @@ public class CapabilitiesFromUser implements Cborable {
     @Override
     public CborObject toCbor() {
         Map<String, CborObject> cbor = new TreeMap<>();
-        cbor.put("count", new CborObject.CborLong(bytesRead));
+        cbor.put("bytes", new CborObject.CborLong(bytesRead));
         cbor.put("caps", new CborObject.CborList(retrievedCapabilities));
         return CborObject.CborMap.build(cbor);
     }
@@ -36,12 +36,12 @@ public class CapabilitiesFromUser implements Cborable {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("CapabilitiesFromUser cbor must be a Map! " + cbor);
         CborObject.CborMap m = (CborObject.CborMap) cbor;
-        long count = m.getLong("count");
+        long bytesRead = m.getLong("bytes");
         List<CapabilityWithPath> caps = m.getList("caps")
                 .value.stream()
                 .map(CapabilityWithPath::fromCbor)
                 .collect(Collectors.toList());
-        return new CapabilitiesFromUser(count, caps);
+        return new CapabilitiesFromUser(bytesRead, caps);
     }
 
 }

--- a/src/peergos/shared/user/fs/CapabilitiesFromUser.java
+++ b/src/peergos/shared/user/fs/CapabilitiesFromUser.java
@@ -8,16 +8,16 @@ import java.util.stream.*;
 
 public class CapabilitiesFromUser implements Cborable {
 
-    private final long recordsRead;
+    private final long bytesRead;
     private final List<CapabilityWithPath> retrievedCapabilities;
 
-    public CapabilitiesFromUser(long recordsRead, List<CapabilityWithPath> retrievedCapabilities) {
-        this.recordsRead = recordsRead;
+    public CapabilitiesFromUser(long bytesRead, List<CapabilityWithPath> retrievedCapabilities) {
+        this.bytesRead = bytesRead;
         this.retrievedCapabilities = retrievedCapabilities;
     }
 
-    public long getRecordsRead() {
-        return recordsRead;
+    public long getBytesRead() {
+        return bytesRead;
     }
 
     public List<CapabilityWithPath> getRetrievedCapabilities() {
@@ -27,7 +27,7 @@ public class CapabilitiesFromUser implements Cborable {
     @Override
     public CborObject toCbor() {
         Map<String, CborObject> cbor = new TreeMap<>();
-        cbor.put("count", new CborObject.CborLong(recordsRead));
+        cbor.put("count", new CborObject.CborLong(bytesRead));
         cbor.put("caps", new CborObject.CborList(retrievedCapabilities));
         return CborObject.CborMap.build(cbor);
     }
@@ -35,8 +35,9 @@ public class CapabilitiesFromUser implements Cborable {
     public static CapabilitiesFromUser fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("CapabilitiesFromUser cbor must be a Map! " + cbor);
-        long count = ((CborObject.CborLong) (((CborObject.CborMap) cbor).values.get(new CborObject.CborString("count")))).value;
-        List<CapabilityWithPath> caps = ((CborObject.CborList)((CborObject.CborMap) cbor).values.get(new CborObject.CborString("caps")))
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        long count = m.getLong("count");
+        List<CapabilityWithPath> caps = m.getList("caps")
                 .value.stream()
                 .map(CapabilityWithPath::fromCbor)
                 .collect(Collectors.toList());

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -267,9 +267,9 @@ public class CapabilityStore {
                                     return Futures.errored(nsee); //a file ancestor no longer exists!?
                                 }
                             } else {
-                                return CompletableFuture.completedFuture(Collections.emptyList());
+                                return CompletableFuture.completedFuture(Collections.<CapabilityWithPath>emptyList());
                             }
-                        }).exceptionally(t -> Collections.emptyList());
+                        }).exceptionally(t -> Collections.<CapabilityWithPath>emptyList());
                     }).collect(Collectors.toList()))
                             .thenApply(res -> res.stream().flatMap(x -> x.stream()).collect(Collectors.toList()))
                             .thenCompose(results -> readSharingRecords(ownerName, owner, reader,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1259,9 +1259,11 @@ public class FileWrapper {
         return WriterData.getWriterData(owner, parentWriter, network.mutable, network.dhtClient)
                 .thenCompose(parentWriterData -> {
 
-            Set<PublicKeyHash> ownedKeys = new HashSet<>(parentWriterData.props.ownedKeys);
-            ownedKeys.remove(signerToRemove);
-            WriterData updatedParentWD = parentWriterData.props.withOwnedKeys(ownedKeys);
+                    Set<OwnerProof> ownedKeys = parentWriterData.props.ownedKeys;
+                    Set<OwnerProof> updatedOwnedKeys = ownedKeys.stream()
+                            .filter(p -> !p.ownedKey.equals(signerToRemove))
+                            .collect(Collectors.toSet());
+                    WriterData updatedParentWD = parentWriterData.props.withOwnedKeys(updatedOwnedKeys);
             return IpfsTransaction.call(owner, tid ->
                     updatedParentWD.commit(owner, parentSigner,
                             parentWriterData.hash, network, tid).thenApply(cwd -> true), network.dhtClient);

--- a/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
+++ b/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
@@ -93,7 +93,7 @@ public class LazyInputStreamCombiner implements AsyncReader {
     }
 
     @Override
-    public CompletableFuture<AsyncReader> seek(int hi32, int low32) {
+    public CompletableFuture<AsyncReader> seekJS(int hi32, int low32) {
         long seek = ((long) (hi32) << 32) | low32;
 
         if (totalLength < seek)


### PR DESCRIPTION
This PR does the following
1) Changes references in WriterData to owned keys to require a proof that we actually do own the key (owned key signing the owner key). This prevents anyone from forging ownership of other's keys, which could cause issues with quota and maybe more. This means the structures are now fully self authenticating as well!

2) All public key hashes now use the identity hash. This reduces the number of network round trips dramatically, makes the pki totally self contained (until we move to post-quantum keys), and improves privacy (no network lookups of other people's keys from their hash)

3) Generalizes the capability store to be able to handle any size capability (this PR changes the serialized size of caps). This simplifies the store into a single append only file of caps, rather than a series of files. Position is remembered by the number of bytes read. 