### PR TITLE
Implement friend annotations

### DIFF
--- a/src/peergos/shared/user/FriendAnnotation.java
+++ b/src/peergos/shared/user/FriendAnnotation.java
@@ -23,6 +23,11 @@ public class FriendAnnotation implements Cborable {
         return username;
     }
 
+    @JsMethod
+    public boolean isVerified() {
+        return isVerified;
+    }
+
     @Override
     public CborObject toCbor() {
         SortedMap<String, Cborable> state = new TreeMap<>();

--- a/src/peergos/shared/user/FriendAnnotation.java
+++ b/src/peergos/shared/user/FriendAnnotation.java
@@ -1,0 +1,45 @@
+package peergos.shared.user;
+
+import jsinterop.annotations.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+
+import java.util.*;
+
+public class FriendAnnotation implements Cborable {
+
+    private final String username;
+    private final boolean isVerified;
+    private final List<PublicKeyHash> keysAtVerification;
+
+    @JsConstructor
+    public FriendAnnotation(String username, boolean isVerified, List<PublicKeyHash> keysAtVerification) {
+        this.username = username;
+        this.isVerified = isVerified;
+        this.keysAtVerification = keysAtVerification;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("u", new CborObject.CborString(username));
+        state.put("v", new CborObject.CborBoolean(isVerified));
+        state.put("k", new CborObject.CborList(keysAtVerification));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static FriendAnnotation fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Incorrect cbor for FriendAnnotation: " + cbor);
+
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        String username = m.getString("u");
+        boolean isVerified = m.getBoolean("v");
+        List<PublicKeyHash> keys = m.getList("k", PublicKeyHash::fromCbor);
+        return new FriendAnnotation(username, isVerified, keys);
+    }
+}

--- a/src/peergos/shared/user/SocialState.java
+++ b/src/peergos/shared/user/SocialState.java
@@ -14,11 +14,13 @@ public class SocialState {
     public final Map<String, FileWrapper> followerRoots;
     public final Set<FileWrapper> followingRoots;
     public final Map<String, FileWrapper> pendingOutgoingFollowRequests;
+    public final Map<String, FriendAnnotation> friendAnnotations;
 
     public SocialState(List<FollowRequestWithCipherText> pendingIncoming,
                        Set<String> actualFollowers,
                        Map<String, FileWrapper> followerRoots,
-                       Set<FileWrapper> followingRoots) {
+                       Set<FileWrapper> followingRoots,
+                       Map<String, FriendAnnotation> friendAnnotations) {
         this.pendingIncoming = pendingIncoming;
         this.pendingOutgoingFollowRequests = followerRoots.entrySet()
                 .stream()
@@ -32,5 +34,6 @@ public class SocialState {
         TreeSet<FileWrapper> sortedByName = new TreeSet<>((a, b) -> a.getName().compareTo(b.getName()));
         sortedByName.addAll(followingRoots);
         this.followingRoots = sortedByName;
+        this.friendAnnotations = friendAnnotations;
     }
 }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -888,14 +888,18 @@ public class UserContext {
                     throw new RuntimeException(e);
                 }
             }
-            return getUserRoot().thenCompose(home -> home.uploadOrOverwriteFile(
-                    FRIEND_ANNOTATIONS_FILE_NAME,
-                    AsyncReader.build(serialized.toByteArray()),
-                    serialized.size(),
-                    network,
-                    crypto,
-                    x -> {},
-                    home.generateChildLocationsFromSize(serialized.size(), crypto.random)))
+            return getUserRoot().thenCompose(home -> home.uploadFileSection(
+                                    FRIEND_ANNOTATIONS_FILE_NAME,
+                                    AsyncReader.build(serialized.toByteArray()),
+                                    true,
+                                    0,
+                                    serialized.size(),
+                                    Optional.empty(),
+                                    true,
+                                    network,
+                                    crypto,
+                                    x -> {},
+                                    home.generateChildLocationsFromSize(serialized.size(), crypto.random)))
                     .thenApply(x -> true);
         });
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -875,8 +875,9 @@ public class UserContext {
     @JsMethod
     public CompletableFuture<Boolean> addFriendAnnotation(FriendAnnotation annotation) {
         return getFriendAnnotations().thenCompose(existing -> {
-            existing.put(annotation.getUsername(), annotation);
-            List<FriendAnnotation> values = existing.values()
+            Map<String, FriendAnnotation> updated = new TreeMap<>(existing);
+            updated.put(annotation.getUsername(), annotation);
+            List<FriendAnnotation> values = updated.values()
                     .stream()
                     .collect(Collectors.toList());
             ByteArrayOutputStream serialized = new ByteArrayOutputStream();

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -289,7 +289,7 @@ public class UserContext {
     /**
      *
      * @param friendName
-     * @return a pair of the firends keys used to generate the fingerprint, and the resulting fingreprint
+     * @return a pair of the friends keys used to generate the fingerprint, and the resulting fingerprint
      */
     @JsMethod
     public CompletableFuture<Pair<List<PublicKeyHash>, FingerPrint>> generateFingerPrint(String friendName) {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1,5 +1,6 @@
 package peergos.shared.user;
 
+import java.io.*;
 import java.util.logging.*;
 
 import peergos.shared.fingerprint.*;
@@ -40,6 +41,7 @@ public class UserContext {
     public static final String PEERGOS_USERNAME = "peergos";
     public static final String SHARED_DIR_NAME = "shared";
     public static final String TRANSACTIONS_DIR_NAME = ".transactions";
+    public static final String FRIEND_ANNOTATIONS_FILE_NAME = ".annotations";
     public static final String FEEDBACK_DIR_NAME = "feedback";
 
     public static final String ENTRY_POINTS_FROM_FRIENDS_FILENAME = ".from-friends.cborstream";
@@ -284,18 +286,24 @@ public class UserContext {
                 .thenApply(x -> globalRoot);
     }
 
+    /**
+     *
+     * @param friendName
+     * @return a pair of the firends keys used to generate the fingerprint, and the resulting fingreprint
+     */
     @JsMethod
-    public CompletableFuture<FingerPrint> generateFingerPrint(String friendName) {
+    public CompletableFuture<Pair<List<PublicKeyHash>, FingerPrint>> generateFingerPrint(String friendName) {
         return getPublicKeyHashes(username)
                 .thenCompose(ourKeys -> getPublicKeyHashes(friendName)
-                        .thenApply(friendKeys -> {
-                            PublicKeyHash friendId = friendKeys.left;
-                            PublicKeyHash friendBox = friendKeys.right;
-                            return FingerPrint.generate(
+                        .thenApply(friendKeysPair -> {
+                            PublicKeyHash friendId = friendKeysPair.left;
+                            PublicKeyHash friendBox = friendKeysPair.right;
+                            List<PublicKeyHash> friendKeys = Arrays.asList(friendId, friendBox);
+                            return new Pair<>(friendKeys, FingerPrint.generate(
                                     username,
                                     Arrays.asList(ourKeys.left, ourKeys.right),
                                     friendName,
-                                    Arrays.asList(friendId, friendBox));
+                                    friendKeys));
                         }));
     }
 
@@ -847,13 +855,58 @@ public class UserContext {
                         }).orElse(CompletableFuture.completedFuture(Collections.emptySet())));
     }
 
+    public CompletableFuture<Map<String, FriendAnnotation>> getFriendAnnotations() {
+        return getUserRoot()
+                .thenCompose(home -> home.hasChild(FRIEND_ANNOTATIONS_FILE_NAME, network)
+                        .thenCompose(exists ->  {
+                            if (! exists)
+                                return CompletableFuture.completedFuture(Collections.emptyMap());
+                            Map<String, FriendAnnotation> res = new TreeMap<>();
+                            return home.getChild(FRIEND_ANNOTATIONS_FILE_NAME, network)
+                                    .thenCompose(fileOpt ->
+                                            fileOpt.get().getInputStream(network, crypto.random, x -> {})
+                                    .thenCompose(reader -> reader.parseStream(FriendAnnotation::fromCbor,
+                                            anno -> res.put(anno.getUsername(), anno),
+                                            fileOpt.get().getSize())))
+                                    .thenApply(x -> res);
+                        }));
+    }
+
+    @JsMethod
+    public CompletableFuture<Boolean> addFriendAnnotation(FriendAnnotation annotation) {
+        return getFriendAnnotations().thenCompose(existing -> {
+            existing.put(annotation.getUsername(), annotation);
+            List<FriendAnnotation> values = existing.values()
+                    .stream()
+                    .collect(Collectors.toList());
+            ByteArrayOutputStream serialized = new ByteArrayOutputStream();
+            for (FriendAnnotation value : values) {
+                try {
+                    serialized.write(value.serialize());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return getUserRoot().thenCompose(home -> home.uploadOrOverwriteFile(
+                    FRIEND_ANNOTATIONS_FILE_NAME,
+                    AsyncReader.build(serialized.toByteArray()),
+                    serialized.size(),
+                    network,
+                    crypto,
+                    x -> {},
+                    home.generateChildLocationsFromSize(serialized.size(), crypto.random)))
+                    .thenApply(x -> true);
+        });
+    }
+
     @JsMethod
     public CompletableFuture<SocialState> getSocialState() {
         return processFollowRequests()
                 .thenCompose(pending -> getFollowerRoots()
                         .thenCompose(followerRoots -> getFriendRoots()
                                 .thenCompose(followingRoots -> getFollowers()
-                                        .thenApply(followers -> new SocialState(pending, followers, followerRoots, followingRoots)))));
+                                        .thenCompose(followers -> getFriendAnnotations()
+                                        .thenApply(annotations -> new SocialState(pending, followers, followerRoots, followingRoots, annotations))))));
     }
 
     @JsMethod


### PR DESCRIPTION
This allows a user to store (privately in their own space) annotations for each of their friends. 

Initially this is used for storing whether or not they have verified the keys of that user. 

It could be extended to add things like a local display name for a user. 