### PR TITLE
Fix/revoking write access to tree

### DIFF
--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -5,7 +5,11 @@ import org.junit.runner.*;
 import org.junit.runners.*;
 import peergos.server.*;
 import peergos.server.util.*;
+import peergos.shared.social.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
 
+import java.nio.file.*;
 import java.util.*;
 
 @RunWith(Parameterized.class)
@@ -26,5 +30,46 @@ public class RamUserTests extends UserTests {
     @BeforeClass
     public static void init() {
         Main.PKI_INIT.main(args);
+    }
+
+    @Test
+    public void revokeWriteAccessToTree() throws Exception {
+        String username1 = generateUsername();
+        String password = "test";
+        UserContext user1 = PeergosNetworkUtils.ensureSignedUp(username1, password, network, crypto);
+        FileWrapper user1Root = user1.getUserRoot().get();
+
+        String folder1 = "folder1";
+        user1Root.mkdir(folder1, user1.network, false, crypto).join();
+
+        String folder11 = "folder1.1";
+        user1.getByPath(Paths.get(username1, folder1)).join().get()
+                .mkdir(folder11, user1.network, false, crypto).join();
+
+        String filename = "somedata.txt";
+        // write empty file
+        byte[] data = new byte[0];
+        user1.getByPath(Paths.get(username1, folder1, folder11)).join().get()
+                .uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length, user1.network,
+                crypto, l -> {}, user1Root.generateChildLocationsFromSize(0, crypto.random)).get();
+
+        // create 2nd user and friend user1
+        String username2 = generateUsername();
+        UserContext user2 = PeergosNetworkUtils.ensureSignedUp(username2, password, network, crypto);
+        user2.sendInitialFollowRequest(username1).join();
+        List<FollowRequestWithCipherText> incoming = user1.getSocialState().join().pendingIncoming;
+        user1.sendReplyFollowRequest(incoming.get(0), true, true).join();
+        user2.getSocialState().join();
+
+        user1.shareWriteAccessWith(Paths.get(username1, folder1), Collections.singleton(username2)).join();
+
+        try {
+            user1.unShareWriteAccess(Paths.get(username1, folder1), Collections.singleton(username2)).join();
+        } catch (Throwable t) {
+            System.out.println();
+        }
+        // next line throws when getting root dir to construct tofu corenode
+        UserContext freshUser1 = PeergosNetworkUtils.ensureSignedUp(username1, password, network, crypto);
+        System.out.println("Can still log in user1");
     }
 }

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -63,13 +63,8 @@ public class RamUserTests extends UserTests {
 
         user1.shareWriteAccessWith(Paths.get(username1, folder1), Collections.singleton(username2)).join();
 
-        try {
-            user1.unShareWriteAccess(Paths.get(username1, folder1), Collections.singleton(username2)).join();
-        } catch (Throwable t) {
-            System.out.println();
-        }
-        // next line throws when getting root dir to construct tofu corenode
+        user1.unShareWriteAccess(Paths.get(username1, folder1), Collections.singleton(username2)).join();
+        // check user1 can still log in
         UserContext freshUser1 = PeergosNetworkUtils.ensureSignedUp(username1, password, network, crypto);
-        System.out.println("Can still log in user1");
     }
 }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -37,8 +37,8 @@ public abstract class UserTests {
 	private static final Logger LOG = Logging.LOG();
 
     public static int RANDOM_SEED = 666;
-    private final NetworkAccess network;
-    private final Crypto crypto = Crypto.initJava();
+    protected final NetworkAccess network;
+    protected final Crypto crypto = Crypto.initJava();
     private final URL peergosUrl;
 
     private static Random random = new Random(RANDOM_SEED);
@@ -71,8 +71,8 @@ public abstract class UserTests {
         }
     }
 
-    private String generateUsername() {
-        return "test" + Math.abs(random.nextInt() % 10000);
+    protected String generateUsername() {
+        return "test" + Math.abs(random.nextInt() % 1_000_000);
     }
 
     private static CompletableFuture<FileWrapper> uploadFileSection(FileWrapper parent,

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -19,7 +19,8 @@ import java.util.stream.*;
 
 /** A cryptree node controls read and write access to a directory or file.
  *
- * A directory contains the following distinct keys {base, parent}, and file contains {base == parent, data}
+ * A directory contains the following distinct symmetric read keys {base, parent}, and file contains {base == parent, data}
+ * A directory or file also has a single base symmetric write key
  *
  * The serialized encrypted form stores a link from the base key to the other key.
  * For a directory, the base key encrypts the links to child directories and files. For a file the datakey encrypts the


### PR DESCRIPTION
This fixes revoking write access when a subdir has children

e.g. /usera/dir1/dir2/file1 exists
and usera grants write access to /usera/dir1, and then revokes it.

The rotation of symmetric write keys was not using the new keys for the subdir's children