### PR TITLE
Cryptree links

### DIFF
--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -155,7 +155,7 @@ public class NativeFileSystemImpl implements FileSystem {
 
                 //TODO make files use the new format with a stream secret
                 Optional<byte[]> streamSecret = file.isDirectory() ? Optional.empty() : Optional.empty();
-                return new FileProperties(file.getName(), file.isDirectory(), mimeType, sizeHi, sizeLo, lastModified,
+                return new FileProperties(file.getName(), file.isDirectory(), false, mimeType, sizeHi, sizeLo, lastModified,
                         isHidden, thumbnail, streamSecret);
 
             }

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.*;
+import java.util.concurrent.*;
 import java.util.stream.*;
 
 import static org.junit.Assert.assertEquals;
@@ -208,6 +209,10 @@ public class PeergosNetworkUtils {
             Assert.assertTrue("shared file present", sharedFile.isPresent());
             Assert.assertTrue("File is writable", sharedFile.get().isWritable());
             checkFileContents(originalFileContents, sharedFile.get(), userContext);
+            // check the other user can't rename the file
+            FileWrapper parent = userContext.getByPath(sharerUser.username).get().get();
+            CompletableFuture<FileWrapper> rename = sharedFile.get().rename("Somenew name.dat", parent, userContext);
+            assertTrue("Cannot rename", rename.isCompletedExceptionally());
         }
 
         // check other users can browser to the friend's root

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -150,6 +150,13 @@ public interface CborObject extends Cborable {
             return ((CborBoolean) get(key)).value;
         }
 
+        public boolean getBoolean(String key, boolean def) {
+            Cborable val = get(key);
+            if (val == null)
+                return def;
+            return ((CborBoolean) val).value;
+        }
+
         public Optional<byte[]> getOptionalByteArray(String key) {
             return Optional.ofNullable((CborByteArray) get(key)).map(c -> c.value);
         }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -827,7 +827,7 @@ public class UserContext {
                                 RelativeCapability nextChunk =
                                         RelativeCapability.buildSubsequentChunk(crypto.random.randomBytes(32), rootRKey);
                                 return CryptreeNode.createDir(MaybeMultihash.empty(), rootRKey, rootWKey, Optional.of(writerPair),
-                                                new FileProperties(directoryName, true, "", 0, LocalDateTime.now(),
+                                                new FileProperties(directoryName, true, false, "", 0, LocalDateTime.now(),
                                                         false, Optional.empty(), Optional.empty()),
                                                 Optional.empty(), SymmetricKey.random(), nextChunk, crypto.hasher)
                                         .thenCompose(root -> {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1258,7 +1258,7 @@ public class UserContext {
                         .thenCompose(rotated ->
                                 parent.getPointer().fileAccess.updateChildLink(
                                         rotated.left, c, (WritableAbsoluteCapability) parentCap,
-                                        parentSigner, originalCap, rotated.right,
+                                        parentSigner, file.isLink() ? file.getLinkPointer().capability : originalCap, rotated.right,
                                         network, crypto.hasher)
                                         .thenCompose(s -> IpfsTransaction.call(owner,
                                                 tid -> FileWrapper.deleteAllChunks(

--- a/src/peergos/shared/user/fs/FileProperties.java
+++ b/src/peergos/shared/user/fs/FileProperties.java
@@ -158,6 +158,10 @@ public class FileProperties implements Cborable {
         return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, isHidden, thumbnail, Optional.of(streamSecret));
     }
 
+    public FileProperties asLink() {
+        return new FileProperties(name, isDirectory, true, mimeType, size, modified, isHidden, thumbnail, streamSecret);
+    }
+
     public String getType() {
         if (isDirectory)
             return "dir";

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -43,7 +43,7 @@ public class FileUploader implements AutoCloseable {
                         byte[] firstLocation) {
         long length = (lengthLow & 0xFFFFFFFFL) + ((lengthHi & 0xFFFFFFFFL) << 32);
         if (fileProperties == null)
-            this.props = new FileProperties(name, false, mimeType, length, LocalDateTime.now(),
+            this.props = new FileProperties(name, false, false, mimeType, length, LocalDateTime.now(),
                     false, Optional.empty(), Optional.empty());
         else
             this.props = fileProperties;

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -139,6 +139,10 @@ public class FileWrapper {
         return pointer;
     }
 
+    public RetrievedCapability getLinkPointer() {
+        return linkPointer.get();
+    }
+
     public boolean isRoot() {
         return props.name.equals("/");
     }
@@ -376,6 +380,10 @@ public class FileWrapper {
     public boolean isDirectory() {
         boolean isNull = pointer == null;
         return isNull || pointer.fileAccess.isDirectory();
+    }
+
+    public boolean isLink() {
+        return props.isLink;
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1304,9 +1304,13 @@ public class FileWrapper {
         return (writableParent ? parent.removeChild(this, network, hasher) : CompletableFuture.completedFuture(parent))
                 .thenCompose(updatedParent -> network.synchronizer.applyComplexUpdate(owner(), signingPair(),
                         (version, committer) -> IpfsTransaction.call(owner(),
-                        tid -> FileWrapper.deleteAllChunks(writableFilePointer(), writableParent ?
-                                parent.signingPair() :
-                                signingPair(), tid, hasher, network, version, committer), network.dhtClient))
+                        tid -> FileWrapper.deleteAllChunks(
+                                writableParent ?
+                                        (WritableAbsoluteCapability) getLinkPointer().capability :
+                                        writableFilePointer(),
+                                writableParent ?
+                                        parent.signingPair() :
+                                        signingPair(), tid, hasher, network, version, committer), network.dhtClient))
                         .thenApply(b -> {
                             userContext.sharedWithCache.clearSharedWith(pointer.capability);
                             return updatedParent;

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -984,6 +984,7 @@ public class FileWrapper {
                 CompletableFuture.completedFuture(Optional.empty()) :
                 parent.getDescendentByPath(newFilename, userContext.crypto.hasher, userContext.network);
         ensureUnmodified();
+        FileProperties currentProps = getFileProperties();
         setModified();
         return childExists
                 .thenCompose(existing -> {
@@ -998,13 +999,9 @@ public class FileWrapper {
                         //get current props
                         RetrievedCapability ourPointer = linkPointer.orElse(pointer);
                         WritableAbsoluteCapability us = (WritableAbsoluteCapability) ourPointer.capability;
-                        SymmetricKey baseKey = us.rBaseKey;
                         CryptreeNode nodeToUpdate = ourPointer.fileAccess;
 
                         boolean isDir = this.isDirectory();
-                        SymmetricKey key = isDir ? nodeToUpdate.getParentKey(baseKey) : baseKey;
-                        FileProperties currentProps = nodeToUpdate.getProperties(key);
-
                         boolean isLink = ourPointer.getProperties().isLink;
                         FileProperties newProps = new FileProperties(newFilename, isDir, isLink,
                                 currentProps.mimeType, currentProps.size,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -383,7 +383,7 @@ public class FileWrapper {
     }
 
     public boolean isLink() {
-        return props.isLink;
+        return linkPointer.isPresent();
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -979,7 +979,7 @@ public class FileWrapper {
         if (! isLegalName(newFilename))
             return CompletableFuture.completedFuture(parent);
         if (! parent.isWritable())
-            return Futures.errored(new IllegalStateException("You cannot rename something without write access to the parent!"));
+            return Futures.errored(new IllegalStateException("Unable to rename something without write access to the parent!"));
         CompletableFuture<Optional<FileWrapper>> childExists = parent == null ?
                 CompletableFuture.completedFuture(Optional.empty()) :
                 parent.getDescendentByPath(newFilename, userContext.crypto.hasher, userContext.network);

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1305,7 +1305,7 @@ public class FileWrapper {
                 .thenCompose(updatedParent -> network.synchronizer.applyComplexUpdate(owner(), signingPair(),
                         (version, committer) -> IpfsTransaction.call(owner(),
                         tid -> FileWrapper.deleteAllChunks(
-                                writableParent ?
+                                isLink() ?
                                         (WritableAbsoluteCapability) getLinkPointer().capability :
                                         writableFilePointer(),
                                 writableParent ?

--- a/src/peergos/shared/user/fs/RetrievedCapability.java
+++ b/src/peergos/shared/user/fs/RetrievedCapability.java
@@ -1,5 +1,6 @@
 package peergos.shared.user.fs;
 
+import peergos.shared.crypto.symmetric.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.user.fs.cryptree.*;
 
@@ -21,6 +22,26 @@ public class RetrievedCapability {
             return false;
         return capability.equals(((RetrievedCapability)that).capability);
     }
+
+    public SymmetricKey getParentKey() {
+        return getParentKey(fileAccess, capability.rBaseKey);
+    }
+
+    public FileProperties getProperties() {
+        return fileAccess.getProperties(getParentKey());
+    }
+
+    private static SymmetricKey getParentKey(CryptreeNode node, SymmetricKey baseKey) {
+        if (node.isDirectory())
+            try {
+                return node.getParentKey(baseKey);
+            } catch (Exception e) {
+                // if we don't have read access to this folder, then we must just have the parent key already
+            }
+        return baseKey;
+    }
+
+
 
     public RetrievedCapability withCryptree(CryptreeNode fileAccess) {
         return new RetrievedCapability(capability, fileAccess);

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -917,6 +917,8 @@ public class CryptreeNode implements Cborable {
                                                 .thenCompose(nextChunkLocation -> {
                                                     AbsoluteCapability nextChunkCap = ourPointer.withMapKey(nextChunkLocation);
                                                     WritableAbsoluteCapability writableNextPointer = nextChunkCap.toWritable(ourPointer.wBaseKey.get());
+                                                    if (! nextOpt.isPresent())
+                                                        throw new IllegalStateException("Child link not present!");
                                                     return nextOpt.get().fileAccess.updateChildLinks(updated, committer,
                                                             writableNextPointer, signer, remaining, network, hasher);
                                                 });


### PR DESCRIPTION
This implements an improved mechanism for granting write access. 

This is done by a new type of cryptree node - a link node. A link node looks like a directory node with exactly one child, and with a isLink flag set on its metadata. This allows us to separate granting write access from granting rename permission. The implementation changes granting write access to add a link node in the same signing space as the parent directory, which points to the file in the new signing space. When retrieving the file we always use the name from the link node's metadata, and the remaining properties from the actual target node's metadata. 

We could use this same mechanism to restrict other permissions that are controlled by the metadata, for example changing the file size. Or even make a file append only by inserting the link node part way through the file. We also use them to implement the normal concept of a soft/hard links. 

After this PR we regain the usual filesystem semantics that if you only have write access to a file/dir and not its parent then you can't rename it. 

Because the only difference between a link node and a different type of cryptree node is a flag in the encrypted metadata, the network cannot distinguish between a link node, a directory, or a small file. 