### PR TITLE
Restart server tests and O(1) log in

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,8 +87,7 @@
     <jar jarfile="${dist}/PeergosServer.jar" basedir="${build}" includes="peergos/server/**,peergos/shared/**,peergos/client/**"></jar>
     <mkdir dir="META-INF"/>
     <echo file="META-INF/MANIFEST.MF">Main-Class: peergos.server.Main
-        Class-Path: ${manifest_cp}
-    </echo>
+Class-Path: ${manifest_cp}</echo>
     <touch millis="0">
       <fileset dir="META-INF"/>
     </touch>

--- a/src/peergos/server/tests/RestartTests.java
+++ b/src/peergos/server/tests/RestartTests.java
@@ -1,0 +1,125 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.storage.*;
+import peergos.server.util.*;
+import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.symmetric.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.social.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.net.*;
+import java.nio.file.*;
+import java.util.*;
+import java.util.stream.*;
+
+import static org.junit.Assert.*;
+
+public class RestartTests {
+
+    private static Args args = UserTests.buildArgs()
+            .with("mutable-pointers-file", "mutable.sql")
+            .with("social-sql-file", "social.sql")
+            .with("useIPFS", "true")
+            .with(IpfsWrapper.IPFS_BOOTSTRAP_NODES, ""); // no bootstrapping;
+    private final NetworkAccess network;
+    private static final Crypto crypto = Crypto.initJava();
+    private static Process server;
+
+    public RestartTests() throws Exception {
+        this.network = NetworkAccess.buildJava(new URL("http://localhost:" + args.getInt("port"))).get();
+    }
+
+    @BeforeClass
+    public static void init() throws Exception {
+        Files.copy(Paths.get("PeergosServer.jar"), args.fromPeergosDir("dummy", "PeergosServer.jar"));
+        Files.copy(Paths.get("lib"), args.fromPeergosDir("dummy", "lib"));
+        for (Path file : Files.list(Paths.get("lib")).collect(Collectors.toList()))
+            Files.copy(file, args.fromPeergosDir("dummy", "lib").resolve(file.getFileName()));
+
+        server = start("pki-init");
+        waitUntilReady();
+    }
+
+    private static void restart() throws Exception {
+        NetworkAccess network = NetworkAccess.buildJava(new URL("http://localhost:" + args.getInt("port")))
+                .join();
+        Multihash pkiNodeId = network.dhtClient.id().join();
+        PublicKeyHash peergosId = network.coreNode.getPublicKeyHash("peergos").join().get();
+        args.setArg("pki-node-id", pkiNodeId.toBase58());
+        args.setArg("peergos.identity.hash", peergosId.toString());
+        server.destroy();
+        server.waitFor();
+        server = start("pki");
+        waitUntilReady();
+    }
+
+    private static void waitUntilReady() {
+        for (int i=0; i < 10; i++) {
+            try {
+                NetworkAccess.buildJava(new URL("http://localhost:" + args.getInt("port"))).get();
+            } catch (Exception e) {
+                try {
+                    Thread.sleep(5000);
+                } catch (InterruptedException f) {}
+            }
+        }
+    }
+
+    public static Process start(String command) throws IOException {
+        Stream<String> classPath = Stream.concat(Stream.of("PeergosServer.jar"),
+                Files.list(args.fromPeergosDir("dummy", "lib")).map(Path::toString));
+        List<String> peergosArgs = Stream.concat(
+                Stream.of("java", "-cp", classPath.collect(Collectors.joining(System.getProperty("path.separator"))), "peergos.server.Main", "-" + command),
+                args.getAllArgs().stream())
+                .collect(Collectors.toList());
+
+        ProcessBuilder pb = new ProcessBuilder(peergosArgs);
+        pb.directory(args.getPeergosDir().toFile());
+        try {
+            Process started = pb.start();
+            new Thread(() -> Logging.log(started.getInputStream(),
+                    "$(peergos server) out: "), "Peergos output stream").start();
+            new Thread(() -> Logging.log(started.getErrorStream(),
+                    "$(peergos server) err: "), "Peergos error stream").start();
+            return started;
+        } catch (IOException ioe) {
+            throw new IllegalStateException(ioe.getMessage(), ioe);
+        }
+    }
+
+    private String random() {
+        return ArrayOps.bytesToHex(crypto.random.randomBytes(15));
+    }
+
+    @Test
+    public void friendPasswordChange() throws Exception {
+        String username1 = random();
+        String password1 = random();
+        UserContext u1 = PeergosNetworkUtils.ensureSignedUp(username1, password1, network, crypto);
+        String username2 = random();
+        String password2 = random();
+        UserContext u2 = PeergosNetworkUtils.ensureSignedUp(username2, password2, network, crypto);
+        u2.sendFollowRequest(u1.username, SymmetricKey.random()).get();
+        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().get();
+        u1.sendReplyFollowRequest(u1Requests.get(0), true, true).get();
+        // complete connection
+        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().get();
+
+        // change password for u2
+        String password3 = random();
+        u2.changePassword(password2, password3).join();
+
+        // restart the server
+        restart();
+
+        Optional<FileWrapper> u2ToU1 = UserContext.signIn(username1, password1, network.clear(), crypto).join()
+                .getByPath("/" + u2.username).get();
+        assertTrue("Friend root present after their password change", u2ToU1.isPresent());
+    }
+}

--- a/src/peergos/server/tests/RestartTests.java
+++ b/src/peergos/server/tests/RestartTests.java
@@ -123,8 +123,8 @@ public class RestartTests {
         // restart the server
         restart();
 
-        Optional<FileWrapper> u2ToU1 = UserContext.signIn(username1, password1, network.clear(), crypto).join()
-                .getByPath("/" + u2.username).get();
+        UserContext freshU1 = UserContext.signIn(username1, password1, network.clear(), crypto).join();
+        Optional<FileWrapper> u2ToU1 = freshU1.getByPath("/" + u2.username).get();
         assertTrue("Friend root present after their password change", u2ToU1.isPresent());
     }
 }

--- a/src/peergos/server/tests/RestartTests.java
+++ b/src/peergos/server/tests/RestartTests.java
@@ -37,10 +37,10 @@ public class RestartTests {
 
     @BeforeClass
     public static void init() throws Exception {
-        Files.copy(Paths.get("PeergosServer.jar"), args.fromPeergosDir("dummy", "PeergosServer.jar"));
-        Files.copy(Paths.get("lib"), args.fromPeergosDir("dummy", "lib"));
+        Files.copy(Paths.get("PeergosServer.jar"), args.getPeergosDirChild("PeergosServer.jar"));
+        Files.copy(Paths.get("lib"), args.getPeergosDirChild("lib"));
         for (Path file : Files.list(Paths.get("lib")).collect(Collectors.toList()))
-            Files.copy(file, args.fromPeergosDir("dummy", "lib").resolve(file.getFileName()));
+            Files.copy(file, args.getPeergosDirChild("lib").resolve(file.getFileName()));
 
         server = start("pki-init");
         waitUntilReady();
@@ -78,7 +78,7 @@ public class RestartTests {
 
     public static Process start(String command) throws IOException {
         Stream<String> classPath = Stream.concat(Stream.of("PeergosServer.jar"),
-                Files.list(args.fromPeergosDir("dummy", "lib")).map(Path::toString));
+                Files.list(args.getPeergosDirChild("lib")).map(Path::toString));
         List<String> peergosArgs = Stream.concat(
                 Stream.of("java", "-cp", classPath.collect(Collectors.joining(System.getProperty("path.separator"))), "peergos.server.Main", "-" + command),
                 args.getAllArgs().stream())

--- a/src/peergos/server/tests/RestartTests.java
+++ b/src/peergos/server/tests/RestartTests.java
@@ -46,6 +46,11 @@ public class RestartTests {
         waitUntilReady();
     }
 
+    @AfterClass
+    public static void shutdown() {
+        server.destroy();
+    }
+
     private static void restart() throws Exception {
         NetworkAccess network = NetworkAccess.buildJava(new URL("http://localhost:" + args.getInt("port")))
                 .join();

--- a/src/peergos/server/tests/slow/MultipartBenchmark.java
+++ b/src/peergos/server/tests/slow/MultipartBenchmark.java
@@ -1,0 +1,82 @@
+package peergos.server.tests.slow;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+import peergos.server.*;
+import peergos.server.tests.*;
+import peergos.server.util.*;
+import peergos.shared.*;
+import peergos.shared.storage.*;
+import peergos.shared.user.*;
+
+import java.net.*;
+import java.util.*;
+
+@RunWith(Parameterized.class)
+public class MultipartBenchmark {
+
+    private static int RANDOM_SEED = 666;
+    private final NetworkAccess network;
+    private final Crypto crypto = Crypto.initJava();
+
+    private static Random random = new Random(RANDOM_SEED);
+
+    public MultipartBenchmark(String useIPFS, Random r) throws Exception {
+        this.network = buildHttpNetworkAccess(useIPFS.equals("IPFS"), r);
+    }
+
+    private static NetworkAccess buildHttpNetworkAccess(boolean useIpfs, Random r) throws Exception {
+        Args args = UserTests.buildArgs().with("useIPFS", "" + useIpfs);
+        Main.PKI_INIT.main(args);
+        return NetworkAccess.buildJava(new URL("http://localhost:" + args.getInt("port"))).get();
+    }
+
+    @Parameterized.Parameters()
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+//                {"IPFS", new Random(0)}
+                {"NOTIPFS", new Random(0)}
+        });
+    }
+
+    private String generateUsername() {
+        return "test" + (random.nextInt() % 10000);
+    }
+
+    public static UserContext ensureSignedUp(String username, String password, NetworkAccess network, Crypto crypto) throws Exception {
+        return UserContext.ensureSignedUp(username, password, network, crypto).get();
+    }
+
+    // 70 KB/S throughput
+    @Test
+    public void smallFragments() throws Exception {
+        testWriteThroughput(4096);
+    }
+
+    // 1500 KB/S throughput
+    @Test
+    public void largeFragments() throws Exception {
+        testWriteThroughput(128*1024);
+    }
+
+    public void testWriteThroughput(int fragmentSize) throws Exception {
+        String username = generateUsername();
+        String password = "test01";
+        UserContext context = ensureSignedUp(username, password, network, crypto);
+
+        long worst = 0, best = Long.MAX_VALUE, start = System.currentTimeMillis();
+        TransactionId tid = network.dhtClient.startTransaction(context.signer.publicKeyHash).join();
+        byte[] data = new byte[fragmentSize];
+        for (int i=0; i < 10000; i++) {
+            random.nextBytes(data);
+            long t1 = System.currentTimeMillis();
+            network.dhtClient.put(context.signer.publicKeyHash, context.signer, data, tid).join();
+            long duration = System.currentTimeMillis() - t1;
+            worst = Math.max(worst, duration);
+            best = Math.min(best, duration);
+            System.err.printf("PUT(%d) duration: %d mS, best: %d mS, worst: %d mS, av: %d mS %d KB/S\n", i,
+                    duration, best, worst, (t1 + duration - start) / (i + 1), data.length / duration);
+        }
+    }
+}

--- a/src/peergos/server/util/Args.java
+++ b/src/peergos/server/util/Args.java
@@ -164,6 +164,10 @@ public class Args {
         return peergosDir.resolve(fName);
     }
 
+    public Path getPeergosDirChild(String filename) {
+        return getPeergosDir().resolve(filename);
+    }
+
     public Path getPeergosDir() {
         return hasArg(Main.PEERGOS_PATH) ? Paths.get(getArg(Main.PEERGOS_PATH)) : Main.DEFAULT_PEERGOS_DIR_PATH;
     }

--- a/src/peergos/server/util/Args.java
+++ b/src/peergos/server/util/Args.java
@@ -15,6 +15,14 @@ public class Args {
 
     private final Map<String, String> params = paramMap();//insertion order
 
+    public List<String> getAllArgs() {
+        Map<String, String> env = System.getenv();
+        return params.entrySet().stream()
+                .filter(e -> ! env.containsKey(e.getKey()))
+                .flatMap(e -> Stream.of("-" + e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+    }
+
     public String getArg(String param, String def) {
         if (!params.containsKey(param))
             return def;
@@ -151,11 +159,14 @@ public class Args {
      * @return
      */
     public Path fromPeergosDir(String fileName, String defaultName) {
-        Path peergosDir = hasArg(Main.PEERGOS_PATH) ? Paths.get(getArg(Main.PEERGOS_PATH)) : Main.DEFAULT_PEERGOS_DIR_PATH;
+        Path peergosDir = getPeergosDir();
         String fName = defaultName == null ? getArg(fileName) : getArg(fileName, defaultName);
         return peergosDir.resolve(fName);
     }
 
+    public Path getPeergosDir() {
+        return hasArg(Main.PEERGOS_PATH) ? Paths.get(getArg(Main.PEERGOS_PATH)) : Main.DEFAULT_PEERGOS_DIR_PATH;
+    }
 
     private static Map<String, String> parseEnv() {
         Map<String, String> map = paramMap();

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -139,6 +139,9 @@ public class FriendSourcedTrieNode implements TrieNode {
                                 }
                                 return sharedOpt.get().retrieveParent(network);
                             });
+                }).exceptionally(t -> {
+                    System.out.println("Couldn't retrieve entry point for friend: " + sharedDir.ownerName + ". Did they remove you as a follower?");
+                    return Optional.empty();
                 });
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -11,7 +11,6 @@ import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.crypto.random.SafeRandom;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.hamt.*;
 import peergos.shared.io.ipfs.multihash.Multihash;
@@ -306,7 +305,7 @@ public class UserContext {
         UserContext context = new UserContext(null, null, null, null, network,
                 crypto, userData, TrieNodeImpl.empty(), null);
         return NetworkAccess.retrieveEntryPoint(entry, network)
-                .thenCompose(r -> addRetrievedEntryPointToTrie(null, context.entrie, entry, r.getPath(), network, crypto))
+                .thenCompose(r -> addRetrievedEntryPointToTrie(null, context.entrie, entry, r.getPath(), true, network, crypto))
                 .thenApply(trieNode -> {
                     context.entrie = trieNode;
                     return context;
@@ -370,14 +369,14 @@ public class UserContext {
                         Futures.reduceAll(children,
                                 true,
                                 (x, friendDirectory) -> {
-                                    return CapabilityStore.loadReadAccessSharingLinks(homeDirSupplier, friendDirectory,
+                                    return CapabilityStore.loadReadOnlyLinks(homeDirSupplier, friendDirectory,
                                             this.username, network, crypto, false)
                                             .thenCompose(readCaps -> {
                                                 readCaps.getRetrievedCapabilities().stream().forEach(rc -> {
                                                     sharedWithCache.addSharedWith(SharedWithCache.Access.READ,
                                                         rc.cap, friendDirectory.getName());
                                                 });
-                                                return CapabilityStore.loadWriteAccessSharingLinks(homeDirSupplier, friendDirectory,
+                                                return CapabilityStore.loadWriteableLinks(homeDirSupplier, friendDirectory,
                                                         this.username, network, crypto, false)
                                                         .thenApply(writeCaps -> {
                                                             writeCaps.getRetrievedCapabilities().stream().forEach(rc -> {
@@ -1072,13 +1071,17 @@ public class UserContext {
                 return new UserStaticData(entryPoints, rootKey);
             });
             return CompletableFuture.completedFuture(wd.withStaticData(updated));
-        }).thenCompose(res -> addRetrievedEntryPointToTrie(username, root, entry, "/" + username, network, crypto));
+        }).thenCompose(res -> addRetrievedEntryPointToTrie(username, root, entry, "/" + username, false, network, crypto));
     }
 
     private synchronized CompletableFuture<FileWrapper> addExternalEntryPoint(EntryPoint entry) {
         boolean isOurs = username.equals(entry.ownerName);
         String filename = isOurs ? ENTRY_POINTS_FROM_US_FILENAME : ENTRY_POINTS_FROM_FRIENDS_FILENAME;
-        return getByPath(Paths.get(username, filename))
+        // verify owner before adding
+        return entry.isValid("/" + entry.ownerName, network)
+                .thenCompose(valid -> valid ?
+                        getByPath(Paths.get(username, filename)) :
+                        Futures.errored(new IllegalStateException("Incorrect claimed owner for entry point")))
                 .thenCompose(existing -> {
                     long offset = existing.map(f -> f.getSize()).orElse(0L);
                     byte[] data = entry.serialize();
@@ -1225,7 +1228,7 @@ public class UserContext {
                 .collect(Collectors.toList());
         return Futures.reduceAll(ourFileSystemEntries, root,
                 (t, e) -> NetworkAccess.getLatestEntryPoint(e, network)
-                        .thenCompose(r -> addRetrievedEntryPointToTrie(ourName, t, r.entry, r.getPath(), network, crypto)),
+                        .thenCompose(r -> addRetrievedEntryPointToTrie(ourName, t, r.entry, r.getPath(), false, network, crypto)),
                 (a, b) -> a)
                 .exceptionally(Futures::logAndThrow);
     }
@@ -1240,8 +1243,8 @@ public class UserContext {
         // need to to retrieve all the entry points of our friends
         return getFriendsEntryPoints()
                 .thenCompose(friendEntries -> Futures.reduceAll(friendEntries, ourRoot,
-                        (t, e) -> NetworkAccess.getLatestEntryPoint(e, network)
-                                .thenCompose(r -> addRetrievedEntryPointToTrie(ourName, t, r.entry, r.getPath(), network, crypto))
+                        (t, e) -> addRetrievedEntryPointToTrie(ourName, t, e,
+                                "/" + e.ownerName + "/" + SHARED_DIR_NAME + "/" + ourName, false, network, crypto)
                                 .exceptionally(ex -> t),
                         (a, b) -> a))
                 .exceptionally(Futures::logAndThrow);
@@ -1249,7 +1252,7 @@ public class UserContext {
 
     private CompletableFuture<TrieNode> retrieveAndAddEntryPointToTrie(TrieNode root, EntryPoint e) {
         return NetworkAccess.retrieveEntryPoint(e, network)
-                .thenCompose(r -> addRetrievedEntryPointToTrie(username, root, r.entry, r.getPath(), network, crypto));
+                .thenCompose(r -> addRetrievedEntryPointToTrie(username, root, r.entry, r.getPath(), false, network, crypto));
     }
 
     private CompletableFuture<List<EntryPoint>> getFriendsEntryPoints() {
@@ -1288,10 +1291,11 @@ public class UserContext {
                                                                             TrieNode root,
                                                                             EntryPoint fileCap,
                                                                             String path,
+                                                                            boolean checkOwner,
                                                                             NetworkAccess network,
                                                                             Crypto crypto) {
         // check entrypoint doesn't forge the owner
-        return (fileCap.ownerName.equals(ourName) ? CompletableFuture.completedFuture(true) :
+        return (fileCap.ownerName.equals(ourName) || ! checkOwner ? CompletableFuture.completedFuture(true) :
                 fileCap.isValid(path, network)).thenCompose(valid -> {
             String[] parts = path.split("/");
             if (parts.length < 3 || !parts[2].equals(SHARED_DIR_NAME))


### PR DESCRIPTION
This implements a new test suite which allows to stop and restart the server. This was required previously to trigger a bug when a friend changed their identity. 

Change log in to not retrieve the entry point from every single friend which takes ages, but just to use the cached versions, and only update upon actually browsing to their dir. This makes log in O(1) in mutable pointer requests. 

E.g. log in time for a user with 11 friends is reduced from 20s to 12s. 