### PR TITLE
Total rewrite of revoking write access

### DIFF
--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -43,6 +43,18 @@ public class Path {
         return new Path(pathString + "/" + other);
     }
 
+    public Path resolve(Path other) {
+        return resolve(other.pathString);
+    }
+
+    public boolean isAbsolute() {
+        return pathString.startsWith("/");
+    }
+
+    public boolean startsWith(Path other) {
+        return pathString.startsWith(other.pathString);
+    }
+
     public File toFile() {
         throw new IllegalArgumentException("Not implemented!");
     }

--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -1,6 +1,7 @@
 package java.nio.file;
 
 import java.io.File;
+import java.util.*;
 
 public class Path {
 
@@ -71,4 +72,17 @@ public class Path {
         throw new IllegalArgumentException("Not implemented!");
     }
 
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Path path = (Path) o;
+        return Objects.equals(pathString, path.pathString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pathString);
+    }
 }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -106,6 +106,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void shareAFileWithDifferentSigner() {
+        PeergosNetworkUtils.shareFileWithDifferentSigner(network, network, 1, random);
+    }
+
+    @Test
     public void grantAndRevokeDirReadAccess() throws Exception {
         PeergosNetworkUtils.grantAndRevokeDirReadAccess(network, network, 2, random);
     }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -121,6 +121,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void grantAndRevokeDirWriteAccessWithNestedWriteAccess() {
+        PeergosNetworkUtils.grantAndRevokeDirWriteAccessWithNestedWriteAccess(network, random);
+    }
+
+    @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
         TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
                 (u1, u2, filename) ->

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -121,7 +121,7 @@ public class MultiUserTests {
     }
 
     @Test
-    public void grantAndRevokeNestedDirWriteAccess2() {
+    public void grantParentNestedWriteAccess() {
         PeergosNetworkUtils.grantParentNestedWriteAccess(network, random);
     }
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -141,8 +141,8 @@ public class MultiUserTests {
     }
 
     @Test
-    public void grantAndRevokeWriteAccessThanReadAccessToFolder() throws IOException{
-        PeergosNetworkUtils.grantAndRevokeWriteAccessThanReadAccessToFolder(network, random);
+    public void grantAndRevokeWriteThenReadAccessToFolder() throws IOException{
+        PeergosNetworkUtils.grantAndRevokeWriteThenReadAccessToFolder(network, random);
     }
 
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -121,8 +121,8 @@ public class MultiUserTests {
     }
 
     @Test
-    public void grantParentNestedWriteAccess() {
-        PeergosNetworkUtils.grantParentNestedWriteAccess(network, random);
+    public void grantAndRevokeParentNestedWriteAccess() {
+        PeergosNetworkUtils.grantAndRevokeParentNestedWriteAccess(network, random);
     }
 
     @Test

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -121,6 +121,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void grantAndRevokeNestedDirWriteAccess2() {
+        PeergosNetworkUtils.grantParentNestedWriteAccess(network, random);
+    }
+
+    @Test
     public void grantAndRevokeDirWriteAccessWithNestedWriteAccess() {
         PeergosNetworkUtils.grantAndRevokeDirWriteAccessWithNestedWriteAccess(network, random);
     }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -136,6 +136,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void grantAndRevokeReadAccessToFileInFolder() throws IOException{
+        PeergosNetworkUtils.grantAndRevokeReadAccessToFileInFolder(network, random);
+    }
+
+    @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
         TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
                 (u1, u2, filename) ->

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -107,7 +107,7 @@ public class MultiUserTests {
 
     @Test
     public void shareAFileWithDifferentSigner() {
-        PeergosNetworkUtils.shareFileWithDifferentSigner(network, network, 1, random);
+        PeergosNetworkUtils.shareFileWithDifferentSigner(network, network, random);
     }
 
     @Test

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -141,6 +141,12 @@ public class MultiUserTests {
     }
 
     @Test
+    public void grantAndRevokeWriteAccessThanReadAccessToFolder() throws IOException{
+        PeergosNetworkUtils.grantAndRevokeWriteAccessThanReadAccessToFolder(network, random);
+    }
+
+
+    @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
         TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
                 (u1, u2, filename) ->

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -312,10 +312,14 @@ public class PeergosNetworkUtils {
         FileWrapper u1File = sharer.getByPath(filePath).join().get();
         sharer.shareWriteAccessWith(filePath, Collections.singleton(sharee.username)).join();
 
-        // check other users can read the file
+        // check other user can read the file directly
         Optional<FileWrapper> sharedFile = sharee.getByPath(filePath).join();
         Assert.assertTrue("shared file present", sharedFile.isPresent());
         checkFileContents(originalFileContents, sharedFile.get(), sharee);
+        // check other user can read the file via its parent
+        Optional<FileWrapper> sharedDirViaFile = sharee.getByPath(dirPath.toString()).join();
+        Set<FileWrapper> children = sharedDirViaFile.get().getChildren(crypto.hasher, sharee.network).join();
+        Assert.assertTrue("shared file present via parent", children.size() == 1);
     }
 
     public static void grantAndRevokeDirReadAccess(NetworkAccess sharerNode, NetworkAccess shareeNode, int shareeCount, Random random) throws Exception {

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -357,7 +357,10 @@ public class PeergosNetworkUtils {
                 .collect(Collectors.toSet());
 
         // file is uploaded, do the actual sharing
-        boolean finished = sharer.shareReadAccessWithAll(updatedFolder, shareeUsers.stream().map(c -> c.username).collect(Collectors.toSet())).get();
+        boolean finished = sharer.shareReadAccessWithAll(updatedFolder, Paths.get(path),
+                shareeUsers.stream()
+                        .map(c -> c.username)
+                        .collect(Collectors.toSet())).get();
 
         // check each user can see the shared folder and directory
         for (UserContext sharee : shareeUsers) {
@@ -475,7 +478,7 @@ public class PeergosNetworkUtils {
         }
 
         // file is uploaded, do the actual sharing
-        boolean finished = sharer.shareWriteAccessWithAll(sharer.getByPath(path).join().get(), sharer.getUserRoot().join(), shareeUsers.stream()
+        boolean finished = sharer.shareWriteAccessWithAll(sharer.getByPath(path).join().get(), Paths.get(path), sharer.getUserRoot().join(), shareeUsers.stream()
                 .map(c -> c.username)
                 .collect(Collectors.toSet())).get();
 
@@ -622,7 +625,7 @@ public class PeergosNetworkUtils {
         }
 
         // share /u1/folder with 'a'
-        sharer.shareWriteAccessWithAll(sharer.getByPath(dirPath).join().get(),
+        sharer.shareWriteAccessWithAll(sharer.getByPath(dirPath).join().get(), dirPath,
                 sharer.getUserRoot().join(), Collections.singleton(a.username)).join();
 
         // create a directory
@@ -632,7 +635,7 @@ public class PeergosNetworkUtils {
 
         // share /u1/folder with 'b'
         Path subdirPath = Paths.get(sharer.username, folderName, subdirName);
-        sharer.shareWriteAccessWithAll(sharer.getByPath(subdirPath).join().get(),
+        sharer.shareWriteAccessWithAll(sharer.getByPath(subdirPath).join().get(), subdirPath,
                 sharer.getByPath(dirPath).join().get(), Collections.singleton(b.username)).join();
 
         // check 'b' can upload a file
@@ -760,7 +763,7 @@ public class PeergosNetworkUtils {
         }
 
         // grant write access to a directory to user 'a'
-        sharer.shareWriteAccessWithAll(sharer.getByPath(dirPath).join().get(),
+        sharer.shareWriteAccessWithAll(sharer.getByPath(dirPath).join().get(), dirPath,
                 sharer.getUserRoot().join(), Collections.singleton(a.username)).join();
 
         // create another sub-directory
@@ -770,7 +773,7 @@ public class PeergosNetworkUtils {
 
         // grant write access to a sub-directory to user 'b'
         Path subdirPath = Paths.get(sharer.username, folderName, subdirName);
-        sharer.shareWriteAccessWithAll(sharer.getByPath(subdirPath).join().get(),
+        sharer.shareWriteAccessWithAll(sharer.getByPath(subdirPath).join().get(), subdirPath,
                 sharer.getByPath(dirPath).join().get(), Collections.singleton(b.username)).join();
 
         List<Set<AbsoluteCapability>> childCapsByChunk0 = getAllChildCapsByChunk(sharer.getByPath(dirPath).join().get(), network);
@@ -916,7 +919,7 @@ public class PeergosNetworkUtils {
         FileWrapper folder = sharer.getByPath(path).get().get();
 
         // file is uploaded, do the actual sharing
-        boolean finished = sharer.shareWriteAccessWithAll(folder, sharer.getUserRoot().join(),
+        boolean finished = sharer.shareWriteAccessWithAll(folder, Paths.get(path), sharer.getUserRoot().join(),
                 shareeUsers.stream()
                         .map(c -> c.username)
                         .collect(Collectors.toSet())).get();

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -321,6 +321,10 @@ public class PeergosNetworkUtils {
         Optional<FileWrapper> sharedDirViaFile = sharee.getByPath(dirPath.toString()).join();
         Set<FileWrapper> children = sharedDirViaFile.get().getChildren(crypto.hasher, sharee.network).join();
         Assert.assertTrue("shared file present via parent", children.size() == 1);
+
+        FileWrapper friend = sharee.getByPath(Paths.get(sharer.username)).join().get();
+        Set<FileWrapper> friendChildren = friend.getChildren(crypto.hasher, sharee.network).join();
+        Assert.assertEquals(friendChildren.size(), 1);
     }
 
     public static void grantAndRevokeDirReadAccess(NetworkAccess sharerNode, NetworkAccess shareeNode, int shareeCount, Random random) throws Exception {

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -801,9 +801,8 @@ public class PeergosNetworkUtils {
         sharer.unShareReadAccess(fileToShare, a.username).join();
         // check 'a' can't see the shared directory
         FileWrapper unsharedLocation = a.getByPath(sharer.username).join().get();
-        unsharedLocation.getChildren(crypto.hasher, sharer.network).join();
-            System.currentTimeMillis();
-//        Assert.assertTrue("a can't see unshared folder", ! unsharedFolder.isPresent());
+        Set<FileWrapper> children = unsharedLocation.getChildren(crypto.hasher, sharer.network).join();
+        Assert.assertTrue("a can't see unshared folder", children.isEmpty());
     }
 
     public static void grantAndRevokeDirWriteAccessWithNestedWriteAccess(NetworkAccess network,

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -845,7 +845,7 @@ public class PeergosNetworkUtils {
         // test 'b' can still see shared sub-dir
         UserContext otherUser = updatedSharees.get(1);
 
-        Optional<FileWrapper> subdirAgain = otherUser.getByPath(updatedSharer.username + "/" + folderName + "/" + subdirName).join();
+        Optional<FileWrapper> subdirAgain = otherUser.getByPath(subdirPath).join();
         Assert.assertTrue("Shared folder present via direct path", subdirAgain.isPresent());
 
         MultiUserTests.checkUserValidity(network, sharer.username);

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -717,7 +717,7 @@ public class PeergosNetworkUtils {
         MultiUserTests.checkUserValidity(network, sharer.username);
     }
 
-    public static void grantParentNestedWriteAccess(NetworkAccess network,
+    public static void grantAndRevokeParentNestedWriteAccess(NetworkAccess network,
                                                     Random random) {
         CryptreeNode.setMaxChildLinkPerBlob(10);
 
@@ -771,6 +771,12 @@ public class PeergosNetworkUtils {
         FileWrapper sharedFolder = a.getByPath(sharer.username + "/" + folderName).join()
                 .orElseThrow(() -> new AssertionError("shared folder is present after sharing"));
         Assert.assertEquals(sharedFolder.getFileProperties().name, folderName);
+
+        // revoke access to /u1/folder from 'a'
+        sharer.unShareWriteAccess(dirPath, a.username).join();
+        // check 'a' can't see the shared directory
+        Optional<FileWrapper> unsharedFolder = a.getByPath(sharer.username + "/" + folderName).join();
+        Assert.assertTrue("a can't see unshared folder", ! unsharedFolder.isPresent());
     }
 
     public static void grantAndRevokeDirWriteAccessWithNestedWriteAccess(NetworkAccess network,

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -256,17 +256,11 @@ public class PeergosNetworkUtils {
         UserContext userToUnshareWith = shareeUsers.stream().findFirst().get();
 
         // unshare with a single user
-        sharerUser.unShareWriteAccess(Paths.get(sharerUser.username, filename), userToUnshareWith.username).get();
+        sharerUser.unShareWriteAccess(Paths.get(sharerUser.username, filename), userToUnshareWith.username).join();
 
         List<UserContext> updatedShareeUsers = shareeUsers.stream()
-                .map(e -> {
-                    try {
-                        return ensureSignedUp(e.username, shareePasswords.get(shareeUsers.indexOf(e)), shareeNode, crypto);
-                    } catch (Exception ex) {
-                        throw new IllegalStateException(ex.getMessage(), ex);
-
-                    }
-                }).collect(Collectors.toList());
+                .map(e -> ensureSignedUp(e.username, shareePasswords.get(shareeUsers.indexOf(e)), shareeNode, crypto))
+                .collect(Collectors.toList());
 
         //test that the other user cannot access it from scratch
         Optional<FileWrapper> otherUserView = updatedShareeUsers.get(0).getByPath(sharerUser.username + "/" + filename).get();

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -273,6 +273,10 @@ public class PeergosNetworkUtils {
 
         UserContext updatedSharerUser = ensureSignedUp(sharerUsername, sharerPassword, sharerNode.clear(), crypto);
 
+        FileWrapper theFile = updatedSharerUser.getByPath(filePath).join().get();
+        String retrievedPath = theFile.getPath(sharerNode).join();
+        Assert.assertTrue("File has correct path", retrievedPath.equals("/" + filePath));
+
         // check remaining users can still read it
         for (UserContext userContext : remainingUsers) {
             String path = filePath;

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -199,6 +199,7 @@ public class PeergosNetworkUtils {
         // share the file from sharer to each of the sharees
         String filePath = sharerUser.username + "/" + filename;
         FileWrapper u1File = sharerUser.getByPath(filePath).get().get();
+        byte[] originalStreamSecret = u1File.getFileProperties().streamSecret.get();
         sharerUser.shareWriteAccessWith(Paths.get(sharerUser.username, filename), shareeUsers.stream().map(u -> u.username).collect(Collectors.toSet())).get();
 
         // check other users can read the file
@@ -241,6 +242,10 @@ public class PeergosNetworkUtils {
         UserContext updatedSharerUser = ensureSignedUp(sharerUsername, sharerPassword, sharerNode.clear(), crypto);
 
         FileWrapper theFile = updatedSharerUser.getByPath(filePath).join().get();
+        byte[] newStreamSecret = theFile.getFileProperties().streamSecret.get();
+        boolean sameStreams = Arrays.equals(originalStreamSecret, newStreamSecret);
+//        Assert.assertTrue("Stream secret should change on revocation", ! sameStreams); TODO
+
         String retrievedPath = theFile.getPath(sharerNode).join();
         Assert.assertTrue("File has correct path", retrievedPath.equals("/" + filePath));
 
@@ -808,7 +813,7 @@ public class PeergosNetworkUtils {
         Assert.assertTrue("a can't see unshared folder", children.isEmpty());
     }
 
-    public static void grantAndRevokeWriteAccessThanReadAccessToFolder(NetworkAccess network, Random random) throws IOException {
+    public static void grantAndRevokeWriteThenReadAccessToFolder(NetworkAccess network, Random random) throws IOException {
         CryptreeNode.setMaxChildLinkPerBlob(10);
 
         String password = "notagoodone";

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -463,7 +463,8 @@ public class NetworkAccess {
                                 IpfsTransaction.call(owner,
                                         tid -> tree.remove(version.props, owner, writer, mapKey, valueHash, tid)
                                                 .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid)),
-                                        dhtClient));
+                                        dhtClient))
+                .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
     }
 
     public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -3,9 +3,8 @@ package peergos.shared.user;
 import peergos.shared.user.fs.AbsoluteCapability;
 import peergos.shared.util.ByteArrayWrapper;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.nio.file.*;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class SharedWithCache {
@@ -17,9 +16,28 @@ public class SharedWithCache {
     // V = list of usernames the file/dir is shared with
     private Map<ByteArrayWrapper, Set<String>> sharedWithReadAccessCache = new ConcurrentHashMap<>();
     private Map<ByteArrayWrapper, Set<String>> sharedWithWriteAccessCache = new ConcurrentHashMap<>();
+    // These would be more space efficient in a trie
+    private Map<Path, Set<String>> writeShares = new ConcurrentHashMap<>();
+    private Map<Path, Set<String>> readShares = new ConcurrentHashMap<>();
 
     public SharedWithCache() {
 
+    }
+
+    public Map<Path, Set<String>> getAllReadShares(Path start) {
+        Map<Path, Set<String>> res = new HashMap<>();
+        for (Path path: readShares.keySet())
+        if (path.startsWith(start))
+            res.put(path, readShares.get(path));
+        return res;
+    }
+
+    public Map<Path, Set<String>> getAllWriteShares(Path start) {
+        Map<Path, Set<String>> res = new HashMap<>();
+        for (Path path: writeShares.keySet())
+        if (path.startsWith(start))
+            res.put(path, writeShares.get(path));
+        return res;
     }
 
     private ByteArrayWrapper generateKey(AbsoluteCapability cap) {
@@ -31,13 +49,6 @@ public class SharedWithCache {
                 || ! getSharedWith(SharedWithCache.Access.WRITE, cap).isEmpty();
     }
 
-    public void copySharedWith(AbsoluteCapability oldCap, AbsoluteCapability newCap) {
-        Set<String> sharedReadAccessWith = getSharedWith(SharedWithCache.Access.READ, oldCap);
-        Set<String> sharedWriteAccessWith = getSharedWith(SharedWithCache.Access.WRITE, oldCap);
-        addSharedWith(SharedWithCache.Access.READ, newCap, sharedReadAccessWith);
-        addSharedWith(SharedWithCache.Access.WRITE, newCap, sharedWriteAccessWith);
-    }
-
     public Set<String> getSharedWith(Access access, AbsoluteCapability cap) {
         return access == Access.READ ?
             getSharedWith(sharedWithReadAccessCache, cap) : getSharedWith(sharedWithWriteAccessCache, cap);
@@ -47,16 +58,22 @@ public class SharedWithCache {
         return new HashSet<>(cache.getOrDefault(generateKey(cap), new HashSet<>()));
     }
 
-    public void addSharedWith(Access access, AbsoluteCapability cap, String name) {
-        Set<String> names = new HashSet<>();
-        names.add(name);
-        addSharedWith(access, cap, names);
+    public void addSharedWith(Access access, String path, AbsoluteCapability cap, String name) {
+        Path p = Paths.get(path);
+        if (access == Access.READ) {
+            readShares.putIfAbsent(p, new HashSet<>());
+            readShares.get(p).add(name);
+        } else {
+            writeShares.putIfAbsent(p, new HashSet<>());
+            writeShares.get(p).add(name);
+        }
+        addSharedWith(access, p, cap, Collections.singleton(name));
     }
 
-    public void addSharedWith(Access access, AbsoluteCapability cap, Set<String> names) {
-        if(access == Access.READ) {
+    public void addSharedWith(Access access, Path path, AbsoluteCapability cap, Set<String> names) {
+        if (access == Access.READ) {
             addCacheEntry(sharedWithReadAccessCache, cap, names);
-        } else if(access == Access.WRITE){
+        } else if (access == Access.WRITE){
             addCacheEntry(sharedWithWriteAccessCache, cap, names);
         }
     }

--- a/src/peergos/shared/user/Snapshot.java
+++ b/src/peergos/shared/user/Snapshot.java
@@ -35,6 +35,14 @@ public class Snapshot {
         return new Snapshot(merge);
     }
 
+    public Snapshot mergeAndOverwriteWith(Snapshot other) {
+        HashMap<PublicKeyHash, CommittedWriterData> merge = new HashMap<>(versions);
+        for (Map.Entry<PublicKeyHash, CommittedWriterData> entry : other.versions.entrySet()) {
+            merge.put(entry.getKey(), entry.getValue());
+        }
+        return new Snapshot(merge);
+    }
+
     public CommittedWriterData get(PublicKeyHash writer) {
         if (! versions.containsKey(writer))
             throw new IllegalStateException("writer not present in snapshot!");

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -34,9 +34,11 @@ public class TrieNodeImpl implements TrieNode {
                         .findAny()
                         .get()
                         .getByPath("", hasher, network)
-                        .thenCompose(child -> child.get()
+                        .thenCompose(child -> child.map(c -> c
                                 .retrieveParent(network)
-                                .thenApply(opt -> opt.map(f -> f.withTrieNode(this))));
+                                .thenApply(opt -> opt.map(f -> f.withTrieNode(this))))
+                                .orElseGet(() -> Futures.of(Optional.empty())))
+                        .exceptionally(t -> Futures.logAndReturn(t, Optional.empty()));
             }
             return network.retrieveEntryPoint(value.get());
         }

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -24,21 +24,30 @@ public class TrieNodeImpl implements TrieNode {
         this.value = value;
     }
 
-    @Override
-    public CompletableFuture<Optional<FileWrapper>> getByPath(String path, Hasher hasher, NetworkAccess network) {
-        LOG.info("GetByPath: " + path);
-        String finalPath = TrieNode.canonicalise(path);
-        if (finalPath.length() == 0) {
-            if (! value.isPresent()) { // find a valid child entry and traverse parent links
-                return Futures.findFirst(children.values(),
+    private CompletableFuture<Optional<FileWrapper>> getAnyValidParentOfAChild(Hasher hasher, NetworkAccess network) {
+        return Futures.findFirst(children.values(),
                         n -> n.getByPath("", hasher, network)
                                 .thenCompose(child -> child.map(c -> c
                                         .retrieveParent(network)
                                         .thenApply(opt -> opt.map(f -> f.withTrieNode(this))))
                                         .orElseGet(() -> Futures.of(Optional.empty())))
                                 .exceptionally(t -> Futures.logAndReturn(t, Optional.empty())));
+    }
+
+    @Override
+    public CompletableFuture<Optional<FileWrapper>> getByPath(String path, Hasher hasher, NetworkAccess network) {
+        LOG.info("GetByPath: " + path);
+        String finalPath = TrieNode.canonicalise(path);
+        if (finalPath.length() == 0) {
+            if (! value.isPresent()) { // find a valid child entry and traverse parent links
+                return getAnyValidParentOfAChild(hasher, network);
             }
-            return network.retrieveEntryPoint(value.get());
+            return network.retrieveEntryPoint(value.get())
+                    .thenCompose(opt -> {
+                        if (opt.isPresent())
+                            return Futures.of(opt);
+                        return getAnyValidParentOfAChild(hasher, network);
+                    });
         }
         String[] elements = finalPath.split("/");
         // There may be an entry point further down the tree, but it will have <= permission than this one
@@ -50,21 +59,29 @@ public class TrieNodeImpl implements TrieNode {
         return children.get(elements[0]).getByPath(finalPath.substring(elements[0].length()), hasher, network);
     }
 
+    private CompletableFuture<Set<FileWrapper>> indirectlyRetrieveChildren(Hasher hasher, NetworkAccess network) {
+        Set<CompletableFuture<Optional<FileWrapper>>> kids = children.values().stream()
+                .map(t -> t.getByPath("", hasher, network)).collect(Collectors.toSet());
+        return Futures.combineAll(kids)
+                .thenApply(set -> set.stream()
+                        .filter(opt -> opt.isPresent())
+                        .map(opt -> opt.get())
+                        .collect(Collectors.toSet()));
+    }
+
     @Override
     public CompletableFuture<Set<FileWrapper>> getChildren(String path, Hasher hasher, NetworkAccess network) {
         String trimmedPath = TrieNode.canonicalise(path);
         if (trimmedPath.length() == 0) {
-            if (!value.isPresent()) { // find a child entry and traverse parent links
-                Set<CompletableFuture<Optional<FileWrapper>>> kids = children.values().stream()
-                        .map(t -> t.getByPath("", hasher, network)).collect(Collectors.toSet());
-                return Futures.combineAll(kids)
-                        .thenApply(set -> set.stream()
-                                .filter(opt -> opt.isPresent())
-                                .map(opt -> opt.get())
-                                .collect(Collectors.toSet()));
+            if (! value.isPresent()) { // find a child entry and traverse parent links
+                return indirectlyRetrieveChildren(hasher, network);
             }
             return network.retrieveEntryPoint(value.get())
-                    .thenCompose(dir -> dir.get().getChildren(hasher, network));
+                    .thenCompose(dir -> {
+                        if (dir.isPresent())
+                            return dir.get().getChildren(hasher, network);
+                        return indirectlyRetrieveChildren(hasher, network);
+                    });
         }
         String[] elements = trimmedPath.split("/");
         if (!children.containsKey(elements[0]))

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1159,7 +1159,11 @@ public class UserContext {
                                                 p.right),
                                         new CryptreeNode.CapAndSigner((WritableAbsoluteCapability) parentCap, parent.signingPair()),
                                         new CryptreeNode.CapAndSigner((WritableAbsoluteCapability) parentCap, parent.signingPair()),
-                                        parent.getParentKey(),
+                                        Optional.of(new RelativeCapability(
+                                                Optional.empty(),
+                                                parent.getPointer().capability.getMapKey(),
+                                                parent.getParentKey(),
+                                                Optional.empty())),
                                         network,
                                         crypto,
                                         p.left,

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1177,7 +1177,7 @@ public class UserContext {
                                                         parentSigner, toUnshare.writer(), network, s, c)))))
                                 .thenCompose(x -> {
                                     sharedWithCache.removeSharedWith(SharedWithCache.Access.WRITE,
-                                            originalCap, writersToRemove);
+                                            path, originalCap, writersToRemove);
                                     return reShareAllWriteAccessRecursive(path)
                                             .thenCompose(b -> reShareAllReadAccessRecursive(path));
                                 });
@@ -1196,7 +1196,7 @@ public class UserContext {
                             toUnshare.rotateReadKeys(network, crypto.random, crypto.hasher, parent.get())
                                     .thenCompose(markedDirty -> {
                                         AbsoluteCapability cap = toUnshare.getPointer().capability;
-                                        sharedWithCache.removeSharedWith(SharedWithCache.Access.READ, cap, readersToRemove);
+                                        sharedWithCache.removeSharedWith(SharedWithCache.Access.READ, path, cap, readersToRemove);
                                         return shareReadAccessWith(path, sharedWithCache.getSharedWith(SharedWithCache.Access.READ, cap));
                                     }));
         });

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1319,6 +1319,7 @@ public class UserContext {
     }
 
     public CompletableFuture<Boolean> sendWriteCapToAll(Path toFile, Set<String> writersToAdd) {
+        System.out.println("Resharing WRITE cap to " + toFile + " with " + writersToAdd);
         return getByPath(toFile.getParent())
                 .thenCompose(parent -> getByPath(toFile)
                         .thenCompose(fileOpt -> fileOpt.map(file -> sendWriteCapToAll(file, parent.get(), writersToAdd))

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1127,7 +1127,7 @@ public class UserContext {
     public CompletableFuture<Boolean> unShareWriteAccess(Path path, Set<String> writersToRemove) {
         // 1. Add new writer pair as an owned key to parent's writer
         // 2. Rotate symmetric writing keys of subtree
-        // 3. Change the signing key pair of the subtree
+        // 3. Change the signing key pair of the subtree, and any sub signing key pairs
         // 4. Rotate the symmetric read keys
         // 5. Remove old writer from parent owned keys
         String pathString = path.toString();

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -96,11 +96,11 @@ public class WriterData implements Cborable {
     }
 
     public CompletableFuture<Snapshot> addOwnedKeyAndCommit(PublicKeyHash owner,
-                                                              SigningPrivateKeyAndPublicHash signer,
-                                                              OwnerProof newOwned,
-                                                              MaybeMultihash currentHash,
-                                                              NetworkAccess network,
-                                                              TransactionId tid) {
+                                                            SigningPrivateKeyAndPublicHash signer,
+                                                            OwnerProof newOwned,
+                                                            MaybeMultihash currentHash,
+                                                            NetworkAccess network,
+                                                            TransactionId tid) {
         return getOwnedKeyChamp(network.dhtClient)
                 .thenCompose(champ -> champ.add(owner, signer, newOwned, tid)
                         .thenApply(newRoot -> new WriterData(controller, generationAlgorithm, publicData,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -257,11 +257,12 @@ public class FileWrapper {
                                                     network, random, hasher))
                                             .thenCompose(finished ->
                                                     // update pointer from parent to us
-                                                    (updateParent ? parent.pointer.fileAccess
-                                                            .updateChildLink(finished, committer,
-                                                                    (WritableAbsoluteCapability) parent.pointer.capability,
-                                                                    parent.signingPair(), this.pointer,
-                                                                    theNewUs.pointer, network, hasher) :
+                                                    (updateParent ? finished.withWriter(owner(), parent.writer(), network)
+                                                            .thenCompose(withParent -> parent.pointer.fileAccess
+                                                                    .updateChildLink(withParent, committer,
+                                                                            parent.writableFilePointer(),
+                                                                            parent.signingPair(), this.pointer,
+                                                                            theNewUs.pointer, network, hasher)) :
                                                             CompletableFuture.completedFuture(finished))
                                             );
                                 });

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -43,6 +43,7 @@ public class FileWrapper {
     private final String ownername;
     private final Optional<TrieNode> globalRoot;
     private final Snapshot version;
+    private final boolean isWritable;
     private AtomicBoolean modified = new AtomicBoolean(); // This only used as a guard against concurrent modifications
 
     /**
@@ -61,6 +62,9 @@ public class FileWrapper {
         this.entryWriter = entryWriter;
         this.ownername = ownername;
         this.version = version;
+        this.isWritable = pointer != null &&
+                pointer.capability instanceof WritableAbsoluteCapability ||
+                entryWriter.map(s -> s.publicKeyHash.equals(pointer.capability.writer)).orElse(false);
         if (pointer == null)
             props = new FileProperties("/", true, "", 0, LocalDateTime.MIN, false, Optional.empty(), Optional.empty());
         else {
@@ -175,7 +179,7 @@ public class FileWrapper {
             SafeRandom random,
             Hasher hasher) {
         return pointer.fileAccess
-                .updateChildLinks(version, committer, (WritableAbsoluteCapability) pointer.capability, entryWriter,
+                .updateChildLinks(version, committer, (WritableAbsoluteCapability) pointer.capability, signingPair(),
                         childCases, network, hasher);
     }
 
@@ -277,7 +281,7 @@ public class FileWrapper {
                                                     (updateParent ? parent.pointer.fileAccess
                                                             .updateChildLink(finished, committer,
                                                                     (WritableAbsoluteCapability) parent.pointer.capability,
-                                                                    parent.entryWriter, this.pointer,
+                                                                    parent.signingPair(), this.pointer,
                                                                     theNewUs.pointer, network, hasher) :
                                                             CompletableFuture.completedFuture(finished))
                                             );
@@ -322,7 +326,7 @@ public class FileWrapper {
                                         .thenCompose(withParent -> network.retrieveMetadata(this.writableFilePointer().withBaseKey(baseReadKey), withParent)
                                                 .thenCompose(meta -> parent.pointer.fileAccess
                                                         .updateChildLink(withParent, committer, parent.writableFilePointer(),
-                                                                parent.entryWriter, pointer, meta.get(), network, hasher))) :
+                                                                parent.signingPair(), pointer, meta.get(), network, hasher))) :
                                 CompletableFuture.completedFuture(newVersion)
                         );
                     }).thenApply(x -> {
@@ -361,70 +365,13 @@ public class FileWrapper {
                                                         Committer committer) {
         if (!isWritable())
             throw new IllegalStateException("You cannot rotate write keys without write access!");
-        WritableAbsoluteCapability cap = writableFilePointer();
-        SymmetricKey newBaseWriteKey = suppliedBaseWriteKey.orElseGet(SymmetricKey::random);
-        WritableAbsoluteCapability ourNewPointer = cap.withBaseWriteKey(newBaseWriteKey);
-
-        if (isDirectory()) {
-            CryptreeNode existing = pointer.fileAccess;
-            Optional<SymmetricLinkToSigner> updatedWriter = existing.getWriterLink(cap.rBaseKey)
-                    .map(toSigner -> SymmetricLinkToSigner.fromPair(newBaseWriteKey, toSigner.target(cap.wBaseKey.get())));
-            CryptreeNode.DirAndChildren updatedDirAccess = existing.withWriterLink(cap.rBaseKey, updatedWriter)
-                    .withChildren(cap.rBaseKey, CryptreeNode.ChildrenLinks.empty(), crypto.hasher);
-
-            byte[] nextChunkMapKey = existing.getNextChunkLocation(cap.rBaseKey, Optional.empty(), null, null);
-            WritableAbsoluteCapability nextChunkCap = cap.withMapKey(nextChunkMapKey);
-
-            RetrievedCapability ourNewRetrievedPointer = new RetrievedCapability(ourNewPointer, updatedDirAccess.dir);
-            FileWrapper theNewUs = new FileWrapper(ourNewRetrievedPointer, entryWriter, ownername, version);
-
-            // clean all subtree write keys
-            return IpfsTransaction.call(owner(),
-                    tid -> updatedDirAccess.commitChildrenLinks(ourNewPointer, entryWriter, network, tid), network.dhtClient)
-                    .thenCompose(hashes -> getDirectChildren(network, crypto.hasher, version))
-                    .thenCompose(childFiles -> {
-                        Set<Pair<FileWrapper, SymmetricKey>> withNewBaseWriteKeys = childFiles.stream()
-                                .map(c -> new Pair<>(c, SymmetricKey.random()))
-                                .collect(Collectors.toSet());
-                        List<WritableAbsoluteCapability> childPointers = withNewBaseWriteKeys.stream()
-                                .map(p -> ((WritableAbsoluteCapability)p.left.pointer.capability)
-                                        .withBaseWriteKey(p.right))
-                                .collect(Collectors.toList());
-
-                        return Futures.reduceAll(withNewBaseWriteKeys, version,
-                                (s, pair) -> pair.left.rotateWriteKeys(false, theNewUs, Optional.of(pair.right),
-                                        network, crypto, s, committer), (a, b) -> b)
-                                .thenCompose(version2 -> theNewUs.addChildLinks(version2, committer, childPointers, network, crypto));
-                    }).thenCompose(updatedVersion ->
-                            // update pointer from parent to us
-                            (updateParent ?
-                                    updatedVersion.withWriter(owner(), parent.writer(), network)
-                                            .thenCompose(withParent -> network.retrieveMetadata(this.writableFilePointer(), withParent)
-                                                    .thenCompose(updatedUs -> parent.pointer.fileAccess
-                                                            .updateChildLink(withParent, committer,
-                                                                    parent.writableFilePointer(),
-                                                                    parent.entryWriter, this.pointer,
-                                                                    updatedUs.get(), network, crypto.hasher))) :
-                                    CompletableFuture.completedFuture(updatedVersion))
-                    ).thenCompose(updatedVersion -> {
-                        return network.getMetadata(version.get(nextChunkCap.writer).props, nextChunkCap)
-                                .thenCompose(mOpt -> {
-                                    if (! mOpt.isPresent())
-                                        return CompletableFuture.completedFuture(updatedVersion);
-                                    return new FileWrapper(new RetrievedCapability(nextChunkCap, mOpt.get()),
-                                            Optional.of(signingPair()), ownername, version)
-                                            .rotateWriteKeys(false, parent,
-                                                    Optional.of(newBaseWriteKey), network, crypto, updatedVersion, committer);
-                                });
-                    }).thenApply(x -> {
-                        setModified();
-                        return x;
-                    });
-        } else {
-            CryptreeNode existing = pointer.fileAccess;
-            // Only need to do the first chunk, because only those can have writer links
-            return existing.rotateBaseWriteKey(cap, entryWriter, newBaseWriteKey, network, version, committer);
-        }
+        return pointer.fileAccess.rotateWriteKeys(updateParent, parent.pointer.fileAccess, parent.writableFilePointer(),
+                parent.signingPair(), suppliedBaseWriteKey, writableFilePointer(), signingPair(), network, crypto,
+                version, committer)
+                .thenApply(x -> {
+                    setModified();
+                    return x;
+                });
     }
 
     public CompletableFuture<Boolean> hasChildWithName(Snapshot version, String name, Hasher hasher, NetworkAccess network) {
@@ -490,7 +437,7 @@ public class FileWrapper {
 
     @JsMethod
     public boolean isWritable() {
-        return pointer != null && pointer.capability instanceof WritableAbsoluteCapability;
+        return isWritable;
     }
 
     @JsMethod
@@ -1275,7 +1222,9 @@ public class FileWrapper {
     public SigningPrivateKeyAndPublicHash signingPair() {
         if (! isWritable())
             throw new IllegalStateException("File is not writable!");
-        return pointer.fileAccess.getSigner(pointer.capability.rBaseKey, pointer.capability.wBaseKey.get(), entryWriter);
+        return pointer.capability.wBaseKey
+                .map(w -> pointer.fileAccess.getSigner(pointer.capability.rBaseKey, w, entryWriter))
+                .orElseGet(entryWriter::get);
     }
 
     @JsMethod
@@ -1387,7 +1336,7 @@ public class FileWrapper {
                         .thenCompose(copiedVersion -> copiedVersion.withWriter(owner, parent.writer(), network))
                         .thenCompose(withParent -> parent.getPointer().fileAccess
                                 .updateChildLink(withParent, committer, parent.writableFilePointer(),
-                                        parent.entryWriter,
+                                        parent.signingPair(),
                                         getPointer(),
                                         newRetrievedCapability, network, hasher))
                         .thenCompose(updatedParentVersion -> deleteAllChunks(cap, signingPair(), tid, hasher, network,
@@ -1455,36 +1404,37 @@ public class FileWrapper {
                                                               NetworkAccess network,
                                                               Snapshot version,
                                                               Committer committer) {
-        return network.getMetadata(version.get(currentCap.writer).props, currentCap)
-                .thenCompose(mOpt -> {
-                    if (! mOpt.isPresent()) {
-                        return CompletableFuture.completedFuture(version);
-                    }
-                    SigningPrivateKeyAndPublicHash ourSigner = mOpt.get()
-                            .getSigner(currentCap.rBaseKey, currentCap.wBaseKey.get(), Optional.of(signer));
-                    return network.deleteChunk(version, committer, mOpt.get(), currentCap.owner,
-                            currentCap.getMapKey(), ourSigner, tid)
-                            .thenCompose(deletedVersion -> {
-                                CryptreeNode chunk = mOpt.get();
-                                Optional<byte[]> streamSecret = chunk.getProperties(chunk
+        return version.withWriter(currentCap.owner, currentCap.writer, network)
+                .thenCompose(current -> network.getMetadata(current.get(currentCap.writer).props, currentCap)
+                        .thenCompose(mOpt -> {
+                            if (! mOpt.isPresent()) {
+                                return CompletableFuture.completedFuture(current);
+                            }
+                            SigningPrivateKeyAndPublicHash ourSigner = mOpt.get()
+                                    .getSigner(currentCap.rBaseKey, currentCap.wBaseKey.get(), Optional.of(signer));
+                            return network.deleteChunk(current, committer, mOpt.get(), currentCap.owner,
+                                    currentCap.getMapKey(), ourSigner, tid)
+                                    .thenCompose(deletedVersion -> {
+                                        CryptreeNode chunk = mOpt.get();
+                                        Optional<byte[]> streamSecret = chunk.getProperties(chunk
                                                 .getParentKey(currentCap.rBaseKey)).streamSecret;
-                                byte[] nextChunkMapKey = chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
-                                        currentCap.getMapKey(), hasher);
-                                return deleteAllChunks(currentCap.withMapKey(nextChunkMapKey), signer, tid, hasher,
-                                        network, deletedVersion, committer);
-                            })
-                            .thenCompose(updatedVersion -> {
-                                if (! mOpt.get().isDirectory())
-                                    return CompletableFuture.completedFuture(updatedVersion);
-                                return mOpt.get().getDirectChildrenCapabilities(currentCap, network).thenCompose(childCaps ->
-                                        Futures.reduceAll(childCaps,
-                                                updatedVersion,
-                                                (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap, signer,
-                                                        tid, hasher, network, v, committer),
-                                                (x, y) -> y));
-                            })
-                            .thenCompose(s -> removeSigningKey(currentCap.writer, signer, currentCap.owner, network, s, committer));
-                });
+                                        byte[] nextChunkMapKey = chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
+                                                currentCap.getMapKey(), hasher);
+                                        return deleteAllChunks(currentCap.withMapKey(nextChunkMapKey), signer, tid, hasher,
+                                                network, deletedVersion, committer);
+                                    })
+                                    .thenCompose(updatedVersion -> {
+                                        if (! mOpt.get().isDirectory())
+                                            return CompletableFuture.completedFuture(updatedVersion);
+                                        return mOpt.get().getDirectChildrenCapabilities(currentCap, network).thenCompose(childCaps ->
+                                                Futures.reduceAll(childCaps,
+                                                        updatedVersion,
+                                                        (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap, signer,
+                                                                tid, hasher, network, v, committer),
+                                                        (x, y) -> y));
+                                    })
+                                    .thenCompose(s -> removeSigningKey(currentCap.writer, signer, currentCap.owner, network, s, committer));
+                        }));
     }
 
     /**
@@ -1523,7 +1473,8 @@ public class FileWrapper {
             return CompletableFuture.completedFuture(current);
 
         return network.synchronizer.applyUpdate(owner, parentSigner, (parentWriterData, tid) -> parentWriterData
-                .removeOwnedKey(owner, parentSigner, signerToRemove, network.dhtClient));
+                .removeOwnedKey(owner, parentSigner, signerToRemove, network.dhtClient))
+                .thenApply(removed -> current.mergeAndOverwriteWith(removed));
     }
 
     public CompletableFuture<? extends AsyncReader> getInputStream(NetworkAccess network,

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -65,6 +65,10 @@ public class RelativeCapability implements Cborable {
         return new RelativeCapability(Optional.of(writingKey), mapKey, rBaseKey, wBaseKeyLink);
     }
 
+    public RelativeCapability withWritingKey(Optional<PublicKeyHash> writingKey) {
+        return new RelativeCapability(writingKey, mapKey, rBaseKey, wBaseKeyLink);
+    }
+
     public static RelativeCapability buildSubsequentChunk(byte[] mapkey, SymmetricKey baseKey) {
         return new RelativeCapability(Optional.empty(), mapkey, baseKey, Optional.empty());
     }

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -15,6 +15,8 @@ import java.util.*;
  *  folder or entry point. This also includes the relative link between the symmetric write base keys if they are different.
  */
 public class RelativeCapability implements Cborable {
+    public static final int MAP_KEY_LENGTH = 32;
+
     // writer is only present when it is not implicit (an entry point, or a child link to a different writing key)
     public final Optional<PublicKeyHash> writer;
     private final byte[] mapKey;
@@ -32,10 +34,6 @@ public class RelativeCapability implements Cborable {
         this.mapKey = mapKey;
         this.rBaseKey = rBaseKey;
         this.wBaseKeyLink = wBaseKeyLink;
-    }
-
-    public RelativeCapability(byte[] mapKey, SymmetricKey rBaseKey, SymmetricLink wBaseKeyLink) {
-        this(Optional.empty(), mapKey, rBaseKey, Optional.ofNullable(wBaseKeyLink));
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/WritableAbsoluteCapability.java
@@ -4,6 +4,7 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.io.ipfs.multibase.*;
+import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.stream.*;
@@ -54,5 +55,10 @@ public class WritableAbsoluteCapability extends AbsoluteCapability {
         String encodedWBaseKey = Base58.encode(wBaseKey.get().serialize());
         return Stream.of(encodedOwnerKey, encodedWriterKey, encodedMapKey, encodedBaseKey, encodedWBaseKey)
                 .collect(Collectors.joining("/", "#", ""));
+    }
+
+    @Override
+    public String toString() {
+        return writer + "." + ArrayOps.bytesToHex(getMapKey());
     }
 }

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -624,9 +624,11 @@ public class CryptreeNode implements Cborable {
             NetworkAccess network,
             Snapshot version,
             Committer committer) {
+        PublicKeyHash parentWriter = parentSigner.publicKeyHash;
         CommittedWriterData cwd = version.get(parentSigner);
         return IpfsTransaction.call(owner, tid -> cwd.props.removeOwnedKey(owner, parentSigner, signer, network.dhtClient)
-                .thenCompose(wd -> committer.commit(owner, parentSigner, wd, cwd, tid)), network.dhtClient);
+                .thenCompose(wd -> committer.commit(owner, parentSigner, wd, cwd, tid)), network.dhtClient)
+                .thenApply(committed -> version.withVersion(parentWriter, committed.get(parentWriter)));
     }
 
     /** Rotate the base read key, base write key, map key and signing key of a file or directory recursively

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -733,8 +733,9 @@ public class CryptreeNode implements Cborable {
                                             committer, newUs.cap, newUs.signer, network, tid), network.dhtClient);
                                 });
                     } else {
-                        RelativeCapability toParent = new RelativeCapability(Optional.empty(), newParent.cap.getMapKey(),
-                                newParentParentKey, Optional.empty());
+                        RelativeCapability toParent = newParentCap
+                                .orElseGet(() -> new RelativeCapability(Optional.empty(), newParent.cap.getMapKey(),
+                                        newParentParentKey, Optional.empty()));
                         Optional<SymmetricLinkToSigner> signerLink = !isFirstChunk |
                                 newUs.cap.writer.equals(newParent.cap.writer) ?
                                 Optional.empty() :

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -735,7 +735,10 @@ public class CryptreeNode implements Cborable {
                     } else {
                         RelativeCapability toParent = new RelativeCapability(Optional.empty(), newParent.cap.getMapKey(),
                                 newParentParentKey, Optional.empty());
-                        Optional<SymmetricLinkToSigner> signerLink = Optional.empty();
+                        Optional<SymmetricLinkToSigner> signerLink = !isFirstChunk |
+                                newUs.cap.writer.equals(newParent.cap.writer) ?
+                                Optional.empty() :
+                                Optional.of(SymmetricLinkToSigner.fromPair(newUs.cap.wBaseKey.get(), newUs.signer));
                         SymmetricKey dataKey = getDataKey(us.cap.rBaseKey).makeDirty();
                         CryptreeNode newFileChunk = createFile(MaybeMultihash.empty(), signerLink, newUs.cap.rBaseKey, dataKey, props,
                                 this.childrenOrData, toParent, RelativeCapability.buildSubsequentChunk(

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -81,6 +81,11 @@ public class Futures {
         return result;
     }
 
+    public static <T> T logAndReturn(Throwable t, T result) {
+        t.printStackTrace();
+        return result;
+    }
+
     public static <T> T logAndThrow(Throwable t) {
         return logAndThrow(t, Optional.empty());
     }

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -67,6 +67,29 @@ public class Futures {
         );
     }
 
+    /*** Asynchronously map a set of input values to output values until one matches a predicate
+     *
+     * @param input the values to reduce
+     * @param producer maps an input value to a completable future of the return type
+     * @param <X> input type
+     * @param <V> return type
+     * @return
+     */
+    public static <X, V> CompletableFuture<Optional<V>> findFirst(
+            Collection<X> input,
+            Function<X, CompletableFuture<Optional<V>>> producer) {
+        if (input.isEmpty())
+            return Futures.of(Optional.empty());
+        List<X> inList = new ArrayList<>(input);
+
+        return producer.apply(inList.get(0))
+                .thenCompose(optRes -> {
+                    if (optRes.isPresent())
+                        return Futures.of(optRes);
+                    return findFirst(inList.subList(1, inList.size()), producer);
+                });
+    }
+
     public static <T> CompletableFuture<T> asyncExceptionally(Supplier<CompletableFuture<T>> normal,
                                                               Function<Throwable, CompletableFuture<T>> exceptional) {
         CompletableFuture<T> result = new CompletableFuture<>();


### PR DESCRIPTION
This is a fairly large and fundamental change and worth understanding in detail.

We weren't handling nested write access when revoking write access. This fixes that. 

The rewrite makes revoking write access a single pass over the subtree rather than the previous 3. 
It also makes it atomic as far as the filesystem view is concerned. The operation can crash at any point and the filesystem will be in a consistent state, without any data loss. (There may be duplicated data lying around, but this can be handled in a future pr with a similar mechanism to file uploads - by first writing a transaction file describing the operation.)

We have to be careful when encountering descendants with different signing keys to first auth the new signing key by adding it as an owned key to the new parent signer, and similarly clean up old signers as we go.  

I've also added a path based lookup to who something has been shared with (as well as the mapkey based one). This allows easy resharing of all subtree shares to remaining sharees when revoking access to others. 

Granting write access is now also O(1) if the parent already has a different signer (previously we always rotated the child).

The critical method where everything happens is CryptreeNode.rotateAllKeys()

One thing to bear in mind is that subsequent chunks of files or dirs do not have a parent link (otherwise we'd have to keep them updated)

UPDATE:
After submitting this I found a pre-existing issue with granting write access (and made a test for it). I've fixed that and made it atomic by making it use the same method revoking access uses to rotate all the keys of a subtree. 

UPDATE2:
The other interesting change was fixing TrieNodeImpl to handle revoked capabilities correctly. 