### PR TITLE
Unfollow asymmetry

### DIFF
--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1129,6 +1129,8 @@ public class MultiUserTests {
 
         Set<String> newU1Following = u1.getFollowing().get();
         Assert.assertTrue("u1 no longer following u2", ! newU1Following.contains(u2.username));
+
+
     }
 
     @Test
@@ -1146,6 +1148,9 @@ public class MultiUserTests {
         u1.removeFollower(u2.username).get();
 
         Set<String> newU1Followers = u1.getFollowerNames().get();
-        Assert.assertTrue("u1 no longer has u2 as follower", ! newU1Followers.contains(u2.username));
+        Assert.assertTrue("u1 no longer has u2 as follower", !newU1Followers.contains(u2.username));
+        
+        Set<String> u2Following = u2.getFollowing().get();
+        Assert.assertTrue("u2 is no longer following u1", !u2Following.contains(u1.username));
     }
 }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1128,9 +1128,13 @@ public class MultiUserTests {
         u1.unfollow(u2.username).get();
 
         Set<String> newU1Following = u1.getFollowing().get();
-        Assert.assertTrue("u1 no longer following u2", ! newU1Following.contains(u2.username));
+        Assert.assertTrue("u1 no longer following u2", !newU1Following.contains(u2.username));
 
+        Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).get();
+        assertTrue("u1 can no longer see u2's root", !u2Tou1.isPresent());
 
+        Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).get();
+        assertTrue("u2 can still see u1's root", u1Tou2.isPresent());
     }
 
     @Test
@@ -1154,7 +1158,7 @@ public class MultiUserTests {
         Assert.assertTrue("u2 is no longer following u1", !u2Following.contains(u1.username));
 
         Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).get();
-        assertTrue("u1 can no longer see u2's root", !u2Tou1.isPresent());
+        assertTrue("u1 can still see u2's root", u2Tou1.isPresent());
 
         Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).get();
         assertTrue("u2 can no longer see u1's root", !u1Tou2.isPresent());

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1152,5 +1152,11 @@ public class MultiUserTests {
         
         Set<String> u2Following = u2.getFollowing().get();
         Assert.assertTrue("u2 is no longer following u1", !u2Following.contains(u1.username));
+
+        Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).get();
+        assertTrue("u1 can no longer see u2's root", !u2Tou1.isPresent());
+
+        Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).get();
+        assertTrue("u2 can no longer see u1's root", !u1Tou2.isPresent());
     }
 }


### PR DESCRIPTION
This adds some additional checks to the test suite to ensure that, starting with u1 and u2 following each other:

1. If u1 removes u2 as a follower, u2 can longer see u1's root directory, but u1 continues to follow u2 and can still see u2's root.
2. If u1 unfollows u2, u1 can no longer see u2's root directory but u2 can continue to see u1.