### PR TITLE
Memoize all the things!

### DIFF
--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -287,9 +287,9 @@ public abstract class UserTests {
 
         //rename
         String newname = "newname.txt";
-        updatedRoot4.getDescendentByPath(otherName, context.network).get().get()
+        FileWrapper updatedRoot5 = updatedRoot4.getDescendentByPath(otherName, context.network).get().get()
                 .rename(newname, updatedRoot4, context).get();
-        checkFileContents(data3, updatedRoot4.getDescendentByPath(newname, context.network).get().get(), context);
+        checkFileContents(data3, updatedRoot5.getDescendentByPath(newname, context.network).get().get(), context);
         // check from the root as well
         checkFileContents(data3, context.getByPath(username + "/" + newname).get().get(), context);
         // check from a fresh log in too

--- a/src/peergos/server/tests/slow/LoginBenchmark.java
+++ b/src/peergos/server/tests/slow/LoginBenchmark.java
@@ -47,8 +47,8 @@ public class LoginBenchmark {
         return UserContext.ensureSignedUp(username, password, network, crypto).get();
     }
 
-    // LOGIN(19) duration: 2323 mS, best: 2134 mS, worst: 2619 mS, av: 2328 mS
-    //    scrypt: 2019 mS
+    // LOGIN(19) duration: 1971 mS, best: 1901 mS, worst: 2246 mS, av: 2039 mS
+    //    scrypt: 1900 mS
     @Test
     public void login() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/slow/MediumFileBenchmark.java
+++ b/src/peergos/server/tests/slow/MediumFileBenchmark.java
@@ -55,8 +55,7 @@ public class MediumFileBenchmark {
     // to
     // UPLOAD(99) duration: 9864 mS, best: 7959 mS, worst: 10653 mS, av: 8974 mS or 1.1 MiB/s
     //
-    // GetData(10) duration: 6674 mS, best: 6605 mS, worst: 6994 mS, av: 6732 mS or 1.5 MiB/s
-    //    pointers.get: 106 * 45 mS = 4770 mS <== This should be 0 or 1 gets!! which would be ~ 4.8 MiB/s
+    // GetData(10) duration: 1037 mS, best: 868 mS, worst: 1167 mS, av: 944 mS or 10.5 MiB/s
     @Test
     public void mediumFiles() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/slow/MkdirBenchmark.java
+++ b/src/peergos/server/tests/slow/MkdirBenchmark.java
@@ -59,7 +59,7 @@ public class MkdirBenchmark {
     // MKDIR(99) duration: 1106 mS, best: 867 mS, worst: 1467 mS, av: 1063 mS
     //    mutable.set 130 mS
     //    block.put 62 mS
-    // GetByPath(99) duration: 48 mS, best: 46 mS, worst: 165 mS, av: 53 mS
+    // GetByPath(99) duration: 9 mS, best: 8 mS, worst: 54 mS, av: 9 mS
     @Test
     public void hugeFolder() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/slow/SmallFileBenchmark.java
+++ b/src/peergos/server/tests/slow/SmallFileBenchmark.java
@@ -55,7 +55,7 @@ public class SmallFileBenchmark {
     // to
     // UPLOAD(99) duration: 1772 mS, best: 1226 mS, worst: 2132 mS, av: 1638 mS
     //
-    // GetData(99) duration: 816 mS, best: 801 mS, worst: 1136 mS, av: 868 mS
+    // GetData(99) duration: 54 mS, best: 51 mS, worst: 234 mS, av: 55 mS
     @Test
     public void smallFiles() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/slow/SocialBenchmark.java
+++ b/src/peergos/server/tests/slow/SocialBenchmark.java
@@ -40,8 +40,7 @@ public class SocialBenchmark {
         });
     }
 
-    // SendFollowRequest(10) duration: 2967 mS, best: 2296 mS, worst: 2967 mS, av: 2572 mS
-    //    pointers.get: 19 * 45 mS = 855 mS
+    // SendFollowRequest(19) duration: 2132 mS, best: 1891 mS, worst: 2576 mS, av: 2110 mS
     //    pointers.set: 4 * 80 mS = 320 mS
     @Test
     public void social() {

--- a/src/peergos/shared/user/MutableTree.java
+++ b/src/peergos/shared/user/MutableTree.java
@@ -21,10 +21,10 @@ public interface MutableTree {
      * @throws IOException
      */
     CompletableFuture<CommittedWriterData> put(PublicKeyHash owner,
-                                                       SigningPrivateKeyAndPublicHash sharingKey,
-                                                       byte[] mapKey,
-                                                       MaybeMultihash existing,
-                                                       Multihash value);
+                                               SigningPrivateKeyAndPublicHash sharingKey,
+                                               byte[] mapKey,
+                                               MaybeMultihash existing,
+                                               Multihash value);
 
     /**
      *
@@ -73,10 +73,12 @@ public interface MutableTree {
      * @return  hash(sharingKey.metadata) | the new root hash of the tree
      * @throws IOException
      */
-    CompletableFuture<Boolean> remove(PublicKeyHash owner,
-                                      SigningPrivateKeyAndPublicHash sharingKey,
-                                      byte[] mapKey,
-                                      MaybeMultihash existing);
+    CompletableFuture<WriterData> remove(WriterData base,
+                                         PublicKeyHash owner,
+                                         SigningPrivateKeyAndPublicHash sharingKey,
+                                         byte[] mapKey,
+                                         MaybeMultihash existing,
+                                         TransactionId tid);
 
 
     class CasException extends RuntimeException {

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -78,18 +78,18 @@ public class MutableTreeImpl implements MutableTree {
     }
 
     @Override
-    public CompletableFuture<Boolean> remove(PublicKeyHash owner,
-                                             SigningPrivateKeyAndPublicHash writer,
-                                             byte[] mapKey,
-                                             MaybeMultihash existing) {
-        return synchronizer.applyUpdate(owner, writer, (wd, tid) -> {
-            if (! wd.tree.isPresent())
-                throw new IllegalStateException("Tree root not present!");
-            return ChampWrapper.create(wd.tree.get(), hasher, dht)
-                    .thenCompose(tree -> tree.remove(owner, writer, mapKey, existing, tid))
-                    .thenApply(pair -> LOGGING ? log(pair, "TREE.rm ("
-                            + ArrayOps.bytesToHex(mapKey) + "  => " + pair) : pair)
-                    .thenApply(newTreeRoot -> wd.withChamp(newTreeRoot));
-        }).thenApply(x -> true);
+    public CompletableFuture<WriterData> remove(WriterData base,
+                                                PublicKeyHash owner,
+                                                SigningPrivateKeyAndPublicHash writer,
+                                                byte[] mapKey,
+                                                MaybeMultihash existing,
+                                                TransactionId tid) {
+        if (! base.tree.isPresent())
+            throw new IllegalStateException("Tree root not present!");
+        return ChampWrapper.create(base.tree.get(), hasher, dht)
+                .thenCompose(tree -> tree.remove(owner, writer, mapKey, existing, tid))
+                .thenApply(pair -> LOGGING ? log(pair, "TREE.rm ("
+                        + ArrayOps.bytesToHex(mapKey) + "  => " + pair) : pair)
+                .thenApply(newTreeRoot -> base.withChamp(newTreeRoot));
     }
 }

--- a/src/peergos/shared/user/Snapshot.java
+++ b/src/peergos/shared/user/Snapshot.java
@@ -3,6 +3,7 @@ package peergos.shared.user;
 import peergos.shared.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -56,6 +57,11 @@ public class Snapshot {
         if (versions.containsKey(writer))
             return CompletableFuture.completedFuture(this);
         return network.synchronizer.getValue(owner, writer).thenApply(s -> s.merge(this));
+    }
+
+    public CompletableFuture<Snapshot> withWriters(PublicKeyHash owner, Set<PublicKeyHash> writers, NetworkAccess network) {
+        return Futures.reduceAll(writers, this,
+                (s, writer) -> s.withWriter(owner, writer, network), (a, b) -> b);
     }
 
     @Override

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -303,13 +303,15 @@ public class FileWrapper {
                                 .thenCompose(mOpt -> {
                                     if (! mOpt.isPresent())
                                         return CompletableFuture.completedFuture(updatedVersion);
-                                    return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()), entryWriter, ownername, version)
-                                            .rotateReadKeys(false, network, random, hasher, parent, Optional.of(baseReadKey), updatedVersion, committer);
+                                    return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()),
+                                            entryWriter, ownername, updatedVersion)
+                                            .rotateReadKeys(false, network, random, hasher, parent,
+                                                    Optional.of(baseReadKey), updatedVersion, committer);
                                 });
                     }).thenCompose(newVersion -> {
                         // only update link from parent folder to file if we are the first chunk
                         return (updateParent ?
-                                network.retrieveMetadata(this.writableFilePointer(), newVersion)
+                                network.retrieveMetadata(this.writableFilePointer().withBaseKey(baseReadKey), newVersion)
                                         .thenCompose(meta -> parent.pointer.fileAccess
                                                 .updateChildLink(newVersion, committer, parent.writableFilePointer(),
                                                         parent.entryWriter, pointer, meta.get(), network, hasher)) :

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -92,6 +92,8 @@ public class FileWrapper {
     }
 
     public CompletableFuture<FileWrapper> getUpdated(Snapshot version, NetworkAccess network) {
+        if (this.version.get(writer()).equals(version.get(writer())))
+            return CompletableFuture.completedFuture(this);
         return network.getFile(version, pointer.capability, entryWriter, ownername)
                 .thenApply(Optional::get);
     }
@@ -156,16 +158,16 @@ public class FileWrapper {
         modified.set(true);
     }
 
-    public CompletableFuture<FileWrapper> updateChildLinks(
-            Collection<Pair<RetrievedCapability, RetrievedCapability>> childCases,
+    public CompletableFuture<Snapshot> updateChildLinks(
+            Snapshot version,
+            WriteSynchronizer.Committer committer,
+            Collection<Pair<AbsoluteCapability, AbsoluteCapability>> childCases,
             NetworkAccess network,
             SafeRandom random,
             Hasher hasher) {
         return pointer.fileAccess
-                .updateChildLinks((WritableAbsoluteCapability) pointer.capability, entryWriter,
-                        childCases, network, random, hasher)
-                .thenApply(committedCryptree ->
-                        new FileWrapper(pointer.withCryptree(committedCryptree), entryWriter, ownername, version));
+                .updateChildLinks(version, committer, (WritableAbsoluteCapability) pointer.capability, entryWriter,
+                        childCases, network, random, hasher);
     }
 
     /**
@@ -175,17 +177,17 @@ public class FileWrapper {
      * @param random
      * @return An updated version of this directory
      */
-    public CompletableFuture<FileWrapper> addChildLinks(Collection<RetrievedCapability> children,
-                                                        NetworkAccess network,
-                                                        SafeRandom random,
-                                                        Hasher hasher) {
+    public CompletableFuture<Snapshot> addChildLinks(Snapshot version,
+                                                     WriteSynchronizer.Committer committer,
+                                                     Collection<RetrievedCapability> children,
+                                                     NetworkAccess network,
+                                                     SafeRandom random,
+                                                     Hasher hasher) {
         return pointer.fileAccess
-                .addChildrenAndCommit(children.stream()
+                .addChildrenAndCommit(version, committer, children.stream()
                                 .map(p -> ((WritableAbsoluteCapability)pointer.capability).relativise(p.capability))
                                 .collect(Collectors.toList()), (WritableAbsoluteCapability) pointer.capability, entryWriter,
-                        network, random, hasher)
-                .thenApply(committedCryptree ->
-                        new FileWrapper(pointer.withCryptree(committedCryptree), entryWriter, ownername, version));
+                        network, random, hasher);
     }
 
     /**
@@ -198,15 +200,22 @@ public class FileWrapper {
      * @throws IOException
      */
     public CompletableFuture<FileWrapper> rotateReadKeys(NetworkAccess network, SafeRandom random, Hasher hasher, FileWrapper parent) {
-        return rotateReadKeys(true, network, random, hasher, parent, Optional.empty());
+        Optional<SymmetricKey> newBaseKey = Optional.of(SymmetricKey.random());
+        WritableAbsoluteCapability ourNewCap = writableFilePointer().withBaseKey(newBaseKey.get());
+        return network.synchronizer.applyComplexUpdate(owner(), signingPair(), (current, committer) ->
+                rotateReadKeys(true, network, random, hasher, parent, newBaseKey, current, committer))
+                .thenCompose(version -> network.getFile(version, ourNewCap, entryWriter, ownername)
+                        .thenApply(newUs -> newUs.get()));
     }
 
-    private CompletableFuture<FileWrapper> rotateReadKeys(boolean updateParent,
-                                                          NetworkAccess network,
-                                                          SafeRandom random,
-                                                          Hasher hasher,
-                                                          FileWrapper parent,
-                                                          Optional<SymmetricKey> newBaseKey) {
+    private CompletableFuture<Snapshot> rotateReadKeys(boolean updateParent,
+                                                       NetworkAccess network,
+                                                       SafeRandom random,
+                                                       Hasher hasher,
+                                                       FileWrapper parent,
+                                                       Optional<SymmetricKey> newBaseKey,
+                                                       Snapshot version,
+                                                       WriteSynchronizer.Committer committer) {
         if (!isWritable())
             throw new IllegalStateException("You cannot rotate read keys without write access!");
         WritableAbsoluteCapability cap = writableFilePointer();
@@ -233,37 +242,46 @@ public class FileWrapper {
                             tid -> CryptreeNode.createDir(existing.committedHash(), newSubfoldersKey, cap.wBaseKey.get(),
                                     signer, props, Optional.of(cap.relativise(parent.writableFilePointer())),
                                     newParentKey, toNextChunk, new CryptreeNode.ChildrenLinks(children), hasher)
-                                    .commit(ourNewPointer, entryWriter, network, tid), network.dhtClient))
-                    .thenCompose(updatedDirAccess -> {
-                        RetrievedCapability ourNewRetrievedPointer = new RetrievedCapability(ourNewPointer, updatedDirAccess);
-                        FileWrapper theNewUs = new FileWrapper(ourNewRetrievedPointer, entryWriter, ownername, version);
+                                    .commit(version, committer, ourNewPointer, entryWriter, network, tid), network.dhtClient))
+                    .thenCompose(updatedVersion -> network.getFile(updatedVersion, ourNewPointer, entryWriter, ownername)
+                            .thenCompose(usOpt -> {
+                                FileWrapper theNewUs = usOpt.get();
 
-                        // clean all subtree keys except file dataKeys (lazily re-key and re-encrypt them)
-                        return getDirectChildren(network).thenCompose(childFiles -> {
-                            List<CompletableFuture<Pair<RetrievedCapability, RetrievedCapability>>> cleanedChildren = childFiles.stream()
-                                    .map(child -> child.rotateReadKeys(false, network, random, hasher, theNewUs,
-                                            Optional.empty())
-                                            .thenApply(updated -> new Pair<>(child.pointer, updated.pointer)))
-                                    .collect(Collectors.toList());
-
-                            return Futures.combineAll(cleanedChildren);
-                        }).thenCompose(childrenCases -> theNewUs.updateChildLinks(childrenCases, network, random, hasher))
-                                .thenCompose(finished ->
-                                        // update pointer from parent to us
-                                        (updateParent ? parent.pointer.fileAccess
-                                                .updateChildLink((WritableAbsoluteCapability) parent.pointer.capability,
-                                                        parent.entryWriter, this.pointer,
-                                                        ourNewRetrievedPointer, network, random, hasher) :
-                                                CompletableFuture.completedFuture(null))
-                                                .thenApply(x -> theNewUs));
-                    }).thenCompose(updated -> {
+                                // clean all subtree keys except file dataKeys (lazily re-key and re-encrypt them)
+                                return getDirectChildren(network).thenCompose(childFiles -> {
+                                    List<Pair<FileWrapper, SymmetricKey>> childrenWithNewKeys = childFiles.stream()
+                                            .map(c -> new Pair<>(c, SymmetricKey.random()))
+                                            .collect(Collectors.toList());
+                                    return Futures.reduceAll(childrenWithNewKeys, version,
+                                            (s, childAndKey) -> childAndKey.left.rotateReadKeys(false,
+                                                    network, random, hasher, theNewUs,
+                                                    Optional.of(childAndKey.right), s, committer), (a, b) -> b)
+                                            .thenCompose(newVersion -> theNewUs.updateChildLinks(newVersion, committer,
+                                                    childrenWithNewKeys.stream()
+                                                            .map(p -> new Pair<>(p.left.pointer.capability,
+                                                                    p.left.pointer.capability.withBaseKey(p.right)))
+                                                            .collect(Collectors.toList()),
+                                                    network, random, hasher))
+                                            .thenCompose(finished ->
+                                                    // update pointer from parent to us
+                                                    (updateParent ? parent.pointer.fileAccess
+                                                            .updateChildLink(finished, committer,
+                                                                    (WritableAbsoluteCapability) parent.pointer.capability,
+                                                                    parent.entryWriter, this.pointer,
+                                                                    theNewUs.pointer, network, random, hasher) :
+                                                            CompletableFuture.completedFuture(null))
+                                            );
+                                });
+                            })
+                    ).thenCompose(updated -> {
                         return network.getMetadata(nextChunkCap)
                                 .thenCompose(mOpt -> {
                                     if (! mOpt.isPresent())
                                         return CompletableFuture.completedFuture(updated);
-                                    return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()), entryWriter, ownername, version)
-                                            .rotateReadKeys(false, network, random, hasher, parent, Optional.of(newSubfoldersKey))
-                                            .thenApply(x -> updated);
+                                    return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()),
+                                            entryWriter, ownername, version)
+                                            .rotateReadKeys(false, network, random, hasher, parent,
+                                                    Optional.of(newSubfoldersKey), updated, committer);
                                 });
                     }).thenApply(x -> {
                         setModified();
@@ -273,27 +291,26 @@ public class FileWrapper {
             // create a new rBaseKey == parentKey
             SymmetricKey baseReadKey = newBaseKey.orElseGet(SymmetricKey::random);
             return pointer.fileAccess.rotateBaseReadKey(writableFilePointer(), entryWriter,
-                    cap.relativise(parent.getMinimalReadPointer()), baseReadKey, network)
-                    .thenCompose(updated -> {
+                    cap.relativise(parent.getMinimalReadPointer()), baseReadKey, network, version, committer)
+                    .thenCompose(updatedVersion -> {
                         byte[] nextChunkMapKey = pointer.fileAccess.getNextChunkLocation(cap.rBaseKey);
                         WritableAbsoluteCapability nextChunkCap = cap.withMapKey(nextChunkMapKey);
                         return network.getMetadata(nextChunkCap)
                                 .thenCompose(mOpt -> {
                                     if (! mOpt.isPresent())
-                                        return CompletableFuture.completedFuture(updated);
+                                        return CompletableFuture.completedFuture(updatedVersion);
                                     return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()), entryWriter, ownername, version)
-                                            .rotateReadKeys(false, network, random, hasher, parent, Optional.of(baseReadKey))
-                                            .thenApply(x -> updated);
+                                            .rotateReadKeys(false, network, random, hasher, parent, Optional.of(baseReadKey), updatedVersion, committer);
                                 });
-                    }).thenCompose(newFileAccess -> {
-                        RetrievedCapability newPointer = new RetrievedCapability(this.pointer.capability.withBaseKey(baseReadKey), newFileAccess);
+                    }).thenCompose(newVersion -> {
                         // only update link from parent folder to file if we are the first chunk
                         return (updateParent ?
-                                parent.pointer.fileAccess
-                                        .updateChildLink(parent.writableFilePointer(), parent.entryWriter, pointer,
-                                                newPointer, network, random, hasher) :
-                                CompletableFuture.completedFuture(null)
-                        ).thenApply(x -> new FileWrapper(newPointer, entryWriter, ownername, version));
+                                network.retrieveMetadata(this.writableFilePointer(), newVersion)
+                                        .thenCompose(meta -> parent.pointer.fileAccess
+                                                .updateChildLink(newVersion, committer, parent.writableFilePointer(),
+                                                        parent.entryWriter, pointer, meta.get(), network, random, hasher)) :
+                                CompletableFuture.completedFuture(newVersion)
+                        );
                     }).thenApply(x -> {
                         setModified();
                         return x;
@@ -312,15 +329,23 @@ public class FileWrapper {
                                                                              NetworkAccess network,
                                                                              SafeRandom random,
                                                                              Hasher hasher) {
-        return rotateWriteKeys(true, parent, Optional.empty(), network, random, hasher);
+        Optional<SymmetricKey> newBaseWriteKey = Optional.of(SymmetricKey.random());
+        WritableAbsoluteCapability ourNewCap = writableFilePointer().withBaseWriteKey(newBaseWriteKey.get());
+        return network.synchronizer.applyComplexUpdate(owner(), signingPair(), (current, committer) ->
+                rotateWriteKeys(true, parent, newBaseWriteKey, network, random, hasher, current, committer))
+                .thenCompose(s -> parent.getUpdated(s, network)
+                        .thenCompose(p -> network.getFile(s, ourNewCap, entryWriter, ownername)
+                                .thenApply(newUs -> new Pair<>(newUs.get(), p))));
     }
 
-    private CompletableFuture<Pair<FileWrapper, FileWrapper>> rotateWriteKeys(boolean updateParent,
-                                                                              FileWrapper parent,
-                                                                              Optional<SymmetricKey> suppliedBaseWriteKey,
-                                                                              NetworkAccess network,
-                                                                              SafeRandom random,
-                                                                              Hasher hasher) {
+    private CompletableFuture<Snapshot> rotateWriteKeys(boolean updateParent,
+                                                        FileWrapper parent,
+                                                        Optional<SymmetricKey> suppliedBaseWriteKey,
+                                                        NetworkAccess network,
+                                                        SafeRandom random,
+                                                        Hasher hasher,
+                                                        Snapshot version,
+                                                        WriteSynchronizer.Committer committer) {
         if (!isWritable())
             throw new IllegalStateException("You cannot rotate write keys without write access!");
         WritableAbsoluteCapability cap = writableFilePointer();
@@ -345,38 +370,32 @@ public class FileWrapper {
                     tid -> updatedDirAccess.commitChildrenLinks(ourNewPointer, entryWriter, network, tid), network.dhtClient)
                     .thenCompose(hashes -> getDirectChildren(network))
                     .thenCompose(childFiles -> {
-                        List<CompletableFuture<Pair<RetrievedCapability, RetrievedCapability>>> cleanedChildren = childFiles.stream()
-                                .map(child -> child.rotateWriteKeys(false, theNewUs, Optional.empty(), network, random, hasher)
-                                        .thenApply(updated -> new Pair<>(child.pointer, updated.left.pointer)))
+                        List<RetrievedCapability> childPointers = childFiles.stream()
+                                .map(c -> c.pointer)
                                 .collect(Collectors.toList());
-
-                        return Futures.combineAll(cleanedChildren);
-                    }).thenCompose(childrenCases -> {
-
-                                return theNewUs.addChildLinks(childrenCases.stream()
-                                        .map(p -> p.left)
-                                        .collect(Collectors.toList()), network, random, hasher);
-                    }
-                    ).thenCompose(updatedDir ->
+                        return Futures.reduceAll(childFiles, version,
+                                (s, child) -> child.rotateWriteKeys(false, theNewUs, Optional.empty(),
+                                        network, random, hasher, version, committer), (a, b) -> b)
+                                .thenCompose(version2 -> theNewUs.addChildLinks(version2, committer, childPointers, network, random, hasher));
+                    }).thenCompose(updatedVersion ->
                             // update pointer from parent to us
-                            (updateParent ? parent.pointer.fileAccess
-                                    .updateChildLink((WritableAbsoluteCapability) parent.pointer.capability,
-                                            parent.entryWriter, this.pointer,
-                                            updatedDir.pointer, network, random, hasher)
-                                    .thenApply(parentDa -> new FileWrapper(parent.pointer.withCryptree(parentDa),
-                                            parent.entryWriter, parent.ownername, version)):
-                                    CompletableFuture.completedFuture(parent))
-                                    .thenApply(newParent -> new Pair<>(updatedDir, newParent))
-                    ).thenCompose(updatedPair -> {
+                            (updateParent ?
+                                    network.retrieveMetadata(this.writableFilePointer(), updatedVersion)
+                                            .thenCompose(updatedUs -> parent.pointer.fileAccess
+                                                    .updateChildLink(updatedVersion, committer,
+                                                            (WritableAbsoluteCapability) parent.pointer.capability,
+                                                            parent.entryWriter, this.pointer,
+                                                            updatedUs.get(), network, random, hasher)) :
+                                    CompletableFuture.completedFuture(updatedVersion))
+                    ).thenCompose(updatedVersion -> {
                         return network.getMetadata(nextChunkCap)
                                 .thenCompose(mOpt -> {
                                     if (! mOpt.isPresent())
-                                        return CompletableFuture.completedFuture(updatedPair);
+                                        return CompletableFuture.completedFuture(updatedVersion);
                                     return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()),
                                             Optional.of(signingPair()), ownername, version)
                                             .rotateWriteKeys(false, parent,
-                                                    Optional.of(newBaseWriteKey), network, random, hasher)
-                                            .thenApply(x -> updatedPair);
+                                                    Optional.of(newBaseWriteKey), network, random, hasher, updatedVersion, committer);
                                 });
                     }).thenApply(x -> {
                         setModified();
@@ -385,10 +404,7 @@ public class FileWrapper {
         } else {
             CryptreeNode existing = pointer.fileAccess;
             // Only need to do the first chunk, because only those can have writer links
-            return existing.rotateBaseWriteKey(cap, entryWriter, newBaseWriteKey, network)
-                    .thenApply(updatedFa -> new Pair<>(
-                            new FileWrapper(new RetrievedCapability(ourNewPointer, updatedFa), entryWriter,
-                                    ownername, version), parent));
+            return existing.rotateBaseWriteKey(cap, entryWriter, newBaseWriteKey, network, version, committer);
         }
     }
 
@@ -398,7 +414,7 @@ public class FileWrapper {
                 .thenApply(children -> children.stream().anyMatch(c -> c.props.name.equals(name)));
     }
 
-    public CompletableFuture<Boolean> hasChildWithName(WriterData version, String name, NetworkAccess network) {
+    public CompletableFuture<Boolean> hasChildWithName(Snapshot version, String name, NetworkAccess network) {
         ensureUnmodified();
         return getChildren(version, network)
                 .thenApply(children -> children.stream().anyMatch(c -> c.props.name.equals(name)));
@@ -429,7 +445,7 @@ public class FileWrapper {
         if (!this.isDirectory() || !this.isWritable()) {
             return Futures.errored(new IllegalArgumentException("Can only add link to a writable directory!"));
         }
-        return hasChildWithName(version.get(writer()).props, name, network).thenCompose(hasChild -> {
+        return hasChildWithName(version, name, network).thenCompose(hasChild -> {
             if (hasChild) {
                 return Futures.errored(new IllegalStateException("Child already exists with name: " + name));
             }
@@ -471,7 +487,7 @@ public class FileWrapper {
         ensureUnmodified();
         if (!this.isDirectory())
             return CompletableFuture.completedFuture(Collections.emptySet());
-        return pointer.fileAccess.getAllChildrenCapabilities(pointer.capability, network);
+        return pointer.fileAccess.getAllChildrenCapabilities(version, pointer.capability, network);
     }
 
     public CompletableFuture<Optional<FileWrapper>> retrieveParent(NetworkAccess network) {
@@ -479,7 +495,7 @@ public class FileWrapper {
         if (pointer == null)
             return CompletableFuture.completedFuture(Optional.empty());
         AbsoluteCapability cap = pointer.capability;
-        CompletableFuture<RetrievedCapability> parent = pointer.fileAccess.getParent(cap.owner, cap.writer, cap.rBaseKey, network);
+        CompletableFuture<RetrievedCapability> parent = pointer.fileAccess.getParent(cap.owner, cap.writer, cap.rBaseKey, network, version);
         return parent.thenApply(parentRFP -> {
             if (parentRFP == null)
                 return Optional.empty();
@@ -528,13 +544,13 @@ public class FileWrapper {
         throw new IllegalStateException("Unreadable FileWrapper!");
     }
 
-    public CompletableFuture<Set<FileWrapper>> getChildren(WriterData base, NetworkAccess network) {
+    public CompletableFuture<Set<FileWrapper>> getChildren(Snapshot version, NetworkAccess network) {
         if (globalRoot.isPresent())
             return globalRoot.get().getChildren("/", network);
         if (isReadable()) {
             Optional<SigningPrivateKeyAndPublicHash> childsEntryWriter = pointer.capability.wBaseKey
                     .map(wBase -> pointer.fileAccess.getSigner(pointer.capability.rBaseKey, wBase, entryWriter));
-            return retrieveChildren(base, network).thenApply(childrenRFPs -> {
+            return retrieveChildren(version, network).thenApply(childrenRFPs -> {
                 Set<FileWrapper> newChildren = childrenRFPs.stream()
                         .map(x -> new FileWrapper(x, childsEntryWriter, ownername, version))
                         .collect(Collectors.toSet());
@@ -566,8 +582,8 @@ public class FileWrapper {
                 .thenApply(children -> children.stream().filter(f -> f.getName().equals(name)).findAny());
     }
 
-    public CompletableFuture<Optional<FileWrapper>> getChild(WriterData base, String name, NetworkAccess network) {
-        return getChildren(base, network)
+    public CompletableFuture<Optional<FileWrapper>> getChild(Snapshot version, String name, NetworkAccess network) {
+        return getChildren(version, network)
                 .thenApply(children -> children.stream().filter(f -> f.getName().equals(name)).findAny());
     }
 
@@ -575,15 +591,15 @@ public class FileWrapper {
         CryptreeNode fileAccess = pointer.fileAccess;
 
         if (isReadable())
-            return fileAccess.getChildren(network, pointer.capability);
+            return fileAccess.getChildren(version, network, pointer.capability);
         throw new IllegalStateException("No credentials to retrieve children!");
     }
 
-    private CompletableFuture<Set<RetrievedCapability>> retrieveChildren(WriterData base, NetworkAccess network) {
+    private CompletableFuture<Set<RetrievedCapability>> retrieveChildren(Snapshot version, NetworkAccess network) {
         CryptreeNode fileAccess = pointer.fileAccess;
 
         if (isReadable())
-            return fileAccess.getChildren(base, network, pointer.capability);
+            return fileAccess.getChildren(version, network, pointer.capability);
         throw new IllegalStateException("No credentials to retrieve children!");
     }
 
@@ -591,7 +607,7 @@ public class FileWrapper {
         CryptreeNode fileAccess = pointer.fileAccess;
 
         if (isReadable())
-            return fileAccess.getDirectChildren(pointer.capability, network);
+            return fileAccess.getDirectChildren(version, pointer.capability, network);
         throw new IllegalStateException("No credentials to retrieve children!");
     }
 
@@ -750,7 +766,7 @@ public class FileWrapper {
                                                          Hasher hasher,
                                                          ProgressConsumer<Long> monitor,
                                                          List<Location> locations) {
-        return getUpdated(current, network).thenCompose(latest -> latest.getChild(current.get(writer()).props, filename, network)
+        return getUpdated(current, network).thenCompose(latest -> latest.getChild(current, filename, network)
                 .thenCompose(childOpt -> {
                     if (childOpt.isPresent()) {
                         if (! overwriteExisting)
@@ -886,7 +902,7 @@ public class FileWrapper {
         return current.withWriter(existingChild.owner(), existingChild.writer(), network)
                 .thenCompose(state -> (existingChild.isDirty() ?
                                 existingChild.clean(state, committer, network, random, parent, hasher)
-                                        .thenCompose(pair -> pair.left.getChild(pair.right.get(existingChild.writer()).props, filename, network)
+                                        .thenCompose(pair -> pair.left.getChild(pair.right, filename, network)
                                                 .thenApply(cleanedChild -> new Triple<>(pair.left, cleanedChild.get(), pair.right))) :
                         CompletableFuture.completedFuture(new Triple<>(this, existingChild, state)))
                 ).thenCompose(updatedTriple -> {
@@ -1024,7 +1040,7 @@ public class FileWrapper {
             return result;
         }
         return network.synchronizer.applyComplexUpdate(owner(), signingPair(),
-                (state, committer) -> hasChildWithName(state.get(writer()).props, newFolderName, network).thenCompose(hasChild -> {
+                (state, committer) -> hasChildWithName(state, newFolderName, network).thenCompose(hasChild -> {
                     if (hasChild) {
                         CompletableFuture<Snapshot> error = new CompletableFuture<>();
                         error.completeExceptionally(new IllegalStateException("Child already exists with name: " + newFolderName));
@@ -1036,7 +1052,7 @@ public class FileWrapper {
                         return x;
                     });
                 })).thenCompose(version -> getUpdated(version, network)
-                .thenCompose(newUs -> newUs.getChild(version.get(writer()).props, newFolderName, network))
+                .thenCompose(newUs -> newUs.getChild(version, newFolderName, network))
                 .thenApply(Optional::get));
     }
 
@@ -1160,8 +1176,8 @@ public class FileWrapper {
             return Futures.errored(new IllegalStateException("CopyTo target " + target + " must be a directory"));
         }
 
-        return context.network.synchronizer.applyComplexUpdate(target.owner(), target.signingPair(), (base, committer) -> {
-            return target.hasChildWithName(base.get(target.writer()).props, getFileProperties().name, network).thenCompose(childExists -> {
+        return context.network.synchronizer.applyComplexUpdate(target.owner(), target.signingPair(), (version, committer) -> {
+            return target.hasChildWithName(version, getFileProperties().name, network).thenCompose(childExists -> {
                 if (childExists) {
                     CompletableFuture<Snapshot> error = new CompletableFuture<>();
                     error.completeExceptionally(new IllegalStateException("CopyTo target " + target + " already has child with name " + getFileProperties().name));
@@ -1174,14 +1190,14 @@ public class FileWrapper {
                     WritableAbsoluteCapability newCap = new WritableAbsoluteCapability(target.owner(), target.writer(),
                             newMapKey, newBaseKey, newWriterBaseKey);
                     SymmetricKey newParentParentKey = target.getParentKey();
-                    return pointer.fileAccess.copyTo(base, committer, pointer.capability, newBaseKey,
+                    return pointer.fileAccess.copyTo(version, committer, pointer.capability, newBaseKey,
                                     target.writableFilePointer(), target.entryWriter, newParentParentKey,
                                     newMapKey, network, random, hasher)
                             .thenCompose(updatedBase -> {
                                 return target.addLinkTo(updatedBase, committer, getName(), newCap, network, random, hasher);
                             });
                 } else {
-                    return base.withWriter(owner(), writer(), network).thenCompose(snapshot ->
+                    return version.withWriter(owner(), writer(), network).thenCompose(snapshot ->
                             getInputStream(snapshot.get(writer()).props, network, random, x -> {})
                                     .thenCompose(stream -> target.uploadFileSection(snapshot, committer,
                                             getName(), stream, false, 0, getSize(),
@@ -1215,26 +1231,27 @@ public class FileWrapper {
         CryptreeNode newFileAccess = fileAccess
                 .withWriterLink(cap.rBaseKey, signerLink)
                 .withParentLink(getParentKey(), newParentLink);
-        RetrievedCapability newRetrievedCapability = new RetrievedCapability(cap.withSigner(signer.publicKeyHash), newFileAccess);
+        WritableAbsoluteCapability ourNewCap = cap.withSigner(signer.publicKeyHash);
+        RetrievedCapability newRetrievedCapability = new RetrievedCapability(ourNewCap, newFileAccess);
 
         // create the new signing subspace move subtree to it
         PublicKeyHash owner = owner();
 
         network.synchronizer.putEmpty(owner, signer.publicKeyHash);
-        return network.synchronizer.applyUpdate(owner, signer, (wd, tid) -> CompletableFuture.completedFuture(wd))
-                .thenCompose(empty -> IpfsTransaction.call(owner,
-                        tid -> network.uploadChunk(newFileAccess, owner, getPointer().capability.getMapKey(), signer, tid)
-                                .thenCompose(ourNewHash -> copyAllChunks(false, cap, signer, network)
-                                        .thenCompose(y -> parent.getPointer().fileAccess.updateChildLink(parent.writableFilePointer(),
-                                                parent.entryWriter,
-                                                getPointer(),
-                                                newRetrievedCapability, network, random, hasher))
-                                        .thenCompose(updatedParentDA -> deleteAllChunks(cap, signingPair(), tid, network)
-                                        .thenApply(x -> new FileWrapper(parent.pointer
-                                                .withCryptree(updatedParentDA), parent.entryWriter, parent.ownername, version)))
-                                .thenApply(updatedParent -> new Pair<>(new FileWrapper(newRetrievedCapability.withHash(ourNewHash),
-                                        Optional.of(signer), ownername, version), updatedParent))),
-                network.dhtClient));
+        return network.synchronizer.applyComplexUpdate(owner, signer, (version, committer) -> IpfsTransaction.call(owner,
+                tid -> network.uploadChunk(version, committer, newFileAccess, owner, getPointer().capability.getMapKey(), signer, tid)
+                        .thenCompose(newVersion -> copyAllChunks(false, cap, signer, network, newVersion, committer))
+                        .thenCompose(copiedVersion -> parent.getPointer().fileAccess
+                                .updateChildLink(copiedVersion, committer, parent.writableFilePointer(),
+                                        parent.entryWriter,
+                                        getPointer(),
+                                        newRetrievedCapability, network, random, hasher))
+                        .thenCompose(updatedParentVersion -> deleteAllChunks(cap, signingPair(), tid, network,
+                                updatedParentVersion, committer)),
+                network.dhtClient)
+        ).thenCompose(finalVersion -> parent.getUpdated(finalVersion, network)
+                .thenCompose(updatedParent -> network.getFile(finalVersion, ourNewCap, Optional.of(signer), ownername)
+                .thenApply(updatedUs -> new Pair<>(updatedUs.get(), updatedParent))));
     }
 
     /** This copies all the cryptree nodes from one signing key to another for a file or subtree
@@ -1245,63 +1262,74 @@ public class FileWrapper {
      * @param network
      * @return
      */
-    private static CompletableFuture<Boolean> copyAllChunks(boolean includeFirst,
-                                                            AbsoluteCapability currentCap,
-                                                            SigningPrivateKeyAndPublicHash targetSigner,
-                                                            NetworkAccess network) {
+    private static CompletableFuture<Snapshot> copyAllChunks(boolean includeFirst,
+                                                             AbsoluteCapability currentCap,
+                                                             SigningPrivateKeyAndPublicHash targetSigner,
+                                                             NetworkAccess network,
+                                                             Snapshot version,
+                                                             WriteSynchronizer.Committer committer) {
 
         return network.getMetadata(currentCap)
                 .thenCompose(mOpt -> {
                     if (! mOpt.isPresent()) {
-                        return CompletableFuture.completedFuture(true);
+                        return CompletableFuture.completedFuture(version);
                     }
                     return (includeFirst ?
-                            network.addPreexistingChunk(mOpt.get(), currentCap.owner, currentCap.getMapKey(), targetSigner) :
-                            CompletableFuture.completedFuture(true))
-                            .thenCompose(b -> {
+                            IpfsTransaction.call(currentCap.owner,
+                                    tid -> network.addPreexistingChunk(mOpt.get(), currentCap.owner, currentCap.getMapKey(),
+                                    targetSigner, tid, version, committer), network.dhtClient) :
+                            CompletableFuture.completedFuture(version))
+                            .thenCompose(updated -> {
                                 CryptreeNode chunk = mOpt.get();
                                 byte[] nextChunkMapKey = chunk.getNextChunkLocation(currentCap.rBaseKey);
-                                return copyAllChunks(true, currentCap.withMapKey(nextChunkMapKey), targetSigner, network);
+                                return copyAllChunks(true, currentCap.withMapKey(nextChunkMapKey),
+                                        targetSigner, network, updated, committer);
                             })
-                            .thenCompose(b -> {
+                            .thenCompose(updatedVersion -> {
                                 if (! mOpt.get().isDirectory())
-                                    return CompletableFuture.completedFuture(true);
+                                    return CompletableFuture.completedFuture(updatedVersion);
                                 return mOpt.get().getDirectChildrenCapabilities(currentCap, network).thenCompose(childCaps ->
                                         Futures.reduceAll(childCaps,
-                                                true,
-                                                (x, cap) -> copyAllChunks(true, cap, targetSigner, network),
-                                                (x, y) -> x && y));
+                                                updatedVersion,
+                                                (v, cap) -> copyAllChunks(true, cap, targetSigner, network,
+                                                        v, committer),
+                                                (x, y) -> y));
                             });
                 });
     }
 
-    public static CompletableFuture<Boolean> deleteAllChunks(WritableAbsoluteCapability currentCap,
-                                                             SigningPrivateKeyAndPublicHash signer,
-                                                             TransactionId tid,
-                                                             NetworkAccess network) {
-        return network.getMetadata(currentCap)
+    public static CompletableFuture<Snapshot> deleteAllChunks(WritableAbsoluteCapability currentCap,
+                                                              SigningPrivateKeyAndPublicHash signer,
+                                                              TransactionId tid,
+                                                              NetworkAccess network,
+                                                              Snapshot version,
+                                                              WriteSynchronizer.Committer committer) {
+        return network.getMetadata(version.get(currentCap.writer).props, currentCap)
                 .thenCompose(mOpt -> {
                     if (! mOpt.isPresent()) {
-                        return CompletableFuture.completedFuture(true);
+                        return CompletableFuture.completedFuture(version);
                     }
                     SigningPrivateKeyAndPublicHash ourSigner = mOpt.get()
                             .getSigner(currentCap.rBaseKey, currentCap.wBaseKey.get(), Optional.of(signer));
-                    return network.deleteChunk(mOpt.get(), currentCap.owner, currentCap.getMapKey(), ourSigner)
-                            .thenCompose(b -> {
+                    return network.deleteChunk(version, committer, mOpt.get(), currentCap.owner,
+                            currentCap.getMapKey(), ourSigner, tid)
+                            .thenCompose(deletedVersion -> {
                                 CryptreeNode chunk = mOpt.get();
                                 byte[] nextChunkMapKey = chunk.getNextChunkLocation(currentCap.rBaseKey);
-                                return deleteAllChunks(currentCap.withMapKey(nextChunkMapKey), signer, tid, network);
+                                return deleteAllChunks(currentCap.withMapKey(nextChunkMapKey), signer, tid, network,
+                                        deletedVersion, committer);
                             })
-                            .thenCompose(b -> {
+                            .thenCompose(updatedVersion -> {
                                 if (! mOpt.get().isDirectory())
-                                    return CompletableFuture.completedFuture(true);
+                                    return CompletableFuture.completedFuture(updatedVersion);
                                 return mOpt.get().getDirectChildrenCapabilities(currentCap, network).thenCompose(childCaps ->
                                         Futures.reduceAll(childCaps,
-                                                true,
-                                                (x, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap, signer, tid, network),
-                                                (x, y) -> x && y));
+                                                updatedVersion,
+                                                (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap, signer,
+                                                        tid, network, v, committer),
+                                                (x, y) -> y));
                             })
-                            .thenCompose(b -> removeSigningKey(currentCap.writer, signer, currentCap.owner, network));
+                            .thenCompose(s -> removeSigningKey(currentCap.writer, signer, currentCap.owner, network, s, committer));
                 });
     }
 
@@ -1320,25 +1348,28 @@ public class FileWrapper {
 
         boolean writableParent = parent.isWritable();
         return (writableParent ? parent.removeChild(this, network, hasher) : CompletableFuture.completedFuture(parent))
-                .thenCompose(updatedParent -> IpfsTransaction.call(owner(),
-                        tid -> FileWrapper.deleteAllChunks(writableFilePointer(),
-                                writableParent ? parent.signingPair() : signingPair(), tid, network), network.dhtClient)
+                .thenCompose(updatedParent -> network.synchronizer.applyComplexUpdate(owner(), signingPair(),
+                        (version, committer) -> IpfsTransaction.call(owner(),
+                        tid -> FileWrapper.deleteAllChunks(writableFilePointer(), writableParent ?
+                                parent.signingPair() :
+                                signingPair(), tid, network, version, committer), network.dhtClient))
                         .thenApply(b -> {
                             userContext.sharedWithCache.clearSharedWith(pointer.capability);
                             return updatedParent;
                         }));
     }
 
-    public static CompletableFuture<Boolean> removeSigningKey(PublicKeyHash signerToRemove,
-                                                              SigningPrivateKeyAndPublicHash parentSigner,
-                                                              PublicKeyHash owner,
-                                                              NetworkAccess network) {
+    public static CompletableFuture<Snapshot> removeSigningKey(PublicKeyHash signerToRemove,
+                                                               SigningPrivateKeyAndPublicHash parentSigner,
+                                                               PublicKeyHash owner,
+                                                               NetworkAccess network,
+                                                               Snapshot current,
+                                                               WriteSynchronizer.Committer committer) {
         if (parentSigner.publicKeyHash.equals(signerToRemove))
-            return CompletableFuture.completedFuture(true);
+            return CompletableFuture.completedFuture(current);
 
         return network.synchronizer.applyUpdate(owner, parentSigner, (parentWriterData, tid) -> parentWriterData
-                .removeOwnedKey(owner, parentSigner, signerToRemove, network.dhtClient))
-                .thenApply(cwd -> true);
+                .removeOwnedKey(owner, parentSigner, signerToRemove, network.dhtClient));
     }
 
     public CompletableFuture<? extends AsyncReader> getInputStream(NetworkAccess network,


### PR DESCRIPTION
This PR makes FileWrapper store the Snapshot that it was created from. This allows us to memoize many calls and remove a bunch of network calls, unsigning, and serialization. 

This makes navigating the filesystem MUCH faster!!!
Small file reads are 20X faster (50ms to getByPath and read a 1 KiB file)
Medium file reads are 7X faster, now giving 10.5 MiB/s!!!