### PR TITLE
Ipfs seems to hang sometimes

### DIFF
--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -45,11 +45,14 @@ public class GarbageCollector implements ContentAddressedStorage {
                 synchronized (gcLock) {
                     long start = System.nanoTime();
                     while (openTransactions() > 0) {
-                        if ((System.nanoTime() - start) / 1_000_000 > MAX_WAIT_FOR_TRANSACTION_MILLIS)
+                        if ((System.nanoTime() - start) / 1_000_000 > MAX_WAIT_FOR_TRANSACTION_MILLIS) {
+                            System.out.println("Aborting in flight transactions!");
                             openTransactions.clear();
+                        }
                         System.out.println("GC sleeping waiting for " + openTransactions() + " open transactions..");
                         Thread.sleep(100);
                     }
+                    Logging.LOG().info("Starting GC...");
                     long ready = System.nanoTime();
                     target.gc().join();
                     long done = System.nanoTime();

--- a/src/peergos/server/storage/IpfsInstaller.java
+++ b/src/peergos/server/storage/IpfsInstaller.java
@@ -36,7 +36,7 @@ public class IpfsInstaller {
         LINUX_386("https://github.com/peergos/ipfs-releases/blob/master/v0.4.23/linux-386/ipfs?raw=true",
                 Cid.decode("QmfXwgKYgP6BdutBE413hUz8FsRqGfNBSTF7jD8eWC11PU")),
         LINUX_AMD64("https://github.com/peergos/ipfs-releases/blob/master/v0.4.23/linux-amd64/ipfs?raw=true",
-                Cid.decode("QmbV92CLxEJ4AM1HMHd6mMD1Rz1e8MR8WLMyWpi3QxtzAa"), Arrays.asList(S3_LINUX_AMD64)),
+                Cid.decode("QmRpHBAmAaxNsYRkKUpDPPQdP6jspcAid41ifoA3uEU9ZX"), Arrays.asList(S3_LINUX_AMD64)),
         LINUX_ARM("https://github.com/peergos/ipfs-releases/blob/master/v0.4.23/linux-arm/ipfs?raw=true",
                 Cid.decode("QmRPJWxSTH3iAh69uGcqNWE7wuhznbpVHR2smL5hCKKCmW")),
         LINUX_ARM64("https://github.com/peergos/ipfs-releases/blob/master/v0.4.23/linux-arm64/ipfs?raw=true",


### PR DESCRIPTION
triggered by a repo.gc call made concurrently with a pin.update

This gates pin updates on our side by the same lock as calling GC