### PR TITLE
Disable TLS1.3 for now because it seems to cause CPU thrashing

### DIFF
--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -41,9 +41,9 @@ public class UserService {
         LOG.info("\nInitial security properties:");
         printSecurityProperties();
 
-        // The ECDH and RSA ket exchange algorithms are disabled because they don't provide forward secrecy
+        // The ECDH and RSA key exchange algorithms are disabled because they don't provide forward secrecy
         Security.setProperty("jdk.tls.disabledAlgorithms",
-                "SSLv3, RC4, MD2, MD4, MD5, SHA1, DES, DSA, MD5withRSA, DH, RSA keySize < 2048, EC keySize < 224, 3DES_EDE_CBC, " +
+                "SSLv3, TLSv1.3, RC4, MD2, MD4, MD5, SHA1, DES, DSA, MD5withRSA, DH, RSA keySize < 2048, EC keySize < 224, 3DES_EDE_CBC, " +
                 "TLS_RSA_WITH_AES_256_GCM_SHA384, " +
                 "TLS_RSA_WITH_AES_256_CBC_SHA256, " +
                 "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256, " +


### PR DESCRIPTION
(it only exists in >= java 11)