### PR TITLE
[simulate-sharing] muti-user simulator

### DIFF
--- a/src/peergos/server/simulation/AccessControl.java
+++ b/src/peergos/server/simulation/AccessControl.java
@@ -37,7 +37,18 @@ public interface AccessControl {
 
     default boolean can(Path path, String user, FileSystem.Permission permission) {
 
-        return getOwner(path).equals(user) || get(path, permission).contains(user);
+        boolean isOwner = getOwner(path).equals(user);
+        if (isOwner)
+            return true;
+        //check for sharing of the path and all of it's parents
+        Path sharePath = path;
+        while (sharePath != null) {
+            boolean isShared = get(sharePath, permission).contains(user);
+            if (isShared)
+                return true;
+            sharePath = sharePath.getParent();
+        }
+        return false;
     }
 
     class MemoryImpl implements AccessControl {

--- a/src/peergos/server/simulation/FileSystem.java
+++ b/src/peergos/server/simulation/FileSystem.java
@@ -6,6 +6,7 @@ import peergos.shared.user.fs.FileProperties;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -52,7 +53,6 @@ public interface FileSystem {
         return ls(path, true);
     }
 
-
     default void walk(Path path, Consumer<Path> func)  {
         FileProperties fileProperties = stat(path).fileProperties();
 
@@ -75,5 +75,10 @@ public interface FileSystem {
         walk(Paths.get("/"+  user()), func);
     }
 
+    void follow(FileSystem other);
+
+    Path getRandomSharedPath(Random random, FileSystem.Permission permission);
+
+    List<String> getSharees(Path path, Permission permission);
 }
 

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -144,10 +144,11 @@ public class PeergosFileSystemImpl implements FileSystem {
         this.userContext.sendInitialFollowRequest(other.user()).join();
         List<FollowRequestWithCipherText> join = otherContext.processFollowRequests().join();
         FollowRequestWithCipherText req = join.stream()
-                .filter(e -> e.getEntry().ownerName.equals(other.user()))
+                .filter(e -> e.getEntry().ownerName.equals(user()))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException());
-        otherContext.sendReplyFollowRequest(req, true,  false).join();
+        otherContext.sendReplyFollowRequest(req, true,  true).join();
+        this.userContext.processFollowRequests().join();
     }
 
     @Override

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -1,12 +1,16 @@
 package peergos.server.simulation;
 
+import peergos.shared.social.FollowRequestWithCipherText;
 import peergos.shared.user.UserContext;
 import peergos.shared.user.fs.*;
+import peergos.shared.util.Pair;
 import peergos.shared.util.ProgressConsumer;
 import peergos.shared.util.Serialize;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -75,10 +79,10 @@ public class PeergosFileSystemImpl implements FileSystem {
         Set<String> userSet = Stream.of(user).collect(Collectors.toSet());
         switch (permission) {
             case READ:
-                userContext.shareReadAccessWith(path, userSet);
+                userContext.shareReadAccessWith(path, userSet).join();
                 return;
             case WRITE:
-                userContext.shareWriteAccessWith(path, userSet);
+                userContext.shareWriteAccessWith(path, userSet).join();
                 return;
         }
         throw new IllegalStateException();
@@ -131,6 +135,37 @@ public class PeergosFileSystemImpl implements FileSystem {
                 userContext.network,
                 false,
                 userContext.crypto).join();
+    }
+
+    @Override
+    public void follow(FileSystem other) {
+        UserContext otherContext = ((PeergosFileSystemImpl) other).userContext;
+
+        this.userContext.sendInitialFollowRequest(other.user()).join();
+        List<FollowRequestWithCipherText> join = otherContext.processFollowRequests().join();
+        FollowRequestWithCipherText req = join.stream()
+                .filter(e -> e.getEntry().ownerName.equals(other.user()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException());
+        otherContext.sendReplyFollowRequest(req, true,  false).join();
+    }
+
+    @Override
+    public Path getRandomSharedPath(Random random, Permission permission) {
+        throw new IllegalStateException("Not implemented");
+    }
+
+    @Override
+    public List<String> getSharees(Path path, Permission permission) {
+        Pair<Set<String>, Set<String>> readersAndWriters = userContext.sharedWith(getPath(path)).join();
+        switch (permission) {
+            case READ:
+                return new ArrayList<>(readersAndWriters.left);
+            case WRITE:
+                return new ArrayList<>(readersAndWriters.right);
+            default:
+                throw new IllegalStateException();
+        }
     }
 }
 

--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -37,16 +37,12 @@ public class NativeFileSystemImpl implements FileSystem {
 
     private void init() {
         Path userRoot = Paths.get("/" + user);
-//        Path sharedRoot = userRoot.resolve("shared");
-//        Path peergosShare = sharedRoot.resolve("peergos");
 
         for (Path path : Arrays.asList(
                 userRoot
 //                , sharedRoot,
 //                peergosShare
         )) {
-//            accessControl.add(path, user(), Permission.WRITE);
-//            accessControl.add(path, user(), Permission.READ);
             mkdir(path);
         }
 

--- a/src/peergos/server/tests/simulation/Simulator.java
+++ b/src/peergos/server/tests/simulation/Simulator.java
@@ -291,6 +291,15 @@ public class Simulator implements Runnable {
             // seed the file-system
             run(Simulation.MKDIR, user);
             run(Simulation.WRITE, user);
+
+            // ALL PAIRWISE FRIENDS
+            for (String otherUser : users) {
+                if (user.compareTo(otherUser) >= 0)
+                    continue;
+                fileSystems.getTestFileSystem(user).follow(fileSystems.getTestFileSystem(otherUser));
+                fileSystems.getReferenceFileSystem(user).follow(fileSystems.getReferenceFileSystem(otherUser));
+            }
+
         }
     }
 
@@ -364,11 +373,15 @@ public class Simulator implements Runnable {
                 switch (permission) {
                     case READ:
                         PeergosFileSystemImpl fs = fileSystems.getTestFileSystem(sharee);
-                        System.out.println();
-                        //TODO WIP
+                        try {
+                            //can read?
+                            byte[] read = fs.read(path);
+                        } catch (Exception ex) {
+                            LOG.log(Level.WARNING, "User "+ sharee +" could not read shared-path "+ path +"!", ex);
+                            isVerified = false;
+                        }
                         break;
                     case WRITE:
-                        break;
                     default:
                         throw new IllegalStateException();
                 }


### PR DESCRIPTION
This updates the fuzzer to:
* simulate two users that are followers/following of each other
* implement the grant/revoke read access simulation operations

It verifies correctly for ~10 operations, going to try an extended run shortly.