### PR TITLE
First attempt at a transaction aware GC for ipfs

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -562,7 +562,7 @@ public class Main {
             SigningPrivateKeyAndPublicHash pkiSigner = new SigningPrivateKeyAndPublicHash(pkiPublicHash, pkiSecretKey);
             if (! currentPkiRoot.isPresent())
                 currentPkiRoot = IpfsTransaction.call(peergosIdentity,
-                        tid -> WriterData.createEmpty(peergosIdentity, pkiSigner, dht).join()
+                        tid -> WriterData.createEmpty(peergosIdentity, pkiSigner, dht, tid).join()
                                 .commit(peergosIdentity, pkiSigner, MaybeMultihash.empty(), mutable, dht, tid)
                                 .thenApply(version -> version.get(pkiSigner).hash), dht).join();
 

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -57,6 +57,11 @@ public class FileContentAddressedStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signatures,

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -17,6 +17,7 @@ public class GarbageCollector implements ContentAddressedStorage {
 
     private final ContentAddressedStorage target;
     private final long gcPeriodMillis;
+    // This lock is used to make new transactions block until a pending GC completes
     private final Object gcLock = new Object();
     private final ConcurrentHashMap<PublicKeyHash, AtomicInteger> openTransactions = new ConcurrentHashMap<>();
 
@@ -43,9 +44,10 @@ public class GarbageCollector implements ContentAddressedStorage {
                 synchronized (gcLock) {
                     long start = System.nanoTime();
                     while (openTransactions() > 0) {
-                        if ((System.nanoTime() - start) / 1000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
-                            openTransactions.clear();
-                        Thread.sleep(MAX_WAIT_FOR_TRANSACTION_MILLIS / 20);
+//                        if ((System.nanoTime() - start) / 1000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
+//                            openTransactions.clear();
+                        System.out.println("GC sleeping, " + openTransactions() + " open transactions");
+                        Thread.sleep(100);
                     }
                     long ready = System.nanoTime();
                     target.gc().join();

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -1,0 +1,146 @@
+package peergos.server.storage;
+
+import peergos.server.util.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.storage.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.logging.*;
+
+public class GarbageCollector implements ContentAddressedStorage {
+
+    private static final long MAX_WAIT_FOR_TRANSACTION_MILLIS = 10_000;
+
+    private final ContentAddressedStorage target;
+    private final long gcPeriodMillis;
+    private final Object gcLock = new Object();
+    private final ConcurrentHashMap<PublicKeyHash, AtomicInteger> openTransactions = new ConcurrentHashMap<>();
+
+    public GarbageCollector(ContentAddressedStorage target, long gcPeriodMillis) {
+        this.target = target;
+        this.gcPeriodMillis = gcPeriodMillis;
+    }
+
+    public void start() {
+        new Thread(this::run).start();
+    }
+
+    private int openTransactions() {
+        int res = 0;
+        for (AtomicInteger open : openTransactions.values()) {
+            res += Math.max(0, open.get());
+        }
+        return res;
+    }
+
+    public void run() {
+        while (true) {
+            try {
+                synchronized (gcLock) {
+                    long start = System.nanoTime();
+                    while (openTransactions() > 0) {
+                        if ((System.nanoTime() - start) / 1000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
+                            openTransactions.clear();
+                        Thread.sleep(MAX_WAIT_FOR_TRANSACTION_MILLIS / 20);
+                    }
+                    long ready = System.nanoTime();
+                    target.gc().join();
+                    long done = System.nanoTime();
+                    Logging.LOG().info(String.format("GC took: %d ms waiting to start, %d ms in actual GC",
+                            (ready - start)/1000000, (done - ready)/1000000));
+                }
+                Thread.sleep(gcPeriodMillis);
+            } catch (Throwable t) {
+                Logging.LOG().log(Level.WARNING, t.getMessage(), t);
+            }
+        }
+    }
+
+    @Override
+    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
+        synchronized (gcLock) {
+            openTransactions.putIfAbsent(owner, new AtomicInteger(0));
+            openTransactions.get(owner).incrementAndGet();
+        }
+        return target.startTransaction(owner);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
+        AtomicInteger openTransactionsForUser = openTransactions.get(owner);
+        if (openTransactionsForUser != null)
+            openTransactionsForUser.decrementAndGet();
+        return target.closeTransaction(owner, tid);
+    }
+
+    @Override
+    public CompletableFuture<Multihash> id() {
+        return target.id();
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
+                                                  PublicKeyHash writer,
+                                                  List<byte[]> signatures,
+                                                  List<byte[]> blocks,
+                                                  TransactionId tid) {
+        return target.put(owner, writer, signatures, blocks, tid);
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(Multihash hash) {
+        return target.get(hash);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash owner,
+                                                     PublicKeyHash writer,
+                                                     List<byte[]> signatures,
+                                                     List<byte[]> blocks,
+                                                     TransactionId tid) {
+        return target.putRaw(owner, writer, signatures, blocks, tid);
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Multihash hash) {
+        return target.getRaw(hash);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> pinUpdate(PublicKeyHash owner, Multihash existing, Multihash updated) {
+        return target.pinUpdate(owner, existing, updated);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursivePin(PublicKeyHash owner, Multihash hash) {
+        return target.recursivePin(owner, hash);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursiveUnpin(PublicKeyHash owner, Multihash hash) {
+        return target.recursiveUnpin(owner, hash);
+    }
+
+    /** This method is ignored because we decide when we are calling gc
+     *
+     * @return
+     */
+    @Override
+    public CompletableFuture<Boolean> gc() {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> getLinks(Multihash root) {
+        return target.getLinks(root);
+    }
+
+    @Override
+    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
+        return target.getSize(block);
+    }
+}

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -46,14 +46,14 @@ public class GarbageCollector implements ContentAddressedStorage {
                     while (openTransactions() > 0) {
                         if ((System.nanoTime() - start) / 1_000_000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
                             openTransactions.clear();
-                        System.out.println("GC sleeping, " + openTransactions() + " open transactions");
+                        System.out.println("GC sleeping waiting for " + openTransactions() + " open transactions..");
                         Thread.sleep(100);
                     }
                     long ready = System.nanoTime();
                     target.gc().join();
                     long done = System.nanoTime();
                     Logging.LOG().info(String.format("GC took: %d ms waiting to start, %d ms in actual GC",
-                            (ready - start)/1000000, (done - ready)/1000000));
+                            (ready - start)/1_000_000, (done - ready)/1_000_000));
                 }
                 Thread.sleep(gcPeriodMillis);
             } catch (Throwable t) {

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -44,8 +44,8 @@ public class GarbageCollector implements ContentAddressedStorage {
                 synchronized (gcLock) {
                     long start = System.nanoTime();
                     while (openTransactions() > 0) {
-//                        if ((System.nanoTime() - start) / 1000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
-//                            openTransactions.clear();
+                        if ((System.nanoTime() - start) / 1_000_000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
+                            openTransactions.clear();
                         System.out.println("GC sleeping, " + openTransactions() + " open transactions");
                         Thread.sleep(100);
                     }

--- a/src/peergos/server/storage/IpfsDHT.java
+++ b/src/peergos/server/storage/IpfsDHT.java
@@ -56,6 +56,11 @@ public class IpfsDHT implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signatures,

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -34,6 +34,11 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return modifications.gc();
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signatures,

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -36,6 +36,11 @@ public class RAMStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return CompletableFuture.completedFuture(true);
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signatures,

--- a/src/peergos/server/tests/IpfsUserTests.java
+++ b/src/peergos/server/tests/IpfsUserTests.java
@@ -14,6 +14,8 @@ public class IpfsUserTests extends UserTests {
 
     private static Args args = buildArgs()
             .with("useIPFS", "true")
+            .with("enable-gc", "true")
+            .with("gc.period.millis", "10000")
             .with(IpfsWrapper.IPFS_BOOTSTRAP_NODES, ""); // no bootstrapping
 
     public IpfsUserTests(Args args) {

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -839,7 +839,8 @@ public class MultiUserTests {
         String friendsPathToFile = u1.username + "/" + filename;
         Optional<FileWrapper> priorUnsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         AbsoluteCapability priorPointer = priorUnsharedView.get().getPointer().capability;
-        CryptreeNode priorFileAccess = network.getMetadata(priorPointer).get().get();
+        CommittedWriterData cwd = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
+        CryptreeNode priorFileAccess = network.getMetadata(cwd.props, priorPointer).get().get();
         SymmetricKey priorMetaKey = priorFileAccess.getParentKey(priorPointer.rBaseKey);
 
         // unshare with a single user
@@ -853,7 +854,8 @@ public class MultiUserTests {
         Optional<FileWrapper> unsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         String friendsNewPathToFile = u1.username + "/" + newname;
         Optional<FileWrapper> unsharedView2 = userToUnshareWith.getByPath(friendsNewPathToFile).get();
-        CryptreeNode fileAccess = network.getMetadata(priorPointer).get().get();
+        CommittedWriterData cwd2 = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
+        CryptreeNode fileAccess = network.getMetadata(cwd2.props, priorPointer).get().get();
         // check we are trying to decrypt the correct thing
         PaddedCipherText priorPropsCipherText = (PaddedCipherText) ((CborObject.CborMap) priorFileAccess.toCbor()).get("p");
         CborObject.CborMap priorFromParent = priorPropsCipherText.decrypt(priorMetaKey, x -> (CborObject.CborMap)x);

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -425,25 +425,6 @@ public class NetworkAccess {
                         .flatMap(g -> g.stream()).collect(Collectors.toList()));
     }
 
-    public CompletableFuture<Multihash> uploadChunk(CryptreeNode metadata,
-                                                    PublicKeyHash owner,
-                                                    byte[] mapKey,
-                                                    SigningPrivateKeyAndPublicHash writer,
-                                                    TransactionId tid) {
-        try {
-            System.out.println("Uploading chunk: " + (metadata.isDirectory() ? "dir" : "file")
-                    + " at " + ArrayOps.bytesToHex(mapKey)
-                    + " with " + metadata.toCbor().links().size() + " fragments");
-            byte[] metaBlob = metadata.serialize();
-            return dhtClient.put(owner, writer.publicKeyHash, writer.secret.signatureOnly(metaBlob), metaBlob, tid)
-                    .thenCompose(blobHash -> tree.put(owner, writer, mapKey, metadata.committedHash(), blobHash)
-                            .thenApply(res -> blobHash));
-        } catch (Exception e) {
-            LOG.severe(e.getMessage());
-            throw new RuntimeException(e);
-        }
-    }
-
     public CompletableFuture<Snapshot> uploadChunk(Snapshot current,
                                                    Committer committer,
                                                    CryptreeNode metadata,

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -254,32 +254,6 @@ public class NetworkAccess {
                 .thenApply(res -> res.isEmpty() ? Optional.empty() : Optional.of(res.get(0)));
     }
 
-    public CompletableFuture<List<RetrievedCapability>> retrieveAllMetadata(List<AbsoluteCapability> links) {
-        List<CompletableFuture<Optional<RetrievedCapability>>> all = links.stream()
-                .map(link -> {
-                    PublicKeyHash owner = link.owner;
-                    PublicKeyHash writer = link.writer;
-                    byte[] mapKey = link.getMapKey();
-                    return tree.get(owner, writer, mapKey)
-                            .thenCompose(key -> {
-                                if (key.isPresent())
-                                    return dhtClient.get(key.get())
-                                            .thenApply(dataOpt ->  dataOpt
-                                                    .map(cbor -> new RetrievedCapability(
-                                                            link,
-                                                            CryptreeNode.fromCbor(cbor, link.rBaseKey, key.get()))));
-                                LOG.severe("Couldn't download link at: " + new Location(owner, writer, mapKey));
-                                Optional<RetrievedCapability> result = Optional.empty();
-                                return CompletableFuture.completedFuture(result);
-                            });
-                }).collect(Collectors.toList());
-
-        return Futures.combineAll(all).thenApply(optSet -> optSet.stream()
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(Collectors.toList()));
-    }
-
     public CompletableFuture<List<RetrievedCapability>> retrieveAllMetadata(List<AbsoluteCapability> links, Snapshot current) {
         List<CompletableFuture<Optional<RetrievedCapability>>> all = links.stream()
                 .map(link -> {
@@ -488,15 +462,6 @@ public class NetworkAccess {
                                         tid -> tree.remove(version.props, owner, writer, mapKey, valueHash, tid)
                                                 .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid)),
                                         dhtClient));
-    }
-
-    public CompletableFuture<Optional<CryptreeNode>> getMetadata(AbsoluteCapability cap) {
-        return tree.get(cap.owner, cap.writer, cap.getMapKey()).thenCompose(blobHash -> {
-            if (!blobHash.isPresent())
-                return CompletableFuture.completedFuture(Optional.empty());
-            return dhtClient.get(blobHash.get())
-                    .thenApply(rawOpt -> rawOpt.map(cbor -> CryptreeNode.fromCbor(cbor, cap.rBaseKey, blobHash.get())));
-        });
     }
 
     public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -40,6 +40,11 @@ public class CachingStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return target.gc();
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signatures,

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -134,6 +134,12 @@ public interface ContentAddressedStorage {
      */
     CompletableFuture<List<Multihash>> recursiveUnpin(PublicKeyHash owner, Multihash hash);
 
+    /** Run a garbage collection on the ipfs block store. This is only callable internally to a Peergos server.
+     *
+     * @return true
+     */
+    CompletableFuture<Boolean> gc();
+
     /**
      * Get all the merkle-links referenced directly from this object
      * @param root The hash of the object whose links we want
@@ -256,6 +262,7 @@ public interface ContentAddressedStorage {
         public static final String ID = "id";
         public static final String TRANSACTION_START = "transaction/start";
         public static final String TRANSACTION_CLOSE = "transaction/close";
+        public static final String GC = "repo/gc";
         public static final String BLOCK_PUT = "block/put";
         public static final String BLOCK_GET = "block/get";
         public static final String BLOCK_STAT = "block/stat";
@@ -308,6 +315,12 @@ public interface ContentAddressedStorage {
                 return CompletableFuture.completedFuture(true);
             return poster.get(apiPrefix + TRANSACTION_CLOSE + "?arg=" + tid.toString() + "&owner=" + encode(owner.toString()))
                     .thenApply(raw -> new String(raw).equals("1"));
+        }
+
+        @Override
+        public CompletableFuture<Boolean> gc() {
+            return poster.get(apiPrefix + GC)
+                    .thenApply(raw -> true);
         }
 
         @Override
@@ -437,6 +450,11 @@ public interface ContentAddressedStorage {
             return redirectCall(owner,
                     () -> local.closeTransaction(owner, tid),
                     target -> p2p.closeTransaction(target, owner, tid));
+        }
+
+        @Override
+        public CompletableFuture<Boolean> gc() {
+            return CompletableFuture.completedFuture(true);
         }
 
         @Override

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -56,6 +56,11 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return source.gc();
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signatures,

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -35,6 +35,11 @@ public class WriteFilter implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Boolean> gc() {
+        return dht.gc();
+    }
+
+    @Override
     public CompletableFuture<Optional<CborObject>> get(Multihash object) {
         return dht.get(object);
     }

--- a/src/peergos/shared/user/MutableTree.java
+++ b/src/peergos/shared/user/MutableTree.java
@@ -31,16 +31,6 @@ public interface MutableTree {
 
     /**
      *
-     * @param owner
-     * @param writer
-     * @param mapKey
-     * @return  the value stored under mapKey for sharingKey
-     * @throws IOException
-     */
-    CompletableFuture<MaybeMultihash> get(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey);
-
-    /**
-     *
      * @param base The WriterData at the current mutable pointer for the writer
      * @param owner
      * @param writer

--- a/src/peergos/shared/user/MutableTree.java
+++ b/src/peergos/shared/user/MutableTree.java
@@ -13,21 +13,6 @@ public interface MutableTree {
 
     /**
      *
-     * @param owner
-     * @param sharingKey
-     * @param mapKey
-     * @param value
-     * @return The committed result of setting the value in this tree
-     * @throws IOException
-     */
-    CompletableFuture<CommittedWriterData> put(PublicKeyHash owner,
-                                               SigningPrivateKeyAndPublicHash sharingKey,
-                                               byte[] mapKey,
-                                               MaybeMultihash existing,
-                                               Multihash value);
-
-    /**
-     *
      * @param base
      * @param owner
      * @param sharingKey

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -51,12 +51,6 @@ public class MutableTreeImpl implements MutableTree {
     }
 
     @Override
-    public CompletableFuture<MaybeMultihash> get(PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey) {
-        return synchronizer.getValue(owner, writer)
-                .thenCompose(version -> get(version.get(writer).props, owner, writer, mapKey));
-    }
-
-    @Override
     public CompletableFuture<MaybeMultihash> get(WriterData base, PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey) {
         if (! base.tree.isPresent())
             throw new IllegalStateException("Tree root not present for " + writer);

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -34,17 +34,6 @@ public class MutableTreeImpl implements MutableTree {
     }
 
     @Override
-    public CompletableFuture<CommittedWriterData> put(PublicKeyHash owner,
-                                                      SigningPrivateKeyAndPublicHash writer,
-                                                      byte[] mapKey,
-                                                      MaybeMultihash existing,
-                                                      Multihash value) {
-        return synchronizer.applyUpdate(owner, writer,
-                (wd, tid) -> put(wd, owner, writer, mapKey, existing, value, tid))
-                .thenApply(version -> version.get(writer));
-    }
-
-    @Override
     public CompletableFuture<WriterData> put(WriterData base,
                                              PublicKeyHash owner,
                                              SigningPrivateKeyAndPublicHash writer,

--- a/src/peergos/shared/user/OwnedKeyChamp.java
+++ b/src/peergos/shared/user/OwnedKeyChamp.java
@@ -27,11 +27,11 @@ public class OwnedKeyChamp {
 
     public static CompletableFuture<Multihash> createEmpty(PublicKeyHash owner,
                                                            SigningPrivateKeyAndPublicHash writer,
-                                                           ContentAddressedStorage ipfs) {
+                                                           ContentAddressedStorage ipfs,
+                                                           TransactionId tid) {
         Champ newRoot = Champ.empty();
         byte[] raw = newRoot.serialize();
-        return IpfsTransaction.call(owner,
-                tid -> ipfs.put(owner, writer.publicKeyHash, writer.secret.signatureOnly(raw), raw, tid), ipfs);
+        return ipfs.put(owner, writer.publicKeyHash, writer.secret.signatureOnly(raw), raw, tid);
     }
 
     public static CompletableFuture<OwnedKeyChamp> build(Multihash root, ContentAddressedStorage ipfs) {

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -146,14 +146,6 @@ public class CryptreeNode implements Cborable {
             this.childData = childData;
         }
 
-        public CompletableFuture<CryptreeNode> commit(WritableAbsoluteCapability us,
-                                                      Optional<SigningPrivateKeyAndPublicHash> entryWriter,
-                                                      NetworkAccess network,
-                                                      TransactionId tid) {
-            return commitChildrenLinks(us, entryWriter, network, tid)
-                    .thenCompose(hashes -> dir.commit(us, entryWriter, network, tid));
-        }
-
         public CompletableFuture<Snapshot> commit(Snapshot current,
                                                   Committer committer,
                                                   WritableAbsoluteCapability us,
@@ -689,14 +681,6 @@ public class CryptreeNode implements Cborable {
                             .commit(current, committer, ourPointer, entryWriter, network, tid),
                     network.dhtClient);
         });
-    }
-
-    public CompletableFuture<CryptreeNode> commit(WritableAbsoluteCapability us,
-                                                  Optional<SigningPrivateKeyAndPublicHash> entryWriter,
-                                                  NetworkAccess network,
-                                                  TransactionId tid) {
-        return network.uploadChunk(this, us.owner, us.getMapKey(), getSigner(us.rBaseKey, us.wBaseKey.get(), entryWriter), tid)
-                .thenApply(this::withHash);
     }
 
     public CompletableFuture<Snapshot> commit(Snapshot current,


### PR DESCRIPTION
This implements a transaction aware GC. 

We periodically queue a GC, then wait for all open transactions to complete or time out, before actually doing the gc, and forcing subsequent transaction opens to wait until the gc is completed. 

This can't be called remotely, despite being in ContentAddressedStorage. I'm open to any nicer ways you can think of to implement this without adding a method to CAS. 