### PR TITLE
Handle when a friend changes their identity key.

### DIFF
--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -40,6 +40,13 @@ public interface CoreNode {
      */
     CompletableFuture<List<String>> getUsernames(String prefix);
 
+    /** This is only implemented by caching corenodes
+     *
+     * @param username
+     * @return
+     */
+    default CompletableFuture<Boolean> updateUser(String username) {return CompletableFuture.completedFuture(true);}
+
     /**
      *
      * @param username

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -59,6 +59,7 @@ public class TofuCoreNode implements CoreNode {
                 }).thenApply(x -> true);
     }
 
+    @Override
     public CompletableFuture<Boolean> updateUser(String username) {
         return source.getChain(username)
                 .thenCompose(chain -> tofu.updateChain(username, chain, context.network.dhtClient)

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -18,6 +18,7 @@ import java.util.function.Function;
 public class WriteSynchronizer {
     private final MutablePointers mutable;
     private final ContentAddressedStorage dht;
+    // The keys are <owner, writer> pairs. The owner is only needed to handle identity changes
     private final Map<Pair<PublicKeyHash, PublicKeyHash>, AsyncLock<CommittedWriterData>> pending = new ConcurrentHashMap<>();
 
     public WriteSynchronizer(MutablePointers mutable, ContentAddressedStorage dht) {

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -6,7 +6,7 @@ import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.mutable.HashCasPair;
 import peergos.shared.mutable.MutablePointers;
 import peergos.shared.storage.ContentAddressedStorage;
-import peergos.shared.util.AsyncLock;
+import peergos.shared.util.*;
 
 import java.util.Collections;
 import java.util.Map;
@@ -18,18 +18,18 @@ import java.util.function.Function;
 public class WriteSynchronizer {
     private final MutablePointers mutable;
     private final ContentAddressedStorage dht;
-    private final Map<PublicKeyHash, AsyncLock<CommittedWriterData>> pending = new ConcurrentHashMap<>();
+    private final Map<Pair<PublicKeyHash, PublicKeyHash>, AsyncLock<CommittedWriterData>> pending = new ConcurrentHashMap<>();
 
     public WriteSynchronizer(MutablePointers mutable, ContentAddressedStorage dht) {
         this.mutable = mutable;
         this.dht = dht;
     }
 
-    public void put(PublicKeyHash writer, CommittedWriterData val) {
-        pending.put(writer, new AsyncLock<>(CompletableFuture.completedFuture(val)));
+    public void put(PublicKeyHash owner, PublicKeyHash writer, CommittedWriterData val) {
+        pending.put(new Pair<>(owner, writer), new AsyncLock<>(CompletableFuture.completedFuture(val)));
     }
 
-    public void putEmpty(PublicKeyHash writer) {
+    public void putEmpty(PublicKeyHash owner, PublicKeyHash writer) {
         WriterData emptyWD = new WriterData(writer,
                 Optional.empty(),
                 Optional.empty(),
@@ -39,7 +39,7 @@ public class WriteSynchronizer {
                 Optional.empty(),
                 Optional.empty());
         CommittedWriterData emptyUserData = new CommittedWriterData(MaybeMultihash.empty(), emptyWD);
-        put(writer, emptyUserData);
+        put(owner, writer, emptyUserData);
     }
 
     public CompletableFuture<CommittedWriterData> getWriterData(PublicKeyHash owner, PublicKeyHash writer) {
@@ -58,7 +58,7 @@ public class WriteSynchronizer {
         // otherwise when the future completes, then the two or more waiters will both proceed with the existing hash,
         // and whoever commits first will win. We also need to retrieve the writer data again from the network after
         // a previous transaction has completed (another node/user may have updated the mapping)
-        return pending.computeIfAbsent(writer, w -> new AsyncLock<>(getWriterData(owner, w)))
+        return pending.computeIfAbsent(new Pair<>(owner, writer), p -> new AsyncLock<>(getWriterData(owner, p.right)))
                 .runWithLock(current -> updater.apply(current), () -> getWriterData(owner, writer));
     }
 

--- a/src/peergos/shared/user/fs/AbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/AbsoluteCapability.java
@@ -96,6 +96,10 @@ public class AbsoluteCapability implements Cborable {
         return new AbsoluteCapability(owner, writer, mapKey, newBaseKey, wBaseKey);
     }
 
+    public AbsoluteCapability withOwner(PublicKeyHash owner) {
+        return new AbsoluteCapability(owner, writer, mapKey, rBaseKey, wBaseKey);
+    }
+
     public boolean isNull() {
         PublicKeyHash nullUser = PublicKeyHash.NULL;
         return nullUser.equals(owner) &&

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1169,7 +1169,7 @@ public class FileWrapper {
         // create the new signing subspace move subtree to it
         PublicKeyHash owner = owner();
 
-        network.synchronizer.putEmpty(signer.publicKeyHash);
+        network.synchronizer.putEmpty(owner, signer.publicKeyHash);
         return IpfsTransaction.call(owner,
                 tid -> network.synchronizer.applyUpdate(owner, signer.publicKeyHash, wd2 ->
                         WriterData.createEmpty(owner, signer, network.dhtClient)

--- a/src/peergos/shared/util/AsyncLock.java
+++ b/src/peergos/shared/util/AsyncLock.java
@@ -44,6 +44,7 @@ public class AsyncLock<T> {
                 .exceptionally(t -> {
                     // The initial supplier failed
                     result.completeExceptionally(t);
+                    newHead.completeExceptionally(t);
                     return true;
                 });
 


### PR DESCRIPTION
This involves looking up their new key when logging in, to retrieve
their entry point correctly. AsyncLock needs to consider the owner as
well as the writer in the key.

Without this, when a friend changes their password you cannot log in!