### PR TITLE
Fix copying of owned key proofs during password change

### DIFF
--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -49,7 +49,15 @@ public class MultiUserTests {
 
     public static void checkUserValidity(NetworkAccess network, String username) {
         PublicKeyHash identity = network.coreNode.getPublicKeyHash(username).join().get();
-        WriterData props = WriterData.getWriterData(identity, identity, network.mutable, network.dhtClient).join().props;
+        checkUserValidity(1, identity, identity, Collections.emptySet(), network);
+    }
+
+    public static void checkUserValidity(int maxClaims,
+                                         PublicKeyHash owner,
+                                         PublicKeyHash writer,
+                                         Set<PublicKeyHash> ancestors,
+                                         NetworkAccess network) {
+        WriterData props = WriterData.getWriterData(owner, writer, network.mutable, network.dhtClient).join().props;
         OwnedKeyChamp ownedChamp = props.getOwnedKeyChamp(network.dhtClient).join();
         Set<OwnerProof> empty = Collections.emptySet();
         Set<OwnerProof> claims = ownedChamp.applyToAllMappings(empty,
@@ -64,12 +72,21 @@ public class MultiUserTests {
         Set<PublicKeyHash> ownerKeys = pairs.stream()
                 .map(p -> p.left)
                 .collect(Collectors.toSet());
-        if (claims.size() != 1)
-            throw new IllegalStateException("More than 1 owned key on identity key pair for " + username);
-        if (ownerKeys.size() != 1)
-            throw new IllegalStateException("More than 1 owner key on identity key pair for " + username);
-        if (ownedKeys.contains(identity))
+        if (claims.size() > maxClaims)
+            throw new IllegalStateException("More than 1 owned key on identity key pair for " + writer);
+        if (! ownerKeys.isEmpty() && ownerKeys.size() != 1)
+            throw new IllegalStateException("More than 1 owner key on writer data for " + writer);
+        if (! ownerKeys.isEmpty() && ! ownerKeys.contains(writer))
+            throw new IllegalStateException("WriterData contains claims with wrong owner for " + writer);
+        if (ownedKeys.contains(writer))
             throw new IllegalStateException("Identity key pair owns itself!");
+        HashSet<PublicKeyHash> withCurrent = new HashSet<>(ancestors);
+        withCurrent.add(writer);
+        for (PublicKeyHash ownedKey : ownedKeys) {
+            if (! withCurrent.contains(ownedKey))
+                checkUserValidity(Integer.MAX_VALUE, owner, ownedKey, withCurrent, network);
+
+        }
     }
 
     private List<UserContext> getUserContexts(int size, List<String> passwords) {

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -58,6 +58,8 @@ public class MultiUserTests {
                                          Set<PublicKeyHash> ancestors,
                                          NetworkAccess network) {
         WriterData props = WriterData.getWriterData(owner, writer, network.mutable, network.dhtClient).join().props;
+        if (! props.ownedKeys.isPresent())
+            return;
         OwnedKeyChamp ownedChamp = props.getOwnedKeyChamp(network.dhtClient).join();
         Set<OwnerProof> empty = Collections.emptySet();
         Set<OwnerProof> claims = ownedChamp.applyToAllMappings(empty,

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -75,7 +75,7 @@ public class MultiUserTests {
                 .map(p -> p.left)
                 .collect(Collectors.toSet());
         if (claims.size() > maxClaims)
-            throw new IllegalStateException("More than 1 owned key on identity key pair for " + writer);
+            throw new IllegalStateException("Too many owned keys on identity key pair for " + writer);
         if (! ownerKeys.isEmpty() && ownerKeys.size() != 1)
             throw new IllegalStateException("More than 1 owner key on writer data for " + writer);
         if (! ownerKeys.isEmpty() && ! ownerKeys.contains(writer))

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -229,11 +229,14 @@ public abstract class UserTests {
         UserContext userContext = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         String newPassword = "newPassword";
         userContext.changePassword(password, newPassword).get();
+        MultiUserTests.checkUserValidity(network, username);
+
         UserContext changedPassword = PeergosNetworkUtils.ensureSignedUp(username, newPassword, network, crypto);
 
         // change it again
         String password3 = "pass3";
         changedPassword.changePassword(newPassword, password3).get();
+        MultiUserTests.checkUserValidity(network, username);
         PeergosNetworkUtils.ensureSignedUp(username, password3, network, crypto);
     }
 

--- a/src/peergos/shared/crypto/OwnerProof.java
+++ b/src/peergos/shared/crypto/OwnerProof.java
@@ -1,6 +1,5 @@
 package peergos.shared.crypto;
 
-import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -699,31 +699,38 @@ public class UserContext {
                                 ).thenCompose(newSignerHash -> {
                                     SigningPrivateKeyAndPublicHash newSigner =
                                             new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey);
-                                    // auth new key by adding to existing writer data first
-                                    OwnerProof proof = OwnerProof.build(newSigner, signer.publicKeyHash);
-                                    return writeSynchronizer.applyUpdate(signer.publicKeyHash, signer, (wd, tid) ->
-                                            wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient))
-                                            .thenCompose(version -> version.get(signer).props.changeKeys(signer,
-                                                    newSigner,
-                                                    updatedUser.getBoxingPair().publicBoxingKey,
-                                                    existingUser.getRoot(),
-                                                    updatedUser.getRoot(),
-                                                    newAlgorithm,
-                                                    network)).thenCompose(writerData -> {
-                                                SigningPrivateKeyAndPublicHash newUser =
-                                                        new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey);
-                                                return network.coreNode.getChain(username).thenCompose(existing -> {
-                                                    List<Multihash> storage = existing.get(existing.size() - 1).claim.storageProviders;
-                                                    List<UserPublicKeyLink> claimChain = UserPublicKeyLink.createChain(signer, newUser, username, expiry, storage);
-                                                    return network.coreNode.updateChain(username, claimChain)
-                                                            .thenCompose(updatedChain -> {
-                                                                if (!updatedChain)
-                                                                    throw new IllegalStateException("Couldn't register new public keys during password change!");
+                                    Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> ownedKeys = new HashMap<>();
+                                    return getUserRoot().thenCompose(homeDir -> {
+                                        // If we ever implement plausibly deniable dual (N) login this will need to include all the other keys
+                                        ownedKeys.put(homeDir.writer(), homeDir.signingPair());
 
-                                                                return UserContext.ensureSignedUp(username, newPassword, network, crypto);
-                                                            });
+                                        // auth new key by adding to existing writer data first
+                                        OwnerProof proof = OwnerProof.build(newSigner, signer.publicKeyHash);
+                                        return writeSynchronizer.applyUpdate(signer.publicKeyHash, signer, (wd, tid) ->
+                                                wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient))
+                                                .thenCompose(version -> version.get(signer).props.changeKeys(signer,
+                                                        newSigner,
+                                                        updatedUser.getBoxingPair().publicBoxingKey,
+                                                        existingUser.getRoot(),
+                                                        updatedUser.getRoot(),
+                                                        newAlgorithm,
+                                                        ownedKeys,
+                                                        network)).thenCompose(writerData -> {
+                                                    SigningPrivateKeyAndPublicHash newUser =
+                                                            new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey);
+                                                    return network.coreNode.getChain(username).thenCompose(existing -> {
+                                                        List<Multihash> storage = existing.get(existing.size() - 1).claim.storageProviders;
+                                                        List<UserPublicKeyLink> claimChain = UserPublicKeyLink.createChain(signer, newUser, username, expiry, storage);
+                                                        return network.coreNode.updateChain(username, claimChain)
+                                                                .thenCompose(updatedChain -> {
+                                                                    if (!updatedChain)
+                                                                        throw new IllegalStateException("Couldn't register new public keys during password change!");
+
+                                                                    return UserContext.ensureSignedUp(username, newPassword, network, crypto);
+                                                                });
+                                                    });
                                                 });
-                                            });
+                                    });
                                 });
                             });
                 });

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -703,6 +703,8 @@ public class UserContext {
                                     return getUserRoot().thenCompose(homeDir -> {
                                         // If we ever implement plausibly deniable dual (N) login this will need to include all the other keys
                                         ownedKeys.put(homeDir.writer(), homeDir.signingPair());
+                                        // Add any named owned key to lookup as well
+                                        // TODO need to get the pki keypair here is were are the 'peergos' user
 
                                         // auth new key by adding to existing writer data first
                                         OwnerProof proof = OwnerProof.build(newSigner, signer.publicKeyHash);

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -198,13 +198,18 @@ public class WriterData implements Cborable {
                             followRequestReceiver, tid
                     ).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner, network.dhtClient, tid)
                             .thenCompose(ownedRoot -> {
+                                Map<String, OwnerProof> newNamedOwnedKeys = namedOwnedKeys.entrySet()
+                                        .stream()
+                                        .collect(Collectors.toMap(e -> e.getKey(),
+                                                e -> OwnerProof.build(ownedKeys.get(e.getValue().ownedKey), signer.publicKeyHash)));
+
                                 // need to add all our owned keys back with the new owner, except for the new signer itself
                                 WriterData base = new WriterData(signer.publicKeyHash,
                                         Optional.of(newAlgorithm),
                                         publicData,
                                         Optional.of(new PublicKeyHash(boxerHash)),
                                         Optional.of(ownedRoot),
-                                        namedOwnedKeys,
+                                        newNamedOwnedKeys,
                                         newEntryPoints,
                                         tree);
                                 return getOwnedKeyChamp(network.dhtClient)

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -77,6 +77,10 @@ public class WriterData implements Cborable {
         return new WriterData(controller, generationAlgorithm, Optional.of(publicChampRoot), followRequestReceiver, ownedKeys, namedOwnedKeys, staticData, tree);
     }
 
+    public WriterData withOwnedRoot(Multihash ownedRoot) {
+        return new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver, Optional.of(ownedRoot), namedOwnedKeys, staticData, tree);
+    }
+
     public CompletableFuture<WriterData> addOwnedKey(PublicKeyHash owner,
                                                      SigningPrivateKeyAndPublicHash signer,
                                                      OwnerProof newOwned,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1391,7 +1391,10 @@ public class FileWrapper {
                                         getPointer(),
                                         newRetrievedCapability, network, hasher))
                         .thenCompose(updatedParentVersion -> deleteAllChunks(cap, signingPair(), tid, hasher, network,
-                                updatedParentVersion, committer)),
+                                updatedParentVersion, committer))
+                        .thenCompose(s -> OwnedKeyChamp.createEmpty(owner, signer, network.dhtClient, tid)
+                                .thenCompose(ownedRoot -> committer.commit(owner, signer,
+                                        s.get(signer.publicKeyHash).props.withOwnedRoot(ownedRoot), s.get(signer.publicKeyHash), tid))),
                 network.dhtClient)
         ).thenCompose(finalVersion -> parent.getUpdated(finalVersion, network)
                 .thenCompose(updatedParent -> network.getFile(finalVersion, ourNewCap, Optional.of(signer), ownername)

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1391,10 +1391,7 @@ public class FileWrapper {
                                         getPointer(),
                                         newRetrievedCapability, network, hasher))
                         .thenCompose(updatedParentVersion -> deleteAllChunks(cap, signingPair(), tid, hasher, network,
-                                updatedParentVersion, committer))
-                        .thenCompose(s -> OwnedKeyChamp.createEmpty(owner, signer, network.dhtClient, tid)
-                                .thenCompose(ownedRoot -> committer.commit(owner, signer,
-                                        s.get(signer.publicKeyHash).props.withOwnedRoot(ownedRoot), s.get(signer.publicKeyHash), tid))),
+                                updatedParentVersion, committer)),
                 network.dhtClient)
         ).thenCompose(finalVersion -> parent.getUpdated(finalVersion, network)
                 .thenCompose(updatedParent -> network.getFile(finalVersion, ourNewCap, Optional.of(signer), ownername)

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -9,6 +9,10 @@ import java.util.stream.*;
 
 public class Futures {
 
+    public static final <T> CompletableFuture<T> of(T val) {
+        return CompletableFuture.completedFuture(val);
+    }
+
     /**
      *
      * @param futures collection of independent futures whose results we want to combine


### PR DESCRIPTION
This includes a test to verify writer data integrity after password
change.

Still need to do the same for the named owned keys. Also make the
WriterData integrity check check the entire tree of writer keys