### PR TITLE
[cli] ProgressBar is now  thread-safe

### DIFF
--- a/src/peergos/server/simulation/FileSystem.java
+++ b/src/peergos/server/simulation/FileSystem.java
@@ -24,10 +24,10 @@ public interface FileSystem {
      */
     String user();
 
-    byte[] read(Path path, BiConsumer<Long, Long> progressConsumer);
+    byte[] read(Path path, Consumer<Long> progressConsumer);
 
     default byte[] read(Path path) {
-        return read(path, (a,b) -> {});
+        return read(path, (a) -> {});
     }
 
     void write(Path path, byte[] data, Consumer<Long> progressConsumer);

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -35,10 +35,10 @@ public class PeergosFileSystemImpl implements FileSystem {
     }
 
     @Override
-    public byte[] read(Path path, BiConsumer<Long, Long> progressConsumer) {
+    public byte[] read(Path path, Consumer<Long> progressConsumer) {
         FileWrapper wrapper = getPath(path);
         long size = wrapper.getFileProperties().size;
-        ProgressConsumer<Long> monitor = (readBytes) -> progressConsumer.accept(readBytes, size);
+        ProgressConsumer<Long> monitor = (readBytes) -> progressConsumer.accept(readBytes);
         AsyncReader in = wrapper.getInputStream(userContext.network, userContext.crypto, size, monitor).join();
         return Serialize.readFully(in, size).join();
     }

--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -68,7 +68,7 @@ public class NativeFileSystemImpl implements FileSystem {
     }
 
     @Override
-    public byte[] read(Path path, BiConsumer<Long, Long> pc) {
+    public byte[] read(Path path, Consumer<Long> pc) {
         Path nativePath = virtualToNative(path);
         ensureCan(path, Permission.READ);
 


### PR DESCRIPTION
Since the progress-updater is called concurrently the progress-bar should be thread-safe - please check it carefully. 

This also simplifies the ProgressBar.

Technically ``animationPos``is not  guarded but I don't think it matters.