### PR TITLE
Super fast seeking

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -310,7 +310,7 @@ public class Main {
 
     public static void startPeergos(Args a) {
         try {
-            Crypto.initJava();
+            Crypto crypto = Crypto.initJava();
             int webPort = a.getInt("port");
             a.setIfAbsent("proxy-target", getLocalMultiAddress(webPort).toString());
 
@@ -399,7 +399,7 @@ public class Main {
                     .stream()
                     .collect(Collectors.toSet());
             Admin storageAdmin = new Admin(adminUsernames, spaceRequests, userQuotas, core, localDht);
-            UserService peergos = new UserService(p2pDht, corePropagator, p2pSocial, p2mMutable, storageAdmin, spaceChecker);
+            UserService peergos = new UserService(p2pDht, crypto, corePropagator, p2pSocial, p2mMutable, storageAdmin, spaceChecker);
             InetSocketAddress localAddress = new InetSocketAddress("localhost", userAPIAddress.getPort());
             Optional<Path> webroot = a.hasArg("webroot") ?
                     Optional.of(Paths.get(a.getArg("webroot"))) :

--- a/src/peergos/server/Uploader.java
+++ b/src/peergos/server/Uploader.java
@@ -39,7 +39,7 @@ public class Uploader {
 
     private static void createPath(FileWrapper parent, Path path, NetworkAccess network, Crypto crypto) throws Exception {
         String name = path.getName(0).toString();
-        Optional<FileWrapper> child = parent.getChild(name, network).get();
+        Optional<FileWrapper> child = parent.getChild(name, crypto.hasher, network).get();
         if (path.getNameCount() == 1) {
             if (! child.isPresent())
                 parent.mkdir(name, network, false, crypto).get();

--- a/src/peergos/server/Uploader.java
+++ b/src/peergos/server/Uploader.java
@@ -112,7 +112,7 @@ public class Uploader {
                 FileWrapper parent = context.getByPath(targetParent.toString()).join().get();
                 parent.uploadOrOverwriteFile(file.getName(), fileData, file.length(),
                         context.network, context.crypto, l -> {},
-                        parent.generateChildLocationsFromSize(file.length(), context.crypto.random)).get();
+                        context.crypto.random.randomBytes(32)).get();
             } catch (Exception e) {
                 System.err.println("Error uploading " + source);
                 e.printStackTrace();

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 
 import com.sun.net.httpserver.*;
 import peergos.server.corenode.*;
+import peergos.shared.*;
 import peergos.shared.corenode.*;
 import peergos.shared.mutable.*;
 import peergos.shared.social.*;
@@ -68,6 +69,7 @@ public class UserService {
     }
 
     private final ContentAddressedStorage storage;
+    private final Crypto crypto;
     private final CoreNode coreNode;
     private final SocialNetwork social;
     private final MutablePointers mutable;
@@ -75,12 +77,14 @@ public class UserService {
     private final SpaceUsage usage;
 
     public UserService(ContentAddressedStorage storage,
+                       Crypto crypto,
                        CoreNode coreNode,
                        SocialNetwork social,
                        MutablePointers mutable,
                        InstanceAdmin controller,
                        SpaceUsage usage) {
         this.storage = storage;
+        this.crypto = crypto;
         this.coreNode = coreNode;
         this.social = social;
         this.mutable = mutable;
@@ -205,7 +209,7 @@ public class UserService {
                 new AdminHandler(this.controller));
         addHandler.accept("/" + Constants.SPACE_USAGE_URL,
                 new StorageHandler(this.usage));
-        addHandler.accept("/" + Constants.PUBLIC_FILES_URL, new PublicFileHandler(coreNode, mutable, storage));
+        addHandler.accept("/" + Constants.PUBLIC_FILES_URL, new PublicFileHandler(coreNode, mutable, storage, crypto));
         addHandler.accept(UI_URL, handler);
 
         localhostServer.setExecutor(Executors.newFixedThreadPool(HANDLER_THREADS));

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -579,7 +579,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             FileWrapper newParent = file.treeNode.remove(parent.treeNode, context).get();
             FileWrapper b = newParent.uploadOrOverwriteFile(file.properties.name, new AsyncReader.ArrayBacked(truncated),
                     truncated.length, context.network, context.crypto, l -> {},
-                    newParent.generateChildLocationsFromSize(truncated.length, context.crypto.random)).get();
+                    context.crypto.random.randomBytes(32)).get();
             return (int) size;
         } catch (Throwable t) {
             LOG.log(Level.WARNING, t.getMessage(), t);
@@ -598,7 +598,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             FileWrapper b = parent.treeNode.uploadFileSection(name, new AsyncReader.ArrayBacked(toWrite), false, offset,
                     offset + size, Optional.empty(), true, context.network,
                     context.crypto, l -> {},
-                    parent.treeNode.generateChildLocationsFromSize(size, context.crypto.random)).get();
+                    context.crypto.random.randomBytes(32)).get();
             return (int) size;
         } catch (Throwable t) {
             LOG.log(Level.WARNING, t.getMessage(), t);

--- a/src/peergos/server/net/PublicFileHandler.java
+++ b/src/peergos/server/net/PublicFileHandler.java
@@ -113,7 +113,7 @@ public class PublicFileHandler implements HttpHandler {
             } else {
                 long fileSize = file.getSize();
                 httpExchange.sendResponseHeaders(200, fileSize);
-                AsyncReader reader = file.getInputStream(network, null, x -> {}).get();
+                AsyncReader reader = file.getInputStream(network, crypto, x -> {}).get();
                 byte[] buf = new byte[(int) Math.min(fileSize, 5 * 1024 * 1024)];
                 long read = 0;
                 OutputStream out = httpExchange.getResponseBody();

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -151,8 +151,7 @@ public class MultiNodeNetworkTests {
         String filename = "hey.txt";
         FileWrapper root = u1.getUserRoot().get();
         FileWrapper upload = root.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length,
-                getNode(iNode1), crypto, x -> {},
-                root.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                getNode(iNode1), crypto, x -> {}, crypto.random.randomBytes(32)).get();
         Optional<FileWrapper> file = u1.getByPath("/" + username1 + "/" + filename).get();
         Assert.assertTrue(file.isPresent());
     }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -206,7 +206,7 @@ public class MultiUserTests {
             Assert.assertTrue("shared file present", sharedFile.isPresent());
 
             AsyncReader inputStream = sharedFile.get().getInputStream(userContext.network,
-                    userContext.crypto.random, l -> {}).get();
+                    userContext.crypto, l -> {}).get();
 
             byte[] fileContents = Serialize.readFully(inputStream, sharedFile.get().getFileProperties().size).get();
             Assert.assertTrue("shared file contents correct", Arrays.equals(data1, fileContents));
@@ -219,7 +219,7 @@ public class MultiUserTests {
             Assert.assertTrue("shared file present", sharedFile.isPresent());
 
             AsyncReader inputStream = sharedFile.get().getInputStream(userContext.network,
-                    userContext.crypto.random, l -> {}).get();
+                    userContext.crypto, l -> {}).get();
 
             byte[] fileContents = Serialize.readFully(inputStream, sharedFile.get().getFileProperties().size).get();
             Assert.assertTrue("shared file contents correct", Arrays.equals(data2, fileContents));
@@ -273,7 +273,7 @@ public class MultiUserTests {
             Assert.assertTrue("shared file present", sharedFile.isPresent());
 
             AsyncReader inputStream = sharedFile.get().getInputStream(userContext.network,
-                    userContext.crypto.random, l -> {}).get();
+                    userContext.crypto, l -> {}).get();
 
             byte[] fileContents = Serialize.readFully(inputStream, sharedFile.get().getFileProperties().size).get();
             Assert.assertTrue("shared file contents correct", Arrays.equals(data1, fileContents));
@@ -829,7 +829,7 @@ public class MultiUserTests {
             Assert.assertTrue("shared file present", sharedFile.isPresent());
 
             AsyncReader inputStream = sharedFile.get().getInputStream(friend.network,
-                    friend.crypto.random, l -> {}).get();
+                    friend.crypto, l -> {}).get();
 
             byte[] fileContents = Serialize.readFully(inputStream, sharedFile.get().getFileProperties().size).get();
             Assert.assertTrue("shared file contents correct", Arrays.equals(originalFileContents, fileContents));
@@ -908,7 +908,7 @@ public class MultiUserTests {
                 originalFileContents.length + suffix.length, Optional.empty(), true,
                 u1New.network, crypto, l -> {}, null).get();
         AsyncReader extendedContents = u1New.getByPath(u1.username + "/" + newname).get().get()
-                .getInputStream(u1New.network, crypto.random, l -> {}).get();
+                .getInputStream(u1New.network, crypto, l -> {}).get();
         byte[] newFileContents = Serialize.readFully(extendedContents, originalFileContents.length + suffix.length).get();
 
         Assert.assertTrue(Arrays.equals(newFileContents, ArrayOps.concat(originalFileContents, suffix)));
@@ -942,7 +942,7 @@ public class MultiUserTests {
         Optional<FileWrapper> u2ToU1 = u1.getByPath("/" + u2.username).get();
         assertTrue("Friend root present after accepted follow request", u2ToU1.isPresent());
 
-        Set<FileWrapper> children = u2ToU1.get().getChildren(u2.network).get();
+        Set<FileWrapper> children = u2ToU1.get().getChildren(crypto.hasher, u2.network).get();
 
         assertTrue("Browse to friend root", children.isEmpty());
 
@@ -1018,14 +1018,14 @@ public class MultiUserTests {
         }
 
         Optional<FileWrapper> newUserToPeergos = peergos.getByPath("/" + newUser.username + "/feedback").get();
-        Set<FileWrapper> feedbackDirectoryContents = newUserToPeergos.get().getChildren(newUser.network).get();
+        Set<FileWrapper> feedbackDirectoryContents = newUserToPeergos.get().getChildren(crypto.hasher, newUser.network).get();
         assertTrue("Feedback directory is non-empty", !feedbackDirectoryContents.isEmpty());
 
         for (FileWrapper feedbackFile : feedbackDirectoryContents) {
             assertTrue("Feedback file is readable", feedbackFile.isReadable());
 
             AsyncReader inputStream = feedbackFile
-                        .getInputStream(peergos.network, peergos.crypto.random, l -> {})
+                        .getInputStream(peergos.network, peergos.crypto, l -> {})
                         .get();
 
             byte[] fileContents = Serialize.readFully(inputStream, feedbackFile.getFileProperties().size).get();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -111,8 +111,7 @@ public class MultiUserTests {
         byte[] data = UserTests.randomData(10*1024*1024);
 
         FileWrapper uploaded = u1Root.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length,
-                u1.network, crypto, l -> {},
-                u1Root.generateChildLocationsFromSize(data.length, u1.crypto.random)).get();
+                u1.network, crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // share the file from "a" to each of the others
         FileWrapper u1File = u1.getByPath(u1.username + "/" + filename).get().get();
@@ -184,8 +183,7 @@ public class MultiUserTests {
         byte[] data1 = "Hello Peergos friend!".getBytes();
         AsyncReader file1Reader = new AsyncReader.ArrayBacked(data1);
         FileWrapper uploaded = u1Root.uploadOrOverwriteFile(filename, file1Reader, data1.length,
-                u1.network, u1.crypto, l -> {},
-                u1Root.generateChildLocationsFromSize(data1.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // upload a different file with the same name in a sub folder
         uploaded.mkdir("subdir", u1.network, false, crypto).get();
@@ -193,8 +191,7 @@ public class MultiUserTests {
         byte[] data2 = "Goodbye Peergos friend!".getBytes();
         AsyncReader file2Reader = new AsyncReader.ArrayBacked(data2);
         subdir.uploadOrOverwriteFile(filename, file2Reader, data2.length,
-                u1.network, u1.crypto, l -> {},
-                u1Root.generateChildLocationsFromSize(data2.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // share the file from "a" to each of the others
         //        sharingFunction.apply(u1, u2, filenameu1.shareReadAccessWith(Paths.get(u1.username, filename), userContexts.stream().map(u -> u.username).collect(Collectors.toSet())).get();
@@ -265,8 +262,7 @@ public class MultiUserTests {
         Path subdirPath = Paths.get(u1.username, subdirName);
         FileWrapper subdir = u1.getByPath(subdirPath).get().get();
         FileWrapper uploaded = subdir.uploadOrOverwriteFile(filename, file1Reader, data1.length,
-                u1.network, u1.crypto, l -> {},
-                subdir.generateChildLocationsFromSize(data1.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         Path filePath = Paths.get(u1.username, subdirName, filename);
         u1.shareWriteAccessWith(filePath, userContexts.stream().map(u -> u.username).collect(Collectors.toSet()));
@@ -368,8 +364,7 @@ public class MultiUserTests {
         Path subdirPath = Paths.get(u1.username, subdirName);
         FileWrapper subdir = u1.getByPath(subdirPath).get().get();
         FileWrapper uploaded = subdir.uploadOrOverwriteFile(filename, file1Reader, data1.length,
-                u1.network, u1.crypto, l -> {},
-                subdir.generateChildLocationsFromSize(data1.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         Path filePath = Paths.get(u1.username, subdirName, filename);
 
@@ -520,8 +515,7 @@ public class MultiUserTests {
         Path subdirPath = Paths.get(u1.username, subdirName);
         FileWrapper subdir = u1.getByPath(subdirPath).get().get();
         FileWrapper uploaded = subdir.uploadOrOverwriteFile(filename, file1Reader, data1.length,
-                u1.network, u1.crypto, l -> {},
-                subdir.generateChildLocationsFromSize(data1.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         Path filePath = Paths.get(u1.username, subdirName, filename);
 
@@ -678,8 +672,7 @@ public class MultiUserTests {
         Path subdirPath = Paths.get(u1.username, subdirName);
         FileWrapper subdir = u1.getByPath(subdirPath).get().get();
         FileWrapper uploaded = subdir.uploadOrOverwriteFile(filename, file1Reader, data1.length,
-                u1.network, u1.crypto, l -> {},
-                subdir.generateChildLocationsFromSize(data1.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         Path filePath = Paths.get(u1.username, subdirName, filename);
         shareFunction.apply(u1, userContexts, filePath);
@@ -823,8 +816,7 @@ public class MultiUserTests {
         Files.write(f.toPath(), originalFileContents);
         ResetableFileInputStream resetableFileInputStream = new ResetableFileInputStream(f);
         FileWrapper uploaded = u1Root.uploadOrOverwriteFile(filename, resetableFileInputStream, f.length(),
-                u1.network, u1.crypto, l -> {},
-                u1Root.generateChildLocationsFromSize(originalFileContents.length, u1.crypto.random)).get();
+                u1.network, u1.crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // share the file from "a" to each of the others
         String originalPath = u1.username + "/" + filename;

--- a/src/peergos/server/tests/P2pStreamNetworkTests.java
+++ b/src/peergos/server/tests/P2pStreamNetworkTests.java
@@ -78,7 +78,7 @@ public class P2pStreamNetworkTests {
         String filename = "hey.txt";
         FileWrapper root = u1.getUserRoot().get();
         FileWrapper upload = root.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length,
-                nodes.get(1), crypto, x -> { }, root.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                nodes.get(1), crypto, x -> { }, crypto.random.randomBytes(32)).get();
         Thread.sleep(7000);
         Optional<FileWrapper> file = ensureSignedUp(username1, password1, nodes.get(0), crypto)
                 .getByPath("/" + username1 + "/" + filename).get();

--- a/src/peergos/server/tests/QuotaTests.java
+++ b/src/peergos/server/tests/QuotaTests.java
@@ -58,13 +58,11 @@ public class QuotaTests {
         byte[] data = new byte[1024*1024];
         random.nextBytes(data);
         FileWrapper newHome = home.uploadOrOverwriteFile("file-1", new AsyncReader.ArrayBacked(data), data.length,
-                network, crypto, x -> {},
-                home.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
 
         try {
             newHome.uploadOrOverwriteFile("file-2", new AsyncReader.ArrayBacked(data), data.length, network,
-                    crypto, x -> {},
-                    newHome.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                    crypto, x -> {}, crypto.random.randomBytes(32)).get();
             Assert.fail("Quota wasn't enforced");
         } catch (Exception e) {}
     }
@@ -81,8 +79,7 @@ public class QuotaTests {
         for (int i=0; i < 5; i++) {
             String filename = "file-1";
             home = home.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length,
-                    network, crypto, x -> {},
-                    home.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                    network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
             FileWrapper file = context.getByPath("/" + username + "/" + filename).get().get();
             home = file.remove(home, context).get();
         }
@@ -101,8 +98,7 @@ public class QuotaTests {
         random.nextBytes(data);
         String filename = "file-1";
         home = home.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length,
-                network, crypto, x -> {},
-                home.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
         FileWrapper file = context.getByPath("/" + username + "/" + filename).get().get();
         file.remove(home, context).get();
     }
@@ -120,13 +116,11 @@ public class QuotaTests {
         random.nextBytes(data);
         String filename = "file-1";
         home = home.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length,
-                network, crypto, x -> {},
-                home.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
         FileWrapper file = context.getByPath("/" + username + "/" + filename).get().get();
         try {
             home = home.uploadOrOverwriteFile("file-2", new AsyncReader.ArrayBacked(data), data.length,
-                    network, crypto, x -> {},
-                    home.generateChildLocationsFromSize(data.length, crypto.random)).get();
+                    network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
             Assert.fail();
         } catch (Exception e) {}
         file.remove(home, context).get();

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -51,7 +51,7 @@ public class RamUserTests extends UserTests {
         byte[] data = new byte[0];
         user1.getByPath(Paths.get(username1, folder1, folder11)).join().get()
                 .uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length, user1.network,
-                crypto, l -> {}, user1Root.generateChildLocationsFromSize(0, crypto.random)).get();
+                crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // create 2nd user and friend user1
         String username2 = generateUsername();

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -271,16 +271,16 @@ public abstract class UserTests {
         byte[] data = new byte[0];
         userRoot.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length, context.network,
                 context.crypto, l -> {}, context.crypto.random.randomBytes(32)).get();
-        checkFileContents(data, context.getUserRoot().get().getDescendentByPath(filename, context.network).get().get(), context);
+        checkFileContents(data, context.getUserRoot().get().getDescendentByPath(filename, crypto.hasher, context.network).get().get(), context);
 
         // write small 1 chunk file
         byte[] data2 = "This is a small amount of data".getBytes();
         FileWrapper updatedRoot = uploadFileSection(context.getUserRoot().get(), filename, new AsyncReader.ArrayBacked(data2), 0, data2.length, context.network,
                 context.crypto, l -> {}).get();
-        checkFileContents(data2, updatedRoot.getDescendentByPath(filename, context.network).get().get(), context);
+        checkFileContents(data2, updatedRoot.getDescendentByPath(filename, crypto.hasher, context.network).get().get(), context);
 
         // check multiple read calls  in one chunk
-        checkFileContentsChunked(data2, updatedRoot.getDescendentByPath(filename, context.network).get().get(), context, 3);
+        checkFileContentsChunked(data2, updatedRoot.getDescendentByPath(filename, crypto.hasher, context.network).get().get(), context, 3);
         // check file size
         // assertTrue("File size", data2.length == userRoot.getDescendentByPath(filename,context.network).get().get().getFileProperties().size);
 
@@ -292,7 +292,7 @@ public abstract class UserTests {
         FileWrapper updatedRoot2 = uploadFileSection(updatedRoot, filename, new AsyncReader.ArrayBacked(bigData), 0, bigData.length, context.network,
                 context.crypto, l -> {}).get();
         checkFileContentsChunked(bigData,
-                updatedRoot2.getDescendentByPath(filename, context.network).get().get(),
+                updatedRoot2.getDescendentByPath(filename, crypto.hasher, context.network).get().get(),
                 context,
                 5);
         assertTrue("File size", bigData.length == context.getByPath(username + "/" + filename).get().get().getFileProperties().size);
@@ -304,7 +304,7 @@ public abstract class UserTests {
         FileWrapper updatedRoot3 = uploadFileSection(updatedRoot2, otherName, new AsyncReader.ArrayBacked(data3), 0, data3.length, context.network,
                 context.crypto, l -> {}).get();
         assertTrue("File size", data3.length == context.getByPath(username + "/" + otherName).get().get().getFileProperties().size);
-        checkFileContents(data3, updatedRoot3.getDescendentByPath(otherName, context.network).get().get(), context);
+        checkFileContents(data3, updatedRoot3.getDescendentByPath(otherName, crypto.hasher, context.network).get().get(), context);
 
         // insert data in the middle
         byte[] data4 = "some data to insert somewhere".getBytes();
@@ -312,13 +312,13 @@ public abstract class UserTests {
         FileWrapper updatedRoot4 = uploadFileSection(updatedRoot3, otherName, new AsyncReader.ArrayBacked(data4), startIndex, startIndex + data4.length,
                 context.network, context.crypto, l -> {}).get();
         System.arraycopy(data4, 0, data3, startIndex, data4.length);
-        checkFileContents(data3, updatedRoot4.getDescendentByPath(otherName, context.network).get().get(), context);
+        checkFileContents(data3, updatedRoot4.getDescendentByPath(otherName, crypto.hasher, context.network).get().get(), context);
 
         //rename
         String newname = "newname.txt";
-        FileWrapper updatedRoot5 = updatedRoot4.getDescendentByPath(otherName, context.network).get().get()
+        FileWrapper updatedRoot5 = updatedRoot4.getDescendentByPath(otherName, crypto.hasher, context.network).get().get()
                 .rename(newname, updatedRoot4, context).get();
-        checkFileContents(data3, updatedRoot5.getDescendentByPath(newname, context.network).get().get(), context);
+        checkFileContents(data3, updatedRoot5.getDescendentByPath(newname, crypto.hasher, context.network).get().get(), context);
         // check from the root as well
         checkFileContents(data3, context.getByPath(username + "/" + newname).get().get(), context);
         // check from a fresh log in too
@@ -339,13 +339,13 @@ public abstract class UserTests {
         byte[] data = randomData(6*1024*1024);
         userRoot.uploadFileJS(filename, new AsyncReader.ArrayBacked(data), 0,data.length, false,
                 network, crypto, l -> {}, context.getTransactionService()).join();
-        checkFileContents(data, context.getUserRoot().join().getDescendentByPath(filename, context.network).join().get(), context);
+        checkFileContents(data, context.getUserRoot().join().getDescendentByPath(filename, crypto.hasher, context.network).join().get(), context);
 
         String file2name = "file2.bin";
         byte[] data2 = randomData(6*1024*1024);
         userRootCopy.uploadFileJS(file2name, new AsyncReader.ArrayBacked(data2), 0,data2.length, false,
                 network, crypto, l -> {}, context.getTransactionService()).join();
-        checkFileContents(data2, context.getUserRoot().join().getDescendentByPath(file2name, context.network).join().get(), context);
+        checkFileContents(data2, context.getUserRoot().join().getDescendentByPath(file2name, crypto.hasher, context.network).join().get(), context);
     }
 
     @Test
@@ -360,7 +360,7 @@ public abstract class UserTests {
         byte[] data = new byte[0];
         userRoot.uploadOrOverwriteFile(filename, new AsyncReader.ArrayBacked(data), data.length, context.network,
                 context.crypto, l -> {}, context.crypto.random.randomBytes(32)).get();
-        checkFileContents(data, context.getUserRoot().get().getDescendentByPath(filename, context.network).get().get(), context);
+        checkFileContents(data, context.getUserRoot().get().getDescendentByPath(filename, crypto.hasher, context.network).get().get(), context);
 
         //rename
         String newname = "newname.txt";
@@ -432,7 +432,7 @@ public abstract class UserTests {
                     FileWrapper result = userRoot.uploadOrOverwriteFile(filename,
                             new AsyncReader.ArrayBacked(data),
                             data.length, context.network, context.crypto, l -> {}, context.crypto.random.randomBytes(32)).join();
-                    Optional<FileWrapper> childOpt = result.getChild(filename, network).join();
+                    Optional<FileWrapper> childOpt = result.getChild(filename, crypto.hasher, network).join();
                     checkFileContents(data, childOpt.get(), context);
                     LOG.info("Finished a file");
                     return true;
@@ -440,7 +440,7 @@ public abstract class UserTests {
 
         boolean success = Futures.combineAll(futs).get().stream().reduce(true, (a, b) -> a && b);
 
-        Set<FileWrapper> files = context.getUserRoot().get().getChildren(context.network).get();
+        Set<FileWrapper> files = context.getUserRoot().get().getChildren(crypto.hasher, context.network).get();
         Set<String> names = files.stream().filter(f -> ! f.getFileProperties().isHidden).map(f -> f.getName()).collect(Collectors.toSet());
         Set<String> expectedNames = IntStream.range(0, concurrency).mapToObj(i -> i + ".bin").collect(Collectors.toSet());
         Assert.assertTrue("All children present and accounted for: " + names, names.equals(expectedNames));
@@ -469,7 +469,7 @@ public abstract class UserTests {
 
         boolean success = Futures.combineAll(futs).get().stream().reduce(true, (a, b) -> a && b);
 
-        Set<FileWrapper> files = context.getUserRoot().get().getChildren(context.network).get();
+        Set<FileWrapper> files = context.getUserRoot().get().getChildren(crypto.hasher, context.network).get();
         Set<String> names = files.stream().filter(f -> ! f.getFileProperties().isHidden).map(f -> f.getName()).collect(Collectors.toSet());
         Set<String> expectedNames = IntStream.range(0, concurrency).mapToObj(i -> "folder" + i).collect(Collectors.toSet());
         Assert.assertTrue("All children present and accounted for: " + names, names.equals(expectedNames));
@@ -506,7 +506,7 @@ public abstract class UserTests {
                             new AsyncReader.ArrayBacked(data),
                             i * CHUNK_SIZE, (i + 1) * CHUNK_SIZE,
                             context.network, context.crypto, l -> {}).join();
-                    Optional<FileWrapper> childOpt = result.getChild(filename, network).join();
+                    Optional<FileWrapper> childOpt = result.getChild(filename, crypto.hasher, network).join();
                     sections.set(i, data);
                     return true;
                 }, pool)).collect(Collectors.toSet());
@@ -700,9 +700,9 @@ public abstract class UserTests {
         random.nextBytes(data5);
         FileWrapper userRoot3 = uploadFileSection(userRoot2, filename, new AsyncReader.ArrayBacked(data5), 0, data5.length, context.network,
                 context.crypto, l -> {}).join();
-        checkFileContents(data5, userRoot3.getDescendentByPath(filename, context.network).get().get(), context);
+        checkFileContents(data5, userRoot3.getDescendentByPath(filename, crypto.hasher, context.network).get().get(), context);
         assertTrue("10MiB file size", data5.length == userRoot3.getDescendentByPath(filename,
-                context.network).get().get().getFileProperties().size);
+                crypto.hasher, context.network).get().get().getFileProperties().size);
 
         // insert data in the middle of second chunk
         LOG.info("\n***** Mid 2nd chunk write test");
@@ -711,7 +711,7 @@ public abstract class UserTests {
         FileWrapper userRoot4 = uploadFileSection(userRoot3, filename, new AsyncReader.ArrayBacked(dataInsert), start, start + dataInsert.length,
                 context.network, context.crypto, l -> {}).get();
         System.arraycopy(dataInsert, 0, data5, start, dataInsert.length);
-        checkFileContents(data5, userRoot4.getDescendentByPath(filename, context.network).get().get(), context);
+        checkFileContents(data5, userRoot4.getDescendentByPath(filename, crypto.hasher, context.network).get().get(), context);
 
         // check used space
         PublicKeyHash signer = context.signer.publicKeyHash;
@@ -737,7 +737,7 @@ public abstract class UserTests {
 
         for (int offset: Arrays.asList(10, 4*MB, 6*MB, 11*MB)) {
             AsyncReader reader = context.getByPath(Paths.get(username, filename)).join()
-                    .get().getInputStream(network, crypto.random, x -> { }).join();
+                    .get().getInputStream(network, crypto, x -> { }).join();
             AsyncReader seeked = reader.seek(offset).join();
             seeked.readIntoArray(buf, 0, buf.length).join();
             if (! Arrays.equals(buf, Arrays.copyOfRange(data, offset, offset + buf.length)))
@@ -746,7 +746,7 @@ public abstract class UserTests {
 
         for (int mb = 0; mb < 13; mb++) {
             AsyncReader reader = context.getByPath(Paths.get(username, filename)).join()
-                    .get().getInputStream(network, crypto.random, x -> { }).join();
+                    .get().getInputStream(network, crypto, x -> { }).join();
             for (int count = 0; count < mb; count++) {
                 reader = reader.seek(count * MB).join();
                 reader.readIntoArray(buf, 0, buf.length).join();
@@ -953,14 +953,14 @@ public abstract class UserTests {
         for (int i=0; i < names.size(); i++) {
             String filename = names.get(i);
             context.getUserRoot().get().mkdir(filename, context.network, false, context.crypto);
-            Set<FileWrapper> children = context.getUserRoot().get().getChildren(context.network).get();
+            Set<FileWrapper> children = context.getUserRoot().get().getChildren(crypto.hasher, context.network).get();
             Assert.assertTrue("All children present", children.size() == i + 3); // 3 due to .keystore and shared
         }
     }
 
     public static void checkFileContents(byte[] expected, FileWrapper f, UserContext context) {
         long size = f.getFileProperties().size;
-        byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto.random,
+        byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto,
             size, l-> {}).join(), f.getSize()).join();
         assertEquals(expected.length, size);
         assertTrue("Correct contents", Arrays.equals(retrievedData, expected));
@@ -968,7 +968,7 @@ public abstract class UserTests {
 
     private static void checkFileContentsChunked(byte[] expected, FileWrapper f, UserContext context, int  nReads) throws Exception {
 
-        AsyncReader in = f.getInputStream(context.network, context.crypto.random,
+        AsyncReader in = f.getInputStream(context.network, context.crypto,
                 f.getFileProperties().size, l -> {}).get();
         assertTrue(nReads > 1);
 
@@ -1008,7 +1008,7 @@ public abstract class UserTests {
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         FileWrapper userRoot = context.getUserRoot().get();
 
-        Set<FileWrapper> children = userRoot.getChildren(context.network).get();
+        Set<FileWrapper> children = userRoot.getChildren(crypto.hasher, context.network).get();
 
         children.stream()
                 .map(FileWrapper::toString)
@@ -1021,7 +1021,7 @@ public abstract class UserTests {
         FileWrapper updatedRoot = userRoot.uploadOrOverwriteFile(name, resetableFileInputStream, data.length,
                 context.network, context.crypto, l -> {}, context.crypto.random.randomBytes(32)).get();
 
-        Optional<FileWrapper> opt = updatedRoot.getChildren(context.network).get()
+        Optional<FileWrapper> opt = updatedRoot.getChildren(crypto.hasher, context.network).get()
                 .stream()
                 .filter(e -> e.getFileProperties().name.equals(name))
                 .findFirst();
@@ -1030,7 +1030,7 @@ public abstract class UserTests {
 
         FileWrapper fileWrapper = opt.get();
         long size = fileWrapper.getFileProperties().size;
-        AsyncReader in = fileWrapper.getInputStream(context.network, context.crypto.random, size, (l) -> {}).get();
+        AsyncReader in = fileWrapper.getInputStream(context.network, context.crypto, size, (l) -> {}).get();
         byte[] retrievedData = Serialize.readFully(in, fileWrapper.getSize()).get();
 
         boolean  dataEquals = Arrays.equals(data, retrievedData);
@@ -1057,7 +1057,7 @@ public abstract class UserTests {
         FileWrapper updatedRoot2 = updatedRoot.uploadOrOverwriteFile(otherName, fileData.reset().join(),
                 data.length, context.network, context.crypto, l -> {}, context.crypto.random.randomBytes(32)).get();
 
-        Optional<FileWrapper> opt = updatedRoot2.getChildren(context.network).get()
+        Optional<FileWrapper> opt = updatedRoot2.getChildren(crypto.hasher, context.network).get()
                         .stream()
                         .filter(e -> e.getFileProperties().name.equals(name))
                         .findFirst();
@@ -1066,7 +1066,7 @@ public abstract class UserTests {
 
         FileWrapper fileWrapper = opt.get();
         long size = fileWrapper.getFileProperties().size;
-        AsyncReader in = fileWrapper.getInputStream(context.network, context.crypto.random, size, (l) -> {}).get();
+        AsyncReader in = fileWrapper.getInputStream(context.network, context.crypto, size, (l) -> {}).get();
         byte[] retrievedData = Serialize.readFully(in, fileWrapper.getSize()).get();
 
         boolean  dataEquals = Arrays.equals(data, retrievedData);
@@ -1082,7 +1082,7 @@ public abstract class UserTests {
 
 
         //check the file is no longer present
-        boolean isPresent = userRoot2.getChildren(context2.network).get()
+        boolean isPresent = userRoot2.getChildren(crypto.hasher, context2.network).get()
                 .stream()
                 .anyMatch(e -> e.getFileProperties().name.equals(name));
 
@@ -1090,13 +1090,13 @@ public abstract class UserTests {
 
 
         //check content of other file in same directory that was not removed
-        FileWrapper otherFileWrapper = userRoot2.getChildren(context2.network).get()
+        FileWrapper otherFileWrapper = userRoot2.getChildren(crypto.hasher, context2.network).get()
                 .stream()
                 .filter(e -> e.getFileProperties().name.equals(otherName))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Missing other file"));
 
-        AsyncReader asyncReader = otherFileWrapper.getInputStream(context2.network, context2.crypto.random, l -> {}).get();
+        AsyncReader asyncReader = otherFileWrapper.getInputStream(context2.network, context2.crypto, l -> {}).get();
 
         byte[] otherRetrievedData = Serialize.readFully(asyncReader, otherFileWrapper.getSize()).get();
         boolean  otherDataEquals = Arrays.equals(data, otherRetrievedData);
@@ -1172,7 +1172,7 @@ public abstract class UserTests {
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         FileWrapper userRoot = context.getUserRoot().get();
 
-        Set<FileWrapper> children = userRoot.getChildren(context.network).get();
+        Set<FileWrapper> children = userRoot.getChildren(crypto.hasher, context.network).get();
 
         children.stream()
                 .map(FileWrapper::toString)
@@ -1185,7 +1185,7 @@ public abstract class UserTests {
         userRoot.mkdir(folderName, context.network, isSystemFolder, context.crypto).get();
 
         FileWrapper updatedUserRoot = context.getUserRoot().get();
-        FileWrapper directory = updatedUserRoot.getChildren(context.network)
+        FileWrapper directory = updatedUserRoot.getChildren(crypto.hasher, context.network)
                 .get()
                 .stream()
                 .filter(e -> e.getFileProperties().name.equals(folderName))
@@ -1205,7 +1205,7 @@ public abstract class UserTests {
         directory.remove(updatedUserRoot, context).get();
 
         //ensure folder directory not  present
-        boolean isPresent = context.getUserRoot().get().getChildren(context.network)
+        boolean isPresent = context.getUserRoot().get().getChildren(crypto.hasher, context.network)
                 .get()
                 .stream()
                 .filter(e -> e.getFileProperties().name.equals(folderName))

--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -147,7 +147,10 @@ public class NativeFileSystemImpl implements FileSystem {
                 boolean isHidden = false;
                 String mimeType="NOT_SUPPORTED";
 
-                return new FileProperties(file.getName(), file.isDirectory(), mimeType, sizeHi, sizeLo, lastModified, isHidden, thumbnail);
+                //TODO make files use the new format with a stream secret
+                Optional<byte[]> streamSecret = file.isDirectory() ? Optional.empty() : Optional.empty();
+                return new FileProperties(file.getName(), file.isDirectory(), mimeType, sizeHi, sizeLo, lastModified,
+                        isHidden, thumbnail, streamSecret);
 
             }
 

--- a/src/peergos/server/tests/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/PeergosFileSystemImpl.java
@@ -35,7 +35,7 @@ public class PeergosFileSystemImpl implements FileSystem {
     public byte[] read(Path path) {
         FileWrapper wrapper = getPath(path);
         long size = wrapper.getFileProperties().size;
-        AsyncReader in = wrapper.getInputStream(userContext.network, userContext.crypto.random, size, (l) -> {
+        AsyncReader in = wrapper.getInputStream(userContext.network, userContext.crypto, size, (l) -> {
         }).join();
         return Serialize.readFully(in, size).join();
     }
@@ -58,7 +58,7 @@ public class PeergosFileSystemImpl implements FileSystem {
 
     @Override
     public List<Path> ls(Path path) {
-        return getPath(path).getChildren(userContext.network)
+        return getPath(path).getChildren(userContext.crypto.hasher, userContext.network)
                 .join()
                 .stream()
                 .map(e -> path.resolve(e.getName()))

--- a/src/peergos/server/tests/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/PeergosFileSystemImpl.java
@@ -46,8 +46,7 @@ public class PeergosFileSystemImpl implements FileSystem {
         AsyncReader resetableFileInputStream = new AsyncReader.ArrayBacked(data);
         String fileName = path.getFileName().toString();
         FileWrapper fileWrapper = directory.uploadOrOverwriteFile(fileName, resetableFileInputStream, data.length,
-                userContext.network, userContext.crypto, x -> {},
-                userContext.getUserRoot().join().generateChildLocationsFromSize(data.length, userContext.crypto.random)).join();
+                userContext.network, userContext.crypto, x -> {}, userContext.crypto.random.randomBytes(32)).join();
 
     }
 

--- a/src/peergos/server/tests/slow/IpfsStressTest.java
+++ b/src/peergos/server/tests/slow/IpfsStressTest.java
@@ -101,7 +101,7 @@ public class IpfsStressTest {
 
     public static void checkFileContents(byte[] expected, FileWrapper f, UserContext context) throws Exception {
         long size = f.getFileProperties().size;
-        byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto.random,
+        byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto,
             size, l-> {}).get(), f.getSize()).get();
         assertEquals(expected.length, size);
         assertTrue("Correct contents", Arrays.equals(retrievedData, expected));
@@ -109,7 +109,7 @@ public class IpfsStressTest {
 
     private static void checkFileContentsChunked(byte[] expected, FileWrapper f, UserContext context, int  nReads) throws Exception {
 
-        AsyncReader in = f.getInputStream(context.network, context.crypto.random,
+        AsyncReader in = f.getInputStream(context.network, context.crypto,
                 f.getFileProperties().size, l -> {}).get();
         assertTrue(nReads > 1);
 

--- a/src/peergos/server/tests/slow/IpfsStressTest.java
+++ b/src/peergos/server/tests/slow/IpfsStressTest.java
@@ -96,8 +96,7 @@ public class IpfsStressTest {
         int size = rnd.nextInt(15*1024*1024);
         FileWrapper parent = context.getByPath(parentPath.toString()).get().get();
         parent.uploadOrOverwriteFile(name, new AsyncReader.ArrayBacked(randomData(rnd, size)), size,
-                        context.network, context.crypto, x -> {},
-                parent.generateChildLocationsFromSize(size, context.crypto.random)).get();
+                        context.network, context.crypto, x -> {}, context.crypto.random.randomBytes(32)).get();
     }
 
     public static void checkFileContents(byte[] expected, FileWrapper f, UserContext context) throws Exception {

--- a/src/peergos/server/tests/slow/MediumFileBenchmark.java
+++ b/src/peergos/server/tests/slow/MediumFileBenchmark.java
@@ -72,8 +72,7 @@ public class MediumFileBenchmark {
             String filename = names.get(i);
             long t1 = System.currentTimeMillis();
             userRoot = userRoot.uploadOrOverwriteFile(filename, AsyncReader.build(data), data.length, context.network,
-                    crypto, x-> {},
-                    userRoot.generateChildLocationsFromSize(data.length, crypto.random)).join();
+                    crypto, x-> {}, context.crypto.random.randomBytes(32)).join();
             long duration = System.currentTimeMillis() - t1;
             worst = Math.max(worst, duration);
             best = Math.min(best, duration);

--- a/src/peergos/server/tests/slow/MediumFileBenchmark.java
+++ b/src/peergos/server/tests/slow/MediumFileBenchmark.java
@@ -85,7 +85,7 @@ public class MediumFileBenchmark {
             long t1 = System.currentTimeMillis();
             FileWrapper file = context.getByPath(Paths.get(username, names.get(random.nextInt(names.size()))))
                     .join().get();
-            AsyncReader reader = file.getInputStream(network, crypto.random, x -> {}).join();
+            AsyncReader reader = file.getInputStream(network, crypto, x -> {}).join();
             byte[] readData = Serialize.readFully(reader, data.length).join();
             long duration = System.currentTimeMillis() - t1;
             Assert.assertTrue(Arrays.equals(readData, data));

--- a/src/peergos/server/tests/slow/SmallFileBenchmark.java
+++ b/src/peergos/server/tests/slow/SmallFileBenchmark.java
@@ -72,8 +72,7 @@ public class SmallFileBenchmark {
             String filename = names.get(i);
             long t1 = System.currentTimeMillis();
             userRoot = userRoot.uploadOrOverwriteFile(filename, AsyncReader.build(data), data.length, context.network,
-                    crypto, x-> {},
-                    userRoot.generateChildLocationsFromSize(data.length, crypto.random)).join();
+                    crypto, x-> {}, context.crypto.random.randomBytes(32)).join();
             long duration = System.currentTimeMillis() - t1;
             worst = Math.max(worst, duration);
             best = Math.min(best, duration);

--- a/src/peergos/server/tests/slow/SmallFileBenchmark.java
+++ b/src/peergos/server/tests/slow/SmallFileBenchmark.java
@@ -85,7 +85,7 @@ public class SmallFileBenchmark {
             long t1 = System.currentTimeMillis();
             FileWrapper file = context.getByPath(Paths.get(username, names.get(random.nextInt(names.size()))))
                     .join().get();
-            AsyncReader reader = file.getInputStream(network, crypto.random, x -> {}).join();
+            AsyncReader reader = file.getInputStream(network, crypto, x -> {}).join();
             byte[] readData = Serialize.readFully(reader, data.length).join();
             long duration = System.currentTimeMillis() - t1;
             Assert.assertTrue(Arrays.equals(readData, data));

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -181,8 +181,8 @@ public class PeergosNetworkUtils {
         parent.uploadFileSection(filename, suffixStream, false, originalFileContents.length, originalFileContents.length + suffix.length,
                 Optional.empty(), true, updatedSharerUser.network, crypto, l -> {},
                 null).get();
-        AsyncReader extendedContents = updatedSharerUser.getByPath(sharerUser.username + "/" + filename).get().get().getInputStream(updatedSharerUser.network,
-                crypto, l -> {}).get();
+        AsyncReader extendedContents = updatedSharerUser.getByPath(sharerUser.username + "/" + filename).get().get()
+                .getInputStream(updatedSharerUser.network, crypto, l -> {}).get();
         byte[] newFileContents = Serialize.readFully(extendedContents, originalFileContents.length + suffix.length).get();
 
         Assert.assertTrue(Arrays.equals(newFileContents, ArrayOps.concat(originalFileContents, suffix)));

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -109,8 +109,7 @@ public class PeergosNetworkUtils {
         Files.write(f.toPath(), originalFileContents);
         ResetableFileInputStream resetableFileInputStream = new ResetableFileInputStream(f);
         FileWrapper uploaded = u1Root.uploadOrOverwriteFile(filename, resetableFileInputStream, f.length(),
-                sharerUser.network, crypto, l -> {},
-                u1Root.generateChildLocationsFromSize(originalFileContents.length, crypto.random)).get();
+                sharerUser.network, crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // share the file from sharer to each of the sharees
         FileWrapper u1File = sharerUser.getByPath(sharerUser.username + "/" + filename).get().get();
@@ -229,8 +228,7 @@ public class PeergosNetworkUtils {
         byte[] originalFileContents = sharerUser.crypto.random.randomBytes(10*1024*1024);
         AsyncReader resetableFileInputStream = AsyncReader.build(originalFileContents);
         FileWrapper uploaded = u1Root.uploadOrOverwriteFile(filename, resetableFileInputStream, originalFileContents.length,
-                sharerUser.network, crypto, l -> {},
-                u1Root.generateChildLocationsFromSize(originalFileContents.length, crypto.random)).get();
+                sharerUser.network, crypto, l -> {}, crypto.random.randomBytes(32)).get();
 
         // share the file from sharer to each of the sharees
         FileWrapper u1File = sharerUser.getByPath(sharerUser.username + "/" + filename).get().get();
@@ -345,8 +343,7 @@ public class PeergosNetworkUtils {
         byte[] originalFileContents = "Hello Peergos friend!".getBytes();
         AsyncReader resetableFileInputStream = new AsyncReader.ArrayBacked(originalFileContents);
         FileWrapper updatedFolder = folder.uploadOrOverwriteFile(filename, resetableFileInputStream,
-                originalFileContents.length, sharer.network, crypto, l -> {},
-                folder.generateChildLocationsFromSize(originalFileContents.length, crypto.random)).get();
+                originalFileContents.length, sharer.network, crypto, l -> {},crypto.random.randomBytes(32)).get();
         String originalFilePath = sharer.username + "/" + folderName + "/" + filename;
 
         for (int i=0; i< 20; i++) {
@@ -469,8 +466,7 @@ public class PeergosNetworkUtils {
         byte[] originalFileContents = "Hello Peergos friend!".getBytes();
         AsyncReader resetableFileInputStream = new AsyncReader.ArrayBacked(originalFileContents);
         folder.uploadOrOverwriteFile(filename, resetableFileInputStream,
-                originalFileContents.length, sharer.network, crypto, l -> {},
-                folder.generateChildLocationsFromSize(originalFileContents.length, crypto.random)).join();
+                originalFileContents.length, sharer.network, crypto, l -> {}, crypto.random.randomBytes(32)).join();
         String originalFilePath = sharer.username + "/" + folderName + "/" + filename;
 
         for (int i=0; i< 20; i++) {
@@ -487,9 +483,8 @@ public class PeergosNetworkUtils {
         String imagename = "small.png";
         byte[] data = Files.readAllBytes(Paths.get("assets", "logo.png"));
         FileWrapper sharedFolderv0 = sharer.getByPath(path).join().get();
-        List<Location> chunkLocations = sharedFolderv0.generateChildLocationsFromSize(originalFileContents.length, crypto.random);
         sharedFolderv0.uploadOrOverwriteFile(imagename, AsyncReader.build(data), data.length,
-                sharer.network, crypto, x -> {}, chunkLocations).join();
+                sharer.network, crypto, x -> {}, crypto.random.randomBytes(32)).join();
 
         // create a directory
         FileWrapper sharedFolderv1 = sharer.getByPath(path).join().get();
@@ -641,8 +636,7 @@ public class PeergosNetworkUtils {
         random.nextBytes(data);
         long t1 = System.currentTimeMillis();
         userRoot.uploadFileSection(filename, new AsyncReader.ArrayBacked(data), false, 0, data.length, Optional.empty(),
-                true, context.network, crypto, l -> {},
-                userRoot.generateChildLocationsFromSize(data.length, context.crypto.random)).get();
+                true, context.network, crypto, l -> {}, crypto.random.randomBytes(32)).get();
         long t2 = System.currentTimeMillis();
         String path = "/" + username + "/" + filename;
         FileWrapper file = context.getByPath(path).get().get();

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -47,7 +47,7 @@ public class PeergosNetworkUtils {
 
     public static void checkFileContents(byte[] expected, FileWrapper f, UserContext context) throws Exception {
         long size = f.getFileProperties().size;
-        byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto.random,
+        byte[] retrievedData = Serialize.readFully(f.getInputStream(context.network, context.crypto,
                 size, l -> {}).get(), f.getSize()).get();
         assertEquals(expected.length, size);
         assertTrue("Correct contents", Arrays.equals(retrievedData, expected));
@@ -130,7 +130,7 @@ public class PeergosNetworkUtils {
         for (UserContext userContext : shareeUsers) {
             Optional<FileWrapper> friendRoot = userContext.getByPath(sharerUser.username).get();
             assertTrue("friend root present", friendRoot.isPresent());
-            Set<FileWrapper> children = friendRoot.get().getChildren(userContext.network).get();
+            Set<FileWrapper> children = friendRoot.get().getChildren(crypto.hasher, userContext.network).get();
             Optional<FileWrapper> sharedFile = children.stream()
                     .filter(file -> file.getName().equals(filename))
                     .findAny();
@@ -182,7 +182,7 @@ public class PeergosNetworkUtils {
                 Optional.empty(), true, updatedSharerUser.network, crypto, l -> {},
                 null).get();
         AsyncReader extendedContents = updatedSharerUser.getByPath(sharerUser.username + "/" + filename).get().get().getInputStream(updatedSharerUser.network,
-                crypto.random, l -> {}).get();
+                crypto, l -> {}).get();
         byte[] newFileContents = Serialize.readFully(extendedContents, originalFileContents.length + suffix.length).get();
 
         Assert.assertTrue(Arrays.equals(newFileContents, ArrayOps.concat(originalFileContents, suffix)));
@@ -246,7 +246,7 @@ public class PeergosNetworkUtils {
         for (UserContext userContext : shareeUsers) {
             Optional<FileWrapper> friendRoot = userContext.getByPath(sharerUser.username).get();
             assertTrue("friend root present", friendRoot.isPresent());
-            Set<FileWrapper> children = friendRoot.get().getChildren(userContext.network).get();
+            Set<FileWrapper> children = friendRoot.get().getChildren(crypto.hasher, userContext.network).get();
             Optional<FileWrapper> sharedFile = children.stream()
                     .filter(file -> file.getName().equals(filename))
                     .findAny();
@@ -298,7 +298,7 @@ public class PeergosNetworkUtils {
                 Optional.empty(), true, updatedSharerUser.network, crypto, l -> {},
                 null).get();
         AsyncReader extendedContents = updatedSharerUser.getByPath(sharerUser.username + "/" + filename).get().get().getInputStream(updatedSharerUser.network,
-                updatedSharerUser.crypto.random, l -> {}).get();
+                updatedSharerUser.crypto, l -> {}).get();
         byte[] newFileContents = Serialize.readFully(extendedContents, originalFileContents.length + suffix.length).get();
 
         Assert.assertTrue(Arrays.equals(newFileContents, ArrayOps.concat(originalFileContents, suffix)));
@@ -351,7 +351,7 @@ public class PeergosNetworkUtils {
                     .mkdir("subdir"+i, sharer.network, false, crypto).join();
         }
 
-        Set<String> childNames = sharer.getByPath(path).join().get().getChildren(sharer.network).join()
+        Set<String> childNames = sharer.getByPath(path).join().get().getChildren(crypto.hasher, sharer.network).join()
                 .stream()
                 .map(f -> f.getName())
                 .collect(Collectors.toSet());
@@ -401,7 +401,7 @@ public class PeergosNetworkUtils {
                     updatedSharer.network, crypto, l -> {},
                     null).get();
             FileWrapper extendedFile = updatedSharer.getByPath(originalFilePath).get().get();
-            AsyncReader extendedContents = extendedFile.getInputStream(updatedSharer.network, crypto.random, l -> {}).get();
+            AsyncReader extendedContents = extendedFile.getInputStream(updatedSharer.network, crypto, l -> {}).get();
             byte[] newFileContents = Serialize.readFully(extendedContents, extendedFile.getSize()).get();
 
             Assert.assertTrue(Arrays.equals(newFileContents, ArrayOps.concat(originalFileContents, suffix)));
@@ -415,7 +415,7 @@ public class PeergosNetworkUtils {
 
                 FileWrapper sharedFile = otherUser.getByPath(updatedSharer.username + "/" + folderName + "/" + filename).get().get();
                 checkFileContents(newFileContents, sharedFile, otherUser);
-                Set<String> sharedChildNames = sharedFolder.get().getChildren(otherUser.network).join()
+                Set<String> sharedChildNames = sharedFolder.get().getChildren(crypto.hasher, otherUser.network).join()
                         .stream()
                         .map(f -> f.getName())
                         .collect(Collectors.toSet());
@@ -496,7 +496,7 @@ public class PeergosNetworkUtils {
         sharedDir.uploadFileJS("a-new-file.png", AsyncReader.build(data), 0, data.length,
                 false, shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService()).join();
 
-        Set<String> childNames = sharer.getByPath(path).join().get().getChildren(sharer.network).join()
+        Set<String> childNames = sharer.getByPath(path).join().get().getChildren(crypto.hasher, sharer.network).join()
                 .stream()
                 .map(f -> f.getName())
                 .collect(Collectors.toSet());
@@ -509,7 +509,7 @@ public class PeergosNetworkUtils {
 
             FileWrapper sharedFile = sharee.getByPath(sharer.username + "/" + folderName + "/" + filename).get().get();
             checkFileContents(originalFileContents, sharedFile, sharee);
-            Set<String> sharedChildNames = sharedFolder.getChildren(sharee.network).join()
+            Set<String> sharedChildNames = sharedFolder.getChildren(crypto.hasher, sharee.network).join()
                     .stream()
                     .map(f -> f.getName())
                     .collect(Collectors.toSet());
@@ -548,7 +548,7 @@ public class PeergosNetworkUtils {
                     updatedSharer.network, crypto, l -> {},
                     null).get();
             FileWrapper extendedFile = updatedSharer.getByPath(originalFilePath).get().get();
-            AsyncReader extendedContents = extendedFile.getInputStream(updatedSharer.network, updatedSharer.crypto.random, l -> {
+            AsyncReader extendedContents = extendedFile.getInputStream(updatedSharer.network, updatedSharer.crypto, l -> {
             }).get();
             byte[] newFileContents = Serialize.readFully(extendedContents, extendedFile.getSize()).get();
 
@@ -563,7 +563,7 @@ public class PeergosNetworkUtils {
 
                 FileWrapper sharedFile = otherUser.getByPath(updatedSharer.username + "/" + folderName + "/" + filename).get().get();
                 checkFileContents(newFileContents, sharedFile, otherUser);
-                Set<String> sharedChildNames = sharedFolder.get().getChildren(otherUser.network).join()
+                Set<String> sharedChildNames = sharedFolder.get().getChildren(crypto.hasher, otherUser.network).join()
                         .stream()
                         .map(f -> f.getName())
                         .collect(Collectors.toSet());
@@ -621,7 +621,7 @@ public class PeergosNetworkUtils {
             sharedFolder.mkdir(sharee.username, shareeNode, false, crypto).get();
         }
 
-        Set<FileWrapper> children = sharer.getByPath(path).get().get().getChildren(sharerNode).get();
+        Set<FileWrapper> children = sharer.getByPath(path).get().get().getChildren(crypto.hasher, sharerNode).get();
         Assert.assertTrue(children.size() == shareeCount);
     }
 

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -423,7 +423,13 @@ public class NetworkAccess {
         return Futures.combineAllInOrder(futures)
                 .thenApply(groups -> groups.stream()
                         .flatMap(g -> g.stream())
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()))
+                .thenApply(res -> {
+                    for (Fragment fragment : fragments) {
+                        FragmentedPaddedCipherText.ArrayCache.releaseArray(fragment.data);
+                    }
+                    return res;
+                });
     }
 
     public CompletableFuture<Multihash> uploadChunk(CryptreeNode metadata,

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -104,7 +104,7 @@ public class NetworkAccess {
     }
 
     public static ContentAddressedStorage buildLocalDht(HttpPoster apiPoster, boolean isPeergosServer) {
-        return new CachingStorage(new ContentAddressedStorage.HTTP(apiPoster, isPeergosServer), 10_000, 50 * 1024);
+        return new CachingStorage(new ContentAddressedStorage.HTTP(apiPoster, isPeergosServer), 1_000, 50 * 1024);
     }
 
     @JsMethod
@@ -422,14 +422,7 @@ public class NetworkAccess {
                 })).collect(Collectors.toList());
         return Futures.combineAllInOrder(futures)
                 .thenApply(groups -> groups.stream()
-                        .flatMap(g -> g.stream())
-                        .collect(Collectors.toList()))
-                .thenApply(res -> {
-                    for (Fragment fragment : fragments) {
-                        FragmentedPaddedCipherText.ArrayCache.releaseArray(fragment.data);
-                    }
-                    return res;
-                });
+                        .flatMap(g -> g.stream()).collect(Collectors.toList()));
     }
 
     public CompletableFuture<Multihash> uploadChunk(CryptreeNode metadata,

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -31,15 +31,15 @@ public class TofuCoreNode implements CoreNode {
         return "/" + username + "/" + KEY_STORE_NAME;
     }
 
-    public static CompletableFuture<TofuKeyStore> load(String username, TrieNode root, NetworkAccess network, SafeRandom random) {
+    public static CompletableFuture<TofuKeyStore> load(String username, TrieNode root, NetworkAccess network, Crypto crypto) {
         if (username == null)
             return CompletableFuture.completedFuture(new TofuKeyStore());
 
-        return root.getByPath(getStorePath(username), network).thenCompose(fileOpt -> {
+        return root.getByPath(getStorePath(username), crypto.hasher, network).thenCompose(fileOpt -> {
             if (! fileOpt.isPresent())
                 return CompletableFuture.completedFuture(new TofuKeyStore());
 
-            return fileOpt.get().getInputStream(network, random, x -> {}).thenCompose(reader -> {
+            return fileOpt.get().getInputStream(network, crypto, x -> {}).thenCompose(reader -> {
                 byte[] storeData = new byte[(int) fileOpt.get().getSize()];
                 return reader.readIntoArray(storeData, 0, storeData.length)
                         .thenApply(x -> TofuKeyStore.fromCbor(CborObject.fromByteArray(storeData)));

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -54,7 +54,7 @@ public class TofuCoreNode implements CoreNode {
                     AsyncReader.ArrayBacked dataReader = new AsyncReader.ArrayBacked(data);
                     return home.uploadFileSection(KEY_STORE_NAME, dataReader, true, 0, (long) data.length,
                             Optional.empty(), true, context.network, context.crypto, x -> {},
-                            home.generateChildLocationsFromSize(data.length, context.crypto.random));
+                            context.crypto.random.randomBytes(32));
                 }).thenApply(x -> true);
     }
 

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -94,7 +94,7 @@ public class FragmentedPaddedCipherText implements Cborable {
     }
 
     private static byte[][] generateCache() {
-        return new byte[40][Fragment.MAX_LENGTH];
+        return new byte[Chunk.MAX_SIZE/Fragment.MAX_LENGTH][Fragment.MAX_LENGTH];
     }
 
     private static ThreadLocal<byte[][]> arrayCache = ThreadLocal.withInitial(FragmentedPaddedCipherText::generateCache);

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -48,7 +48,7 @@ public class CachingStorage implements ContentAddressedStorage {
         return target.put(owner, writer, signatures, blocks, tid)
                 .thenApply(res -> {
                     for (int i=0; i < blocks.size(); i++)
-                        cache.put(res.get(i), blocks.get(i));
+                        cache.put(res.get(i), Arrays.copyOf(blocks.get(i), blocks.get(i).length));
                     return res;
                 });
     }
@@ -92,7 +92,7 @@ public class CachingStorage implements ContentAddressedStorage {
         return target.putRaw(owner, writer, signatures, blocks, tid)
                 .thenApply(res -> {
                     for (int i=0; i < blocks.size(); i++)
-                        cache.put(res.get(i), blocks.get(i));
+                        cache.put(res.get(i), Arrays.copyOf(blocks.get(i), blocks.get(i).length));
                     return res;
                 });
     }

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -47,8 +47,11 @@ public class CachingStorage implements ContentAddressedStorage {
                                                   TransactionId tid) {
         return target.put(owner, writer, signatures, blocks, tid)
                 .thenApply(res -> {
-                    for (int i=0; i < blocks.size(); i++)
-                        cache.put(res.get(i), Arrays.copyOf(blocks.get(i), blocks.get(i).length));
+                    for (int i=0; i < blocks.size(); i++) {
+                        byte[] block = blocks.get(i);
+                        if (block.length < maxValueSize)
+                            cache.put(res.get(i), block);
+                    }
                     return res;
                 });
     }
@@ -91,8 +94,11 @@ public class CachingStorage implements ContentAddressedStorage {
                                                      TransactionId tid) {
         return target.putRaw(owner, writer, signatures, blocks, tid)
                 .thenApply(res -> {
-                    for (int i=0; i < blocks.size(); i++)
-                        cache.put(res.get(i), Arrays.copyOf(blocks.get(i), blocks.get(i).length));
+                    for (int i=0; i < blocks.size(); i++) {
+                        byte[] block = blocks.get(i);
+                        if (block.length < maxValueSize)
+                            cache.put(res.get(i), block);
+                    }
                     return res;
                 });
     }

--- a/src/peergos/shared/user/TrieNode.java
+++ b/src/peergos/shared/user/TrieNode.java
@@ -2,6 +2,7 @@ package peergos.shared.user;
 
 import jsinterop.annotations.JsType;
 import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.user.fs.*;
 
 import java.util.*;
@@ -10,9 +11,9 @@ import java.util.concurrent.*;
 @JsType
 public interface TrieNode {
 
-    CompletableFuture<Optional<FileWrapper>> getByPath(String path, NetworkAccess network);
+    CompletableFuture<Optional<FileWrapper>> getByPath(String path, Hasher hasher, NetworkAccess network);
 
-    CompletableFuture<Set<FileWrapper>> getChildren(String path, NetworkAccess network);
+    CompletableFuture<Set<FileWrapper>> getChildren(String path, Hasher hasher, NetworkAccess network);
 
     Set<String> getChildNames();
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -719,7 +719,7 @@ public class UserContext {
                         CryptreeNode.DirAndChildren root =
                                 CryptreeNode.createDir(MaybeMultihash.empty(), rootRKey, rootWKey, Optional.of(writerPair),
                                 new FileProperties(directoryName, true, "", 0, LocalDateTime.now(),
-                                        false, Optional.empty()), Optional.empty(), SymmetricKey.random(), nextChunk, crypto.hasher);
+                                        false, Optional.empty(), Optional.empty()), Optional.empty(), SymmetricKey.random(), nextChunk, crypto.hasher);
 
                         LOG.info("Uploading entry point directory");
                         return WriterData.createEmpty(owner.publicKeyHash, writerPair, network.dhtClient)
@@ -900,7 +900,7 @@ public class UserContext {
                                     network,
                                     crypto,
                                     x -> {},
-                                    home.generateChildLocationsFromSize(serialized.size(), crypto.random)))
+                                    crypto.random.randomBytes(32)))
                     .thenApply(x -> true);
         });
     }
@@ -1284,7 +1284,7 @@ public class UserContext {
                     return getUserRoot().thenCompose(home ->
                             home.uploadFileSection(filename, reader, true, offset,
                                     offset + data.length, base, true, network, crypto, x -> {},
-                                    home.generateChildLocations(1, crypto.random)));
+                                    crypto.random.randomBytes(32)));
                 });
     }
 
@@ -1589,7 +1589,7 @@ public class UserContext {
                 LOG.info("Posting the feedback!");
                 byte[] feedbackBytes = feedback.getBytes();
                 return feedbackWrapper.uploadOrOverwriteFile(filename, AsyncReader.build(feedbackBytes), feedbackBytes.length,
-                        network, crypto, x -> {}, feedbackWrapper.generateChildLocationsFromSize(feedbackBytes.length, crypto.random));
+                        network, crypto, x -> {}, crypto.random.randomBytes(32));
             }
             )
             .thenCompose(x -> shareReadAccessWith(path.resolve(filename), Collections.singleton(PEERGOS_USERNAME)));

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -61,7 +61,7 @@ public class CapabilityStore {
                     long startIndex = capStore.map(f -> f.getSize()).orElse(0L);
                     return sharedDir.uploadFileSection(capStoreFilename, newCapability, false,
                             startIndex, startIndex + serializedCapability.length, Optional.empty(), true,
-                            network, crypto, x -> {}, sharedDir.generateChildLocations(1, crypto.random));
+                            network, crypto, x -> {}, crypto.random.randomBytes(32));
                 });
     }
 
@@ -351,7 +351,7 @@ public class CapabilityStore {
         return getCapabilityCacheDir(homeDirSupplier, network, crypto)
                 .thenCompose(cacheDir -> cacheDir.uploadOrOverwriteFile(friendName + capabilityType, dataReader,
                         (long) data.length, network, crypto, x-> {},
-                        cacheDir.generateChildLocationsFromSize(data.length, crypto.random))
+                        crypto.random.randomBytes(32))
                         .thenApply(x -> capabilitiesFromUser));
     }
 

--- a/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
+++ b/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
@@ -3,6 +3,7 @@ package peergos.shared.user.fs;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.user.*;
@@ -32,24 +33,27 @@ public class EncryptedChunkRetriever implements FileRetriever {
     @Override
     public CompletableFuture<AsyncReader> getFile(WriterData version,
                                                   NetworkAccess network,
-                                                  SafeRandom random,
+                                                  Crypto crypto,
                                                   AbsoluteCapability ourCap,
+                                                  Optional<byte[]> streamSecret,
                                                   long fileSize,
                                                   MaybeMultihash ourExistingHash,
                                                   ProgressConsumer<Long> monitor) {
-        return getChunk(version, network, random, 0, fileSize, ourCap, ourExistingHash, monitor)
+        return getChunk(version, network, crypto, 0, fileSize, ourCap, streamSecret, ourExistingHash, monitor)
                 .thenApply(chunk -> {
                     Location nextChunkPointer = ourCap.withMapKey(nextChunkLabel).getLocation();
                     return new LazyInputStreamCombiner(version, 0,
-                            chunk.get().chunk.data(), nextChunkPointer,
-                            chunk.get().chunk.data(), nextChunkPointer,
-                            network, random, ourCap.rBaseKey, fileSize, monitor);
+                            chunk.get().chunk.data(), ourCap.getMapKey(), nextChunkPointer,
+                            chunk.get().chunk.data(), ourCap.getMapKey(), streamSecret, nextChunkPointer,
+                            network, crypto, ourCap.rBaseKey, fileSize, monitor);
                 });
     }
 
     public CompletableFuture<Optional<byte[]>> getMapLabelAt(WriterData version,
                                                              AbsoluteCapability startCap,
+                                                             Optional<byte[]> streamSecret,
                                                              long offset,
+                                                             Hasher hasher,
                                                              NetworkAccess network) {
         if (offset < Chunk.MAX_SIZE)
             return CompletableFuture.completedFuture(Optional.of(startCap.getMapKey()));
@@ -57,18 +61,20 @@ public class EncryptedChunkRetriever implements FileRetriever {
             return CompletableFuture.completedFuture(Optional.of(nextChunkLabel)); // chunk at this location hasn't been written yet, only referenced by previous chunk
         return network.getMetadata(version, startCap.withMapKey(nextChunkLabel))
                 .thenCompose(meta -> meta.isPresent() ?
-                        meta.get().retriever(startCap.rBaseKey).getMapLabelAt(version,
-                                startCap.withMapKey(nextChunkLabel), offset - Chunk.MAX_SIZE, network) :
+                        meta.get().retriever(startCap.rBaseKey, streamSecret, nextChunkLabel, hasher)
+                                .getMapLabelAt(version, startCap.withMapKey(nextChunkLabel), streamSecret,
+                                offset - Chunk.MAX_SIZE, hasher, network) :
                         CompletableFuture.completedFuture(Optional.empty())
                 );
     }
 
     public CompletableFuture<Optional<LocatedChunk>> getChunk(WriterData version,
                                                               NetworkAccess network,
-                                                              SafeRandom random,
+                                                              Crypto crypto,
                                                               long startIndex,
                                                               long truncateTo,
                                                               AbsoluteCapability ourCap,
+                                                              Optional<byte[]> streamSecret,
                                                               MaybeMultihash ourExistingHash,
                                                               ProgressConsumer<Long> monitor) {
         if (startIndex >= Chunk.MAX_SIZE) {
@@ -76,10 +82,10 @@ public class EncryptedChunkRetriever implements FileRetriever {
             return network.getMetadata(version, nextChunkCap)
                     .thenCompose(meta -> {
                         if (meta.isPresent())
-                            return meta.get().retriever(ourCap.rBaseKey)
-                                    .getChunk(version, network, random, startIndex - Chunk.MAX_SIZE,
+                            return meta.get().retriever(ourCap.rBaseKey, streamSecret, nextChunkLabel, crypto.hasher)
+                                    .getChunk(version, network, crypto, startIndex - Chunk.MAX_SIZE,
                                             truncateTo - Chunk.MAX_SIZE,
-                                            nextChunkCap, meta.get().committedHash(), l -> {});
+                                            nextChunkCap, streamSecret, meta.get().committedHash(), l -> {});
                         Chunk newEmptyChunk = new Chunk(new byte[0], dataKey, nextChunkLabel, dataKey.createNonce());
                         LocatedChunk withLocation = new LocatedChunk(nextChunkCap.getLocation(),
                                 MaybeMultihash.empty(), newEmptyChunk);

--- a/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
+++ b/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
@@ -59,6 +59,10 @@ public class EncryptedChunkRetriever implements FileRetriever {
             return CompletableFuture.completedFuture(Optional.of(startCap.getMapKey()));
         if (offset < 2*Chunk.MAX_SIZE)
             return CompletableFuture.completedFuture(Optional.of(nextChunkLabel)); // chunk at this location hasn't been written yet, only referenced by previous chunk
+        if (streamSecret.isPresent()) {
+            byte[] mapKey = FileProperties.calculateMapKey(streamSecret.get(), startCap.getMapKey(), offset, hasher);
+            return CompletableFuture.completedFuture(Optional.of(mapKey));
+        }
         return network.getMetadata(version, startCap.withMapKey(nextChunkLabel))
                 .thenCompose(meta -> meta.isPresent() ?
                         meta.get().retriever(startCap.rBaseKey, streamSecret, nextChunkLabel, hasher)

--- a/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
+++ b/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
@@ -43,7 +43,7 @@ public class EncryptedChunkRetriever implements FileRetriever {
                 .thenApply(chunk -> {
                     Location nextChunkPointer = ourCap.withMapKey(nextChunkLabel).getLocation();
                     return new LazyInputStreamCombiner(version, 0,
-                            chunk.get().chunk.data(), ourCap.getMapKey(), nextChunkPointer,
+                            chunk.get().chunk.data(), nextChunkPointer,
                             chunk.get().chunk.data(), ourCap.getMapKey(), streamSecret, nextChunkPointer,
                             network, crypto, ourCap.rBaseKey, fileSize, monitor);
                 });

--- a/src/peergos/shared/user/fs/FileProperties.java
+++ b/src/peergos/shared/user/fs/FileProperties.java
@@ -133,6 +133,10 @@ public class FileProperties implements Cborable {
         return new FileProperties(name, isDirectory, mimeType, size, modified, isHidden, thumbnail, streamSecret);
     }
 
+    public FileProperties withNewStreamSecret(byte[] streamSecret) {
+        return new FileProperties(name, isDirectory, mimeType, size, modified, isHidden, thumbnail, Optional.of(streamSecret));
+    }
+
     public String getType() {
         if (isDirectory)
             return "dir";

--- a/src/peergos/shared/user/fs/FileRetriever.java
+++ b/src/peergos/shared/user/fs/FileRetriever.java
@@ -2,6 +2,7 @@ package peergos.shared.user.fs;
 
 import peergos.shared.*;
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.user.*;
@@ -14,23 +15,27 @@ public interface FileRetriever {
 
     CompletableFuture<AsyncReader> getFile(WriterData version,
                                            NetworkAccess network,
-                                           SafeRandom random,
+                                           Crypto crypto,
                                            AbsoluteCapability ourCap,
+                                           Optional<byte[]> streamSecret,
                                            long fileSize,
                                            MaybeMultihash ourExistingHash,
                                            ProgressConsumer<Long> monitor);
 
     CompletableFuture<Optional<byte[]>> getMapLabelAt(WriterData version,
                                                       AbsoluteCapability startCap,
+                                                      Optional<byte[]> streamSecret,
                                                       long offset,
+                                                      Hasher hasher,
                                                       NetworkAccess network);
 
     CompletableFuture<Optional<LocatedChunk>> getChunk(WriterData version,
                                                        NetworkAccess network,
-                                                       SafeRandom random,
+                                                       Crypto crypto,
                                                        long startIndex,
                                                        long truncateTo,
                                                        AbsoluteCapability ourCap,
+                                                       Optional<byte[]> streamSecret,
                                                        MaybeMultihash ourExistingHash,
                                                        ProgressConsumer<Long> monitor);
 }

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -136,7 +136,8 @@ public class FileUploader implements AutoCloseable {
             throw new IllegalStateException("Trying to write a chunk to the wrong signing key space!");
         RelativeCapability nextChunk = RelativeCapability.buildSubsequentChunk(nextChunkLocation.getMapKey(), baseKey);
         Pair<CryptreeNode, List<FragmentWithHash>> file = CryptreeNode.createFile(chunk.existingHash, baseKey,
-                chunk.chunk.key(), props, chunk.chunk.data(), parentLocation, parentparentKey, nextChunk, hasher);
+                chunk.chunk.key(), props, chunk.chunk.data(), parentLocation, parentparentKey, nextChunk,
+                hasher, network.isJavascript());
 
         CryptreeNode metadata = file.left.withWriterLink(baseKey, writerLink);
 

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -374,7 +374,7 @@ public class CryptreeNode implements Cborable {
     }
 
     private static Pair<FragmentedPaddedCipherText, List<FragmentWithHash>> buildChildren(ChildrenLinks children, SymmetricKey rBaseKey, Hasher hasher) {
-        return FragmentedPaddedCipherText.build(rBaseKey, children, MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, hasher);
+        return FragmentedPaddedCipherText.build(rBaseKey, children, MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, hasher, false);
     }
 
     public <T> CompletableFuture<T> getLinkedData(SymmetricKey baseOrDataKey,
@@ -799,10 +799,11 @@ public class CryptreeNode implements Cborable {
                                                                         Location parentLocation,
                                                                         SymmetricKey parentparentKey,
                                                                         RelativeCapability nextChunk,
-                                                                        Hasher hasher) {
+                                                                        Hasher hasher,
+                                                                        boolean allowArrayCache) {
         Pair<FragmentedPaddedCipherText, List<FragmentWithHash>> linksAndData =
                 FragmentedPaddedCipherText.build(dataKey, new CborObject.CborByteArray(chunkData),
-                        MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, hasher);
+                        MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, hasher, allowArrayCache);
         RelativeCapability toParent = new RelativeCapability(Optional.empty(), parentLocation.getMapKey(),
                 parentparentKey, Optional.empty());
         CryptreeNode cryptree = createFile(existingHash, Optional.empty(), parentKey, dataKey, props,
@@ -860,7 +861,7 @@ public class CryptreeNode implements Cborable {
         PaddedCipherText encryptedBaseBlock = PaddedCipherText.build(rBaseKey, fromBase, BASE_BLOCK_PADDING_BLOCKSIZE);
         PaddedCipherText encryptedParentBlock = PaddedCipherText.build(parentKey, fromParent, META_DATA_PADDING_BLOCKSIZE);
         Pair<FragmentedPaddedCipherText, List<FragmentWithHash>> linksAndData =
-                FragmentedPaddedCipherText.build(rBaseKey, children, MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, hasher);
+                FragmentedPaddedCipherText.build(rBaseKey, children, MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, hasher, false);
         CryptreeNode metadata = new CryptreeNode(lastCommittedHash, true, encryptedBaseBlock, linksAndData.left, encryptedParentBlock);
         return new DirAndChildren(metadata, linksAndData.right);
     }

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -576,7 +576,7 @@ public class CryptreeNode implements Cborable {
         WritableAbsoluteCapability childCap = us.withBaseKey(dirReadKey).withBaseWriteKey(dirWriteKey).withMapKey(dirMapKey);
         DirAndChildren child = CryptreeNode.createDir(MaybeMultihash.empty(), dirReadKey, dirWriteKey, Optional.empty(),
                 new FileProperties(name, true, "", 0, LocalDateTime.now(), isSystemFolder,
-                        Optional.empty()), Optional.of(ourCap), SymmetricKey.random(), nextChunk, crypto.hasher);
+                        Optional.empty(), Optional.empty()), Optional.of(ourCap), SymmetricKey.random(), nextChunk, crypto.hasher);
 
         SymmetricLink toChildWriteKey = SymmetricLink.fromPair(us.wBaseKey.get(), dirWriteKey);
         // Use two transactions to not expose the child linkage

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -509,7 +509,10 @@ public class CryptreeNode implements Cborable {
                                 return CompletableFuture.completedFuture(updated);
                             return mOpt.get().cleanAndCommit(updated, committer, nextCap, newNextCap,
                                     streamSecret, updatedFileProperties.streamSecret, writer, newDataKey,
-                                    parentLocation, parentParentKey, network, crypto);
+                                    parentLocation, parentParentKey, network, crypto)
+                                    .thenCompose(snapshot ->
+                                            IpfsTransaction.call(cap.owner, tid -> network.deleteChunk(snapshot, committer, mOpt.get(),
+                                            cap.owner, nextCap.getMapKey(), writer, tid), network.dhtClient));
                         }));
     }
 

--- a/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
+++ b/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
@@ -43,7 +43,7 @@ public class TransactionServiceImpl implements TransactionService {
         return transactionDirUpdater.updated(version).thenCompose(dir ->
                 dir.uploadFileSection(version, committer, transaction.name(), asyncReader, false,
                         0, data.length, Optional.empty(), false, networkAccess,
-                        crypto, VOID_PROGRESS, dir.generateChildLocations(1, crypto.random)));
+                        crypto, VOID_PROGRESS, crypto.random.randomBytes(32)));
     }
 
     @Override


### PR DESCRIPTION
This PR implement a new scheme for files where the locations of subsequent chunks are deterministically calculated by:

next = hash(secret + current)
The secret is only stored in the initial chunk.

This means that we can seek to arbitrary offsets in a file with O(1) IO operations. Currently seeking in the web ui is super slow ~1s/10MiB. So seeking 1GiB in would take around 1.5 minutes!

There are several things to be careful of here:
1) to avoid downgrade attacks we have to make subsequent chunk calculations also use the hash calculation and not the pointer in the cryptree node
2) we need to rotate the stream secret when we rotate the base key (or the file key)
3) directories cannot use the same scheme, otherwise the size of the dir would be exposed to anyone with a read cap to any descendant of the dir

Obviously this is a fundamental change, so I want at least 2 reviews before merging.

I will also try blake2b instead of sha256, and use which ever is faster in the browser. 

There are a few minor changes to the JS api. FileWrapper.hasChild mainly I think.