### PR TITLE
Enable mirror pki nodes to cache the pki state.

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -345,7 +345,8 @@ public class Main {
             boolean isPkiNode = nodeId.equals(pkiServerNodeId);
             CoreNode core = isPkiNode ?
                     buildPkiCorenode(sqlMutable, localDht, a) :
-                    new MirrorCoreNode(new HTTPCoreNode(ipfsGateway, pkiServerNodeId), localDht, proxingMutable, peergosId);
+                    new MirrorCoreNode(new HTTPCoreNode(ipfsGateway, pkiServerNodeId), proxingMutable, localDht,
+                            peergosId, a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"));
 
             long defaultQuota = a.getLong("default-quota");
             long maxUsers = a.getLong("max-users");

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -2,38 +2,148 @@ package peergos.server.corenode;
 
 import peergos.server.util.*;
 import peergos.shared.*;
+import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.user.*;
 
+import java.io.*;
+import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.logging.*;
+import java.util.stream.*;
 
 public class MirrorCoreNode implements CoreNode {
 
     private final CoreNode writeTarget;
-    private final ContentAddressedStorage ipfs;
     private final MutablePointers mutable;
+    private final ContentAddressedStorage ipfs;
     private final PublicKeyHash pkiOwnerIdentity;
 
-    private final Map<String, List<UserPublicKeyLink>> chains = new ConcurrentHashMap<>();
-    private final Map<PublicKeyHash, String> reverseLookup = new ConcurrentHashMap<>();
-    private final List<String> usernames = new ArrayList<>();
-
-    private MaybeMultihash currentRoot = MaybeMultihash.empty();
+    private volatile CorenodeState state;
+    private final Path statePath;
     private volatile boolean running = true;
 
     public MirrorCoreNode(CoreNode writeTarget,
-                          ContentAddressedStorage ipfs,
                           MutablePointers mutable,
-                          PublicKeyHash pkiOwnerIdentity) {
+                          ContentAddressedStorage ipfs,
+                          PublicKeyHash pkiOwnerIdentity,
+                          Path statePath) {
         this.writeTarget = writeTarget;
-        this.ipfs = ipfs;
         this.mutable = mutable;
+        this.ipfs = ipfs;
         this.pkiOwnerIdentity = pkiOwnerIdentity;
+        this.statePath = statePath;
+        try {
+            this.state = load(statePath);
+        } catch (IOException e) {
+            // load empty
+            this.state = CorenodeState.buildEmpty(pkiOwnerIdentity, pkiOwnerIdentity, MaybeMultihash.empty(), MaybeMultihash.empty());
+        }
+        try {
+            boolean changed = update();
+            if (changed)
+                saveState();
+        } catch (Throwable t) {
+            Logging.LOG().log(Level.SEVERE, "Couldn't update mirror pki state: " + t.getMessage(), t);
+        }
+    }
+
+    private static class CorenodeState implements Cborable {
+        private final PublicKeyHash pkiOwnerIdentity, pkiKey;
+        private final MaybeMultihash pkiOwnerTarget, pkiKeyTarget;
+
+        private final Map<String, List<UserPublicKeyLink>> chains;
+        private final Map<PublicKeyHash, String> reverseLookup;
+        private final List<String> usernames;
+
+        public CorenodeState(PublicKeyHash pkiOwnerIdentity,
+                             PublicKeyHash pkiKey,
+                             MaybeMultihash pkiOwnerTarget,
+                             MaybeMultihash pkiKeyTarget,
+                             Map<String, List<UserPublicKeyLink>> chains,
+                             Map<PublicKeyHash, String> reverseLookup,
+                             List<String> usernames) {
+            this.pkiOwnerIdentity = pkiOwnerIdentity;
+            this.pkiKey = pkiKey;
+            this.pkiOwnerTarget = pkiOwnerTarget;
+            this.pkiKeyTarget = pkiKeyTarget;
+            this.chains = chains;
+            this.reverseLookup = reverseLookup;
+            this.usernames = usernames;
+        }
+
+        public static CorenodeState buildEmpty(PublicKeyHash pkiOwnerIdentity,
+                                               PublicKeyHash pkiKey,
+                                               MaybeMultihash pkiOwnerTarget,
+                                               MaybeMultihash pkiKeyTarget) {
+            return new CorenodeState(pkiOwnerIdentity, pkiKey, pkiOwnerTarget, pkiKeyTarget, new HashMap<>(),
+                    new HashMap<>(), new ArrayList<>());
+        }
+
+        public void load(CorenodeState other) {
+            chains.putAll(other.chains);
+            reverseLookup.putAll(other.reverseLookup);
+            usernames.clear();
+            usernames.addAll(other.usernames);
+        }
+
+        @Override
+        public CborObject toCbor() {
+            Map<String, Cborable> res = new TreeMap<>();
+            res.put("peergosKey", pkiOwnerIdentity);
+            res.put("peergosTarget", pkiOwnerTarget);
+            res.put("pkiKey", pkiOwnerIdentity);
+            res.put("pkiTarget", pkiKeyTarget);
+
+            TreeMap<CborObject, ? extends Cborable> chainsMap = chains.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    e -> new CborObject.CborString(e.getKey()),
+                    e -> new CborObject.CborList(e.getValue()),
+                    (a,b) -> a,
+                    TreeMap::new
+                ));
+            res.put("chains", new CborObject.CborMap(chainsMap));
+            TreeMap<CborObject, ? extends Cborable> reverseMap = reverseLookup.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    e -> e.getKey().toCbor(),
+                    e -> new CborObject.CborString(e.getValue()),
+                    (a,b) -> a,
+                    TreeMap::new
+                ));
+            res.put("reverse", new CborObject.CborMap(reverseMap));
+            res.put("usernames", new CborObject.CborList(usernames.stream()
+                    .map(CborObject.CborString::new)
+                    .collect(Collectors.toList())));
+
+            return CborObject.CborMap.build(res);
+        }
+
+        public static CorenodeState fromCbor(CborObject cbor) {
+            CborObject.CborMap map = (CborObject.CborMap) cbor;
+            PublicKeyHash peergosKey = map.get("peergosKey", PublicKeyHash::fromCbor);
+            PublicKeyHash pkiKey = map.get("pkiKey", PublicKeyHash::fromCbor);
+            MaybeMultihash peergosTarget = map.get("peergosTarget", MaybeMultihash::fromCbor);
+            MaybeMultihash pkiTarget = map.get("pkiTarget", MaybeMultihash::fromCbor);
+
+            Function<Cborable, String> fromString = e -> ((CborObject.CborString) e).value;
+            Function<? super Cborable, List<UserPublicKeyLink>> chainParser =
+                    c -> ((CborObject.CborList) c).map(UserPublicKeyLink::fromCbor);
+            Map<String, List<UserPublicKeyLink>> chains = ((CborObject.CborMap)map.get("chains"))
+                    .getMap(fromString, chainParser);
+
+            Map<PublicKeyHash, String> reverse = ((CborObject.CborMap)map.get("reverse"))
+                    .getMap(PublicKeyHash::fromCbor, fromString);
+
+            List<String> usernames = map.getList("usernames", fromString);
+            return new CorenodeState(peergosKey, pkiKey, peergosTarget, pkiTarget, chains, reverse, usernames);
+        }
     }
 
     public void start() {
@@ -42,7 +152,9 @@ public class MirrorCoreNode implements CoreNode {
             while (running) {
                 try {
                     Thread.sleep(60_000);
-                    update();
+                    boolean changed = update();
+                    if (changed)
+                        saveState();
                 } catch (Throwable t) {
                     Logging.LOG().log(Level.SEVERE, t.getMessage(), t);
                 }
@@ -50,20 +162,56 @@ public class MirrorCoreNode implements CoreNode {
         }, "Mirroring PKI node").start();
     }
 
-    private PublicKeyHash getPkiKey() throws Exception {
-        CommittedWriterData current = WriterData.getWriterData(pkiOwnerIdentity, pkiOwnerIdentity, mutable, ipfs).get();
-        PublicKeyHash pki = current.props.namedOwnedKeys.get("pki").ownedKey;
-        if (pki == null)
-            throw new IllegalStateException("No pki key on owner: " + pkiOwnerIdentity);
-        return pki;
+    private synchronized void saveState() {
+        byte[] serialized = state.toCbor().serialize();
+        Logging.LOG().info("Writing "+ serialized.length +" bytes to "+ statePath);
+        try {
+            Files.write(
+                    statePath,
+                    serialized,
+                    StandardOpenOption.CREATE);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
+    private static CorenodeState load(Path statePath) throws IOException {
+        Logging.LOG().info("Reading state from " + statePath + " which exists ? " + Files.exists(statePath) + " from cwd " + System.getProperty("cwd"));
+        byte[] data = Files.readAllBytes(statePath);
+        CborObject object = CborObject.fromByteArray(data);
+        return CorenodeState.fromCbor(object);
+    }
+
+    /**
+     *
+     * @return whether there was a change
+     */
     private synchronized boolean update() {
         try {
-            PublicKeyHash pkiKey = getPkiKey();
-            MaybeMultihash newRoot = mutable.getPointerTarget(pkiOwnerIdentity, pkiKey, ipfs).get();
-            IpfsCoreNode.updateAllMappings(pkiKey, currentRoot, newRoot, ipfs, chains, reverseLookup, usernames);
-            currentRoot = newRoot;
+            PublicKeyHash peergosKey = writeTarget.getPublicKeyHash("peergos").join().get();
+
+            MaybeMultihash newPeergosRoot = mutable.getPointerTarget(peergosKey, peergosKey, ipfs).get();
+
+            CommittedWriterData currentPeergosWd = WriterData.getWriterData(newPeergosRoot.get(), ipfs).get();
+            PublicKeyHash pkiKey = currentPeergosWd.props.namedOwnedKeys.get("pki").ownedKey;
+            if (pkiKey == null)
+                throw new IllegalStateException("No pki key on owner: " + pkiOwnerIdentity);
+
+            MaybeMultihash currentPkiRoot = mutable.getPointerTarget(pkiOwnerIdentity, pkiKey, ipfs).get();
+            CorenodeState current = state;
+            if (peergosKey.equals(current.pkiOwnerIdentity) &&
+                    newPeergosRoot.equals(current.pkiOwnerTarget) &&
+                    pkiKey.equals(current.pkiKey) &&
+                    currentPkiRoot.equals(current.pkiKeyTarget))
+                return false;
+
+            Logging.LOG().info("Updating pki mirror state...");
+            CorenodeState updated = CorenodeState.buildEmpty(peergosKey, pkiKey, newPeergosRoot, currentPkiRoot);
+            updated.load(current);
+            IpfsCoreNode.updateAllMappings(pkiKey, current.pkiKeyTarget, currentPkiRoot, ipfs, updated.chains,
+                    updated.reverseLookup, updated.usernames);
+            state = updated;
+            Logging.LOG().info("... finished updating pki mirror state.");
             return true;
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
@@ -72,12 +220,12 @@ public class MirrorCoreNode implements CoreNode {
 
     @Override
     public CompletableFuture<List<UserPublicKeyLink>> getChain(String username) {
-        List<UserPublicKeyLink> chain = chains.get(username);
+        List<UserPublicKeyLink> chain = state.chains.get(username);
         if (chain != null)
             return CompletableFuture.completedFuture(chain);
 
         update();
-        return CompletableFuture.completedFuture(chains.getOrDefault(username, Collections.emptyList()));
+        return CompletableFuture.completedFuture(state.chains.getOrDefault(username, Collections.emptyList()));
     }
 
     @Override
@@ -87,16 +235,16 @@ public class MirrorCoreNode implements CoreNode {
 
     @Override
     public CompletableFuture<String> getUsername(PublicKeyHash key) {
-        String username = reverseLookup.get(key);
+        String username = state.reverseLookup.get(key);
         if (username != null)
             return CompletableFuture.completedFuture(username);
         update();
-        return CompletableFuture.completedFuture(reverseLookup.get(key));
+        return CompletableFuture.completedFuture(state.reverseLookup.get(key));
     }
 
     @Override
     public CompletableFuture<List<String>> getUsernames(String prefix) {
-        return CompletableFuture.completedFuture(usernames);
+        return CompletableFuture.completedFuture(state.usernames);
     }
 
     @Override

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -15,7 +15,7 @@ import java.util.concurrent.*;
 import java.util.function.*;
 import java.util.stream.*;
 
-public class UserPublicKeyLink implements Cborable{
+public class UserPublicKeyLink implements Cborable {
     public static final int MAX_SIZE = 2*1024*1024;
     public static final int MAX_USERNAME_SIZE = CoreNode.MAX_USERNAME_SIZE;
 


### PR DESCRIPTION
This enables self hosters to still log in even in the presence of a
full network partition from the rest of the world!