### PR TITLE
Optimise writes

### DIFF
--- a/src/peergos/server/Mirror.java
+++ b/src/peergos/server/Mirror.java
@@ -36,7 +36,8 @@ public class Mirror {
         Optional<PublicKeyHash> identity = source.coreNode.getPublicKeyHash(username).join();
         if (! identity.isPresent())
             return;
-        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, source.coreNode, source.mutable, source.dhtClient).join();
+        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, source.coreNode, source.mutable,
+                source.dhtClient, source.hasher).join();
         for (PublicKeyHash ownedKey : ownedKeys) {
             mirrorMutableSubspace(identity.get(), ownedKey, source, targetPointers, targetStorage);
         }

--- a/src/peergos/server/NonWriteThroughNetwork.java
+++ b/src/peergos/server/NonWriteThroughNetwork.java
@@ -34,8 +34,8 @@ public class NonWriteThroughNetwork extends NetworkAccess {
         MutablePointers nonWriteThroughPointers = new NonWriteThroughMutablePointers(source.mutable, nonWriteThroughIpfs);
         NonWriteThroughCoreNode nonWriteThroughCoreNode = new NonWriteThroughCoreNode(source.coreNode, nonWriteThroughIpfs);
         NonWriteThroughSocialNetwork nonWriteThroughSocial = new NonWriteThroughSocialNetwork(source.social, nonWriteThroughIpfs);
-        WriteSynchronizer synchronizer = new WriteSynchronizer(nonWriteThroughPointers, nonWriteThroughIpfs);
-        MutableTree nonWriteThroughTree = new MutableTreeImpl(nonWriteThroughPointers, nonWriteThroughIpfs, synchronizer);
+        WriteSynchronizer synchronizer = new WriteSynchronizer(nonWriteThroughPointers, nonWriteThroughIpfs, source.hasher);
+        MutableTree nonWriteThroughTree = new MutableTreeImpl(nonWriteThroughPointers, nonWriteThroughIpfs, source.hasher, synchronizer);
         return new NonWriteThroughNetwork(nonWriteThroughCoreNode,
                 nonWriteThroughSocial,
                 nonWriteThroughIpfs,

--- a/src/peergos/server/PinChecker.java
+++ b/src/peergos/server/PinChecker.java
@@ -41,7 +41,8 @@ public class PinChecker {
 
             PublicKeyHash owner = current.owner;
             try {
-                Set<PublicKeyHash> allWriters = WriterData.getOwnedKeysRecursive(owner, owner, network.mutable, network.dhtClient).join();
+                Set<PublicKeyHash> allWriters = WriterData.getOwnedKeysRecursive(owner, owner, network.mutable,
+                        network.dhtClient, network.hasher).join();
                 Set<Multihash> allRoots = allWriters.stream()
                         .map(w -> network.mutable.getPointerTarget(owner, w, network.dhtClient).join())
                         .filter(m -> m.isPresent())

--- a/src/peergos/server/Playground.java
+++ b/src/peergos/server/Playground.java
@@ -46,7 +46,7 @@ public class Playground {
                                    NetworkAccess network) throws Exception {
         // Do something dangerous (you only live once)
         Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, network.coreNode,
-                network.mutable, network.dhtClient).join();
+                network.mutable, network.dhtClient, network.hasher).join();
         for (PublicKeyHash ownedKey : ownedKeys) {
             if (ownedKey.equals(context.signer.publicKeyHash))
                 continue; // only the writer has a tree

--- a/src/peergos/server/RegisteredUserKeyFilter.java
+++ b/src/peergos/server/RegisteredUserKeyFilter.java
@@ -15,12 +15,14 @@ public class RegisteredUserKeyFilter {
     private final CoreNode core;
     private final MutablePointers mutable;
     private final ContentAddressedStorage dht;
+    private final Hasher hasher;
     private final Map<PublicKeyHash, Boolean> allowedKeys = new ConcurrentHashMap<>();
 
-    public RegisteredUserKeyFilter(CoreNode core, MutablePointers mutable, ContentAddressedStorage dht) {
+    public RegisteredUserKeyFilter(CoreNode core, MutablePointers mutable, ContentAddressedStorage dht, Hasher hasher) {
         this.core = core;
         this.mutable = mutable;
         this.dht = dht;
+        this.hasher = hasher;
         ForkJoinPool.commonPool().submit(() -> {
             while(true) {
                 try {
@@ -38,7 +40,7 @@ public class RegisteredUserKeyFilter {
             List<String> usernames = core.getUsernames("").get();
             Set<PublicKeyHash> updated = new HashSet<>();
             for (String username : usernames) {
-                updated.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht).join());
+                updated.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht, hasher).join());
             }
             Set<PublicKeyHash> toRemove = new HashSet<>();
             for (PublicKeyHash hash : allowedKeys.keySet())

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -207,7 +207,7 @@ public class UserService {
                 tlsServer.createContext(path, new HSTSHandler(handlerFunc));
         };
 
-        addHandler.accept(Constants.DHT_URL, new DHTHandler(storage, (h, i) -> true));
+        addHandler.accept(Constants.DHT_URL, new DHTHandler(storage, crypto.hasher, (h, i) -> true));
         addHandler.accept("/" + Constants.CORE_URL,
                 new HttpCoreNodeServer.CoreNodeHandler(this.coreNode));
         addHandler.accept("/" + Constants.SOCIAL_URL,

--- a/src/peergos/server/UserStats.java
+++ b/src/peergos/server/UserStats.java
@@ -27,7 +27,8 @@ public class UserStats {
                 List<Multihash> hosts = last.claim.storageProviders;
                 PublicKeyHash owner = last.owner;
                 Set<PublicKeyHash> ownedKeysRecursive =
-                        WriterData.getOwnedKeysRecursive(username, network.coreNode, network.mutable, network.dhtClient).join();
+                        WriterData.getOwnedKeysRecursive(username, network.coreNode, network.mutable,
+                                network.dhtClient, network.hasher).join();
                 long total = 0;
                 for (PublicKeyHash writer : ownedKeysRecursive) {
                     MaybeMultihash target = network.mutable.getPointerTarget(owner, writer, network.dhtClient).get();

--- a/src/peergos/server/mutable/UserBasedBlacklist.java
+++ b/src/peergos/server/mutable/UserBasedBlacklist.java
@@ -23,15 +23,21 @@ public class UserBasedBlacklist implements PublicKeyBlackList {
     private final CoreNode core;
     private final MutablePointers mutable;
     private final ContentAddressedStorage dht;
+    private final Hasher hasher;
     private final Path source;
     private final ForkJoinPool pool = new ForkJoinPool(1);
     private long lastModified, lastReloaded;
 
-    public UserBasedBlacklist(Path source, CoreNode core, MutablePointers mutable, ContentAddressedStorage dht) {
+    public UserBasedBlacklist(Path source,
+                              CoreNode core,
+                              MutablePointers mutable,
+                              ContentAddressedStorage dht,
+                              Hasher hasher) {
         this.source = source;
         this.core = core;
         this.mutable = mutable;
         this.dht = dht;
+        this.hasher = hasher;
         pool.submit(() -> {
             while (true) {
                 try {
@@ -80,7 +86,7 @@ public class UserBasedBlacklist implements PublicKeyBlackList {
     private Set<PublicKeyHash> buildBlackList(Set<String> usernames) {
         Set<PublicKeyHash> res = new HashSet<>();
         for (String username : usernames) {
-            res.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht).join());
+            res.addAll(WriterData.getOwnedKeysRecursive(username, core, mutable, dht, hasher).join());
         }
         return res;
     }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -60,7 +60,7 @@ public class MultiUserTests {
         WriterData props = WriterData.getWriterData(owner, writer, network.mutable, network.dhtClient).join().props;
         if (! props.ownedKeys.isPresent())
             return;
-        OwnedKeyChamp ownedChamp = props.getOwnedKeyChamp(network.dhtClient).join();
+        OwnedKeyChamp ownedChamp = props.getOwnedKeyChamp(network.dhtClient, network.hasher).join();
         Set<OwnerProof> empty = Collections.emptySet();
         Set<OwnerProof> claims = ownedChamp.applyToAllMappings(empty,
                 (a, b) -> CompletableFuture.completedFuture(Stream.concat(a.stream(), Stream.of(b.right)).collect(Collectors.toSet())),
@@ -355,7 +355,7 @@ public class MultiUserTests {
                 ! metaOnlyParent.isWritable() && ! metaOnlyParent.isReadable());
 
         Set<PublicKeyHash> keysOwnedByRootSigner = WriterData.getDirectOwnedKeys(theFile.owner(), parentFolder.writer(),
-                u1.network.mutable, u1.network.dhtClient).join();
+                u1.network.mutable, u1.network.dhtClient, u1.network.hasher).join();
         Assert.assertTrue("New writer key present", keysOwnedByRootSigner.contains(theFile.writer()));
 
         AbsoluteCapability cap = theFile.getPointer().capability;
@@ -374,7 +374,7 @@ public class MultiUserTests {
             Assert.assertTrue("shared file removed", ! sharedFile.isPresent());
         }
         Set<PublicKeyHash> updatedKeysOwnedByRootSigner = WriterData.getDirectOwnedKeys(theFile.owner(),
-                parentFolder.writer(), u1.network.mutable, u1.network.dhtClient).join();
+                parentFolder.writer(), u1.network.mutable, u1.network.dhtClient, u1.network.hasher).join();
         Assert.assertTrue("New writer key not present", ! updatedKeysOwnedByRootSigner.contains(theFile.writer()));
     }
 

--- a/src/peergos/server/tests/WriterDataTests.java
+++ b/src/peergos/server/tests/WriterDataTests.java
@@ -19,7 +19,8 @@ public class WriterDataTests {
 
     @Test
     public void tolerateLoopsInOwnedKeys() throws  Exception {
-        Crypto.initJava();
+        Crypto crypto = Crypto.initJava();
+        Hasher hasher = crypto.hasher;
         TransactionId test = new TransactionId("dummy");
         ContentAddressedStorage dht = new RAMStorage();
         Connection db = Sqlite.build("::memory::");
@@ -33,24 +34,24 @@ public class WriterDataTests {
         PublicKeyHash pubB = ContentAddressedStorage.hashKey(pairB.publicSigningKey);
         SigningPrivateKeyAndPublicHash signerB = new SigningPrivateKeyAndPublicHash(pubB, pairB.secretSigningKey);
 
-        WriterData wdA = IpfsTransaction.call(pubA, tid -> WriterData.createEmpty(pubA, signerA, dht, tid), dht).join();
-        WriterData wdB = IpfsTransaction.call(pubB, tid -> WriterData.createEmpty(pubB, signerB, dht, tid), dht).join();
+        WriterData wdA = IpfsTransaction.call(pubA, tid -> WriterData.createEmpty(pubA, signerA, dht, hasher, tid), dht).join();
+        WriterData wdB = IpfsTransaction.call(pubB, tid -> WriterData.createEmpty(pubB, signerB, dht, hasher, tid), dht).join();
 
-        WriterData wdA2 = wdA.addOwnedKey(pubA, signerA, OwnerProof.build(signerB, pubA), dht).join();
-        wdA2.commit(pubA, signerA, MaybeMultihash.empty(), mutable, dht, test).join();
-        MaybeMultihash bCurrent = wdB.commit(pubB, signerB, MaybeMultihash.empty(), mutable, dht, test).join().get(pubB).hash;
+        WriterData wdA2 = wdA.addOwnedKey(pubA, signerA, OwnerProof.build(signerB, pubA), dht, hasher).join();
+        wdA2.commit(pubA, signerA, MaybeMultihash.empty(), mutable, dht, hasher, test).join();
+        MaybeMultihash bCurrent = wdB.commit(pubB, signerB, MaybeMultihash.empty(), mutable, dht, hasher, test).join().get(pubB).hash;
 
-        Set<PublicKeyHash> ownedByA1 = WriterData.getOwnedKeysRecursive(pubA, pubA, mutable, dht).join();
-        Set<PublicKeyHash> ownedByB1 = WriterData.getOwnedKeysRecursive(pubB, pubB, mutable, dht).join();
+        Set<PublicKeyHash> ownedByA1 = WriterData.getOwnedKeysRecursive(pubA, pubA, mutable, dht, hasher).join();
+        Set<PublicKeyHash> ownedByB1 = WriterData.getOwnedKeysRecursive(pubB, pubB, mutable, dht, hasher).join();
 
         Assert.assertTrue(ownedByA1.size() == 2);
         Assert.assertTrue(ownedByB1.size() == 1);
 
-        WriterData wdB2 = wdB.addOwnedKey(pubB, signerB, OwnerProof.build(signerA, pubB), dht).join();
-        wdB2.commit(pubB, signerB, bCurrent, mutable, dht, test).join();
+        WriterData wdB2 = wdB.addOwnedKey(pubB, signerB, OwnerProof.build(signerA, pubB), dht, hasher).join();
+        wdB2.commit(pubB, signerB, bCurrent, mutable, dht, hasher, test).join();
 
-        Set<PublicKeyHash> ownedByA2 = WriterData.getOwnedKeysRecursive(pubA, pubA, mutable, dht).join();
-        Set<PublicKeyHash> ownedByB2 = WriterData.getOwnedKeysRecursive(pubB, pubB, mutable, dht).join();
+        Set<PublicKeyHash> ownedByA2 = WriterData.getOwnedKeysRecursive(pubA, pubA, mutable, dht, hasher).join();
+        Set<PublicKeyHash> ownedByB2 = WriterData.getOwnedKeysRecursive(pubB, pubB, mutable, dht, hasher).join();
 
         Assert.assertTrue(ownedByA2.size() == 2);
         Assert.assertTrue(ownedByB2.size() == 2);

--- a/src/peergos/server/tests/slow/EfficiencyComparison.java
+++ b/src/peergos/server/tests/slow/EfficiencyComparison.java
@@ -45,12 +45,14 @@ public class EfficiencyComparison {
                 RAMStorage champStorage = new RAMStorage();
                 SigningPrivateKeyAndPublicHash champUser = ChampTests.createUser(champStorage, crypto);
                 Pair<Champ, Multihash> current = new Pair<>(Champ.empty(), champStorage.put(champUser.publicKeyHash,
-                        champUser, Champ.empty().serialize(), champStorage.startTransaction(champUser.publicKeyHash).get()).get());
+                        champUser, Champ.empty().serialize(), crypto.hasher,
+                        champStorage.startTransaction(champUser.publicKeyHash).get()).get());
 
                 for (Map.Entry<ByteArrayWrapper, MaybeMultihash> e : state.entrySet()) {
                     current = current.left.put(champUser.publicKeyHash, champUser, e.getKey(), e.getKey().data, 0, MaybeMultihash.empty(),
                             e.getValue(), bitWidth, maxCollisions, x -> x.data,
-                            champStorage.startTransaction(champUser.publicKeyHash).get(), champStorage, current.right).get();
+                            champStorage.startTransaction(champUser.publicKeyHash).get(), champStorage, crypto.hasher,
+                            current.right).get();
                 }
 
                 int champSize = champStorage.totalSize();

--- a/src/peergos/server/tests/slow/MediumFileBenchmark.java
+++ b/src/peergos/server/tests/slow/MediumFileBenchmark.java
@@ -51,11 +51,11 @@ public class MediumFileBenchmark {
         return UserContext.ensureSignedUp(username, password, network, crypto).get();
     }
 
-    // UPLOAD(0) duration: 8115 mS, best: 8115 mS, worst: 8115 mS, av: 8115 mS
+    // UPLOAD(0) duration: 7451 mS, best: 7451 mS, worst: 7451 mS, av: 7451 mS
     // to
-    // UPLOAD(99) duration: 9864 mS, best: 7959 mS, worst: 10653 mS, av: 8974 mS or 1.1 MiB/s
+    // UPLOAD(99) duration: 8320 mS, best: 7276 mS, worst: 9540 mS, av: 8325 mS or 1.2 MiB/s
     //
-    // GetData(10) duration: 1037 mS, best: 868 mS, worst: 1167 mS, av: 944 mS or 10.5 MiB/s
+    // GetData(10) duration: 1093 mS, best: 984 mS, worst: 1317 mS, av: 1141 mS or 8.7 MiB/s
     @Test
     public void mediumFiles() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/slow/MultipartBenchmark.java
+++ b/src/peergos/server/tests/slow/MultipartBenchmark.java
@@ -71,7 +71,7 @@ public class MultipartBenchmark {
         for (int i=0; i < 10000; i++) {
             random.nextBytes(data);
             long t1 = System.currentTimeMillis();
-            network.dhtClient.put(context.signer.publicKeyHash, context.signer, data, tid).join();
+            network.dhtClient.put(context.signer.publicKeyHash, context.signer, data, network.hasher, tid).join();
             long duration = System.currentTimeMillis() - t1;
             worst = Math.max(worst, duration);
             best = Math.min(best, duration);

--- a/src/peergos/server/tests/slow/SmallFileBenchmark.java
+++ b/src/peergos/server/tests/slow/SmallFileBenchmark.java
@@ -51,11 +51,11 @@ public class SmallFileBenchmark {
         return UserContext.ensureSignedUp(username, password, network, crypto).get();
     }
 
-    // UPLOAD(0) duration: 1246 mS, best: 1246 mS, worst: 1246 mS, av: 1246 mS
+    // UPLOAD(0) duration: 1189 mS, best: 1189 mS, worst: 1189 mS, av: 1189 mS
     // to
-    // UPLOAD(99) duration: 1772 mS, best: 1226 mS, worst: 2132 mS, av: 1638 mS
+    // UPLOAD(99) duration: 1444 mS, best: 1084 mS, worst: 1724 mS, av: 1311 mS
     //
-    // GetData(99) duration: 54 mS, best: 51 mS, worst: 234 mS, av: 55 mS
+    // GetData(99) duration: 49 mS, best: 39 mS, worst: 82 mS, av: 45 mS
     @Test
     public void smallFiles() throws Exception {
         String username = generateUsername();

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -27,8 +27,10 @@ public interface ContentAddressedStorage {
     default CompletableFuture<Multihash> put(PublicKeyHash owner,
                                              SigningPrivateKeyAndPublicHash writer,
                                              byte[] block,
+                                             Hasher hasher,
                                              TransactionId tid) {
-        return put(owner, writer.publicKeyHash, writer.secret.signatureOnly(block), block, tid);
+        return hasher.sha256(block)
+                .thenCompose(hash -> put(owner, writer.publicKeyHash, writer.secret.signatureOnly(hash), block, tid));
     }
 
     default CompletableFuture<Multihash> put(PublicKeyHash owner,

--- a/src/peergos/shared/user/EntryPoint.java
+++ b/src/peergos/shared/user/EntryPoint.java
@@ -43,7 +43,7 @@ public class EntryPoint implements Cborable {
             if (! ownerKey.isPresent())
                 throw new IllegalStateException("No owner key present for user " + claimedOwner);
             return UserContext.getWriterData(network, ownerKey.get(), ownerKey.get())
-                    .thenCompose(wd -> wd.props.ownsKey(entryWriter, network.dhtClient));
+                    .thenCompose(wd -> wd.props.ownsKey(entryWriter, network.dhtClient, network.hasher));
         });
     }
 

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -206,10 +206,11 @@ public class WriterData implements Cborable {
                 (wd, tid) -> {
                     Optional<UserStaticData> newEntryPoints = staticData
                             .map(sd -> new UserStaticData(sd.getEntryPoints(currentKey), newKey));
-                    return network.dhtClient.putBoxingKey(oldSigner.publicKeyHash,
-                            oldSigner.secret.signatureOnly(followRequestReceiver.serialize()),
+                    return network.hasher.sha256(followRequestReceiver.serialize())
+                            .thenCompose(boxerHash -> network.dhtClient.putBoxingKey(oldSigner.publicKeyHash,
+                            oldSigner.secret.signatureOnly(boxerHash),
                             followRequestReceiver, tid
-                    ).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner,
+                    )).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner,
                             network.dhtClient, network.hasher, tid)
                             .thenCompose(ownedRoot -> {
                                 Map<String, OwnerProof> newNamedOwnedKeys = namedOwnedKeys.entrySet()

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -84,13 +84,14 @@ public class WriterData implements Cborable {
     public CompletableFuture<WriterData> addOwnedKey(PublicKeyHash owner,
                                                      SigningPrivateKeyAndPublicHash signer,
                                                      OwnerProof newOwned,
-                                                     ContentAddressedStorage ipfs) {
+                                                     ContentAddressedStorage ipfs,
+                                                     Hasher hasher) {
         return IpfsTransaction.call(owner,
                 tid -> (! ownedKeys.isPresent() ?
-                        OwnedKeyChamp.createEmpty(owner, signer, ipfs, tid)
-                                .thenCompose(root -> OwnedKeyChamp.build(root, ipfs)) :
-                        getOwnedKeyChamp(ipfs))
-                        .thenCompose(champ -> champ.add(owner, signer, newOwned, tid))
+                        OwnedKeyChamp.createEmpty(owner, signer, ipfs, hasher, tid)
+                                .thenCompose(root -> OwnedKeyChamp.build(root, ipfs, hasher)) :
+                        getOwnedKeyChamp(ipfs, hasher))
+                        .thenCompose(champ -> champ.add(owner, signer, newOwned, hasher, tid))
                         .thenApply(newRoot -> new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver,
                                 Optional.of(newRoot), namedOwnedKeys, staticData, tree)), ipfs);
     }
@@ -101,8 +102,8 @@ public class WriterData implements Cborable {
                                                             MaybeMultihash currentHash,
                                                             NetworkAccess network,
                                                             TransactionId tid) {
-        return getOwnedKeyChamp(network.dhtClient)
-                .thenCompose(champ -> champ.add(owner, signer, newOwned, tid)
+        return getOwnedKeyChamp(network.dhtClient, network.hasher)
+                .thenCompose(champ -> champ.add(owner, signer, newOwned, network.hasher, tid)
                         .thenApply(newRoot -> new WriterData(controller, generationAlgorithm, publicData,
                                 followRequestReceiver, Optional.of(newRoot), namedOwnedKeys, staticData, tree)))
                 .thenCompose(wd -> wd.commit(owner, signer, currentHash, network, tid));
@@ -111,9 +112,10 @@ public class WriterData implements Cborable {
     public CompletableFuture<WriterData> removeOwnedKey(PublicKeyHash owner,
                                                         SigningPrivateKeyAndPublicHash signer,
                                                         PublicKeyHash ownedKey,
-                                                        ContentAddressedStorage ipfs) {
+                                                        ContentAddressedStorage ipfs,
+                                                        Hasher hasher) {
 
-        return getOwnedKeyChamp(ipfs)
+        return getOwnedKeyChamp(ipfs, hasher)
                 .thenCompose(champ -> IpfsTransaction.call(owner,
                         tid -> champ.remove(owner, signer, ownedKey, tid), ipfs)
                         .thenApply(newRoot -> new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver,
@@ -121,21 +123,23 @@ public class WriterData implements Cborable {
     }
 
     public CompletableFuture<Boolean> ownsKey(PublicKeyHash ownedKey,
-                                              ContentAddressedStorage ipfs) {
+                                              ContentAddressedStorage ipfs,
+                                              Hasher hasher) {
         // TODO do this recursively to handle arbitrary trees of key ownership
-        return getOwnedKeyChamp(ipfs)
+        return getOwnedKeyChamp(ipfs, hasher)
                 .thenCompose(champ -> champ.get(ownedKey))
                 .thenApply(Optional::isPresent);
     }
 
-    public CompletableFuture<OwnedKeyChamp> getOwnedKeyChamp(ContentAddressedStorage ipfs) {
-        return ownedKeys.map(root -> OwnedKeyChamp.build(root, ipfs))
+    public CompletableFuture<OwnedKeyChamp> getOwnedKeyChamp(ContentAddressedStorage ipfs, Hasher hasher) {
+        return ownedKeys.map(root -> OwnedKeyChamp.build(root, ipfs, hasher))
                 .orElseThrow(() -> new IllegalStateException("Owned key champ absent!"));
     }
 
     private <T> CompletableFuture<Set<T>> applyToOwnedKeys(Function<OwnedKeyChamp, CompletableFuture<Set<T>>> processor,
-                                                           ContentAddressedStorage ipfs) {
-        return ownedKeys.map(x -> getOwnedKeyChamp(ipfs).thenCompose(processor))
+                                                           ContentAddressedStorage ipfs,
+                                                           Hasher hasher) {
+        return ownedKeys.map(x -> getOwnedKeyChamp(ipfs, hasher).thenCompose(processor))
                 .orElse(CompletableFuture.completedFuture(Collections.emptySet()));
     }
 
@@ -152,8 +156,9 @@ public class WriterData implements Cborable {
     public static CompletableFuture<WriterData> createEmpty(PublicKeyHash owner,
                                                             SigningPrivateKeyAndPublicHash writer,
                                                             ContentAddressedStorage ipfs,
+                                                            Hasher hasher,
                                                             TransactionId tid) {
-        return OwnedKeyChamp.createEmpty(owner, writer, ipfs, tid)
+        return OwnedKeyChamp.createEmpty(owner, writer, ipfs, hasher, tid)
                 .thenApply(ownedRoot -> new WriterData(writer.publicKeyHash,
                         Optional.empty(),
                         Optional.empty(),
@@ -170,8 +175,9 @@ public class WriterData implements Cborable {
                                                                           SymmetricKey rootKey,
                                                                           SecretGenerationAlgorithm algorithm,
                                                                           ContentAddressedStorage ipfs,
+                                                                          Hasher hasher,
                                                                           TransactionId tid) {
-        return OwnedKeyChamp.createEmpty(owner, writer, ipfs, tid)
+        return OwnedKeyChamp.createEmpty(owner, writer, ipfs, hasher, tid)
                 .thenApply(ownedRoot -> new WriterData(writer.publicKeyHash,
                         Optional.of(algorithm),
                         Optional.empty(),
@@ -203,7 +209,8 @@ public class WriterData implements Cborable {
                     return network.dhtClient.putBoxingKey(oldSigner.publicKeyHash,
                             oldSigner.secret.signatureOnly(followRequestReceiver.serialize()),
                             followRequestReceiver, tid
-                    ).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner, network.dhtClient, tid)
+                    ).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner,
+                            network.dhtClient, network.hasher, tid)
                             .thenCompose(ownedRoot -> {
                                 Map<String, OwnerProof> newNamedOwnedKeys = namedOwnedKeys.entrySet()
                                         .stream()
@@ -219,12 +226,12 @@ public class WriterData implements Cborable {
                                         newNamedOwnedKeys,
                                         newEntryPoints,
                                         tree);
-                                return getOwnedKeyChamp(network.dhtClient)
+                                return getOwnedKeyChamp(network.dhtClient, network.hasher)
                                         .thenCompose(okChamp -> okChamp.applyToAllMappings(base, (nwd, p) ->
                                                 p.left.equals(signer.publicKeyHash) ? Futures.of(nwd) :
                                                 nwd.addOwnedKey(oldSigner.publicKeyHash, signer,
                                                         OwnerProof.build(ownedKeys.get(p.left), signer.publicKeyHash),
-                                                        network.dhtClient), network.dhtClient)
+                                                        network.dhtClient, network.hasher), network.dhtClient)
                                         );
                             }));
                 })
@@ -241,7 +248,7 @@ public class WriterData implements Cborable {
                                               MaybeMultihash currentHash,
                                               NetworkAccess network,
                                               TransactionId tid) {
-        return commit(owner, signer, currentHash, network.mutable, network.dhtClient, tid);
+        return commit(owner, signer, currentHash, network.mutable, network.dhtClient, network.hasher, tid);
     }
 
     public CompletableFuture<Snapshot> commit(PublicKeyHash owner,
@@ -249,10 +256,12 @@ public class WriterData implements Cborable {
                                               MaybeMultihash currentHash,
                                               MutablePointers mutable,
                                               ContentAddressedStorage immutable,
+                                              Hasher hasher,
                                               TransactionId tid) {
         byte[] raw = serialize();
 
-        return immutable.put(owner, signer.publicKeyHash, signer.secret.signatureOnly(raw), raw, tid)
+        return hasher.sha256(raw)
+                .thenCompose(hash -> immutable.put(owner, signer.publicKeyHash, signer.secret.signatureOnly(hash), raw, tid))
                 .thenCompose(blobHash -> {
                     MaybeMultihash newHash = MaybeMultihash.of(blobHash);
                     if (newHash.equals(currentHash)) {
@@ -317,26 +326,29 @@ public class WriterData implements Cborable {
     public static CompletableFuture<Set<PublicKeyHash>> getOwnedKeysRecursive(String username,
                                                                               CoreNode core,
                                                                               MutablePointers mutable,
-                                                                              ContentAddressedStorage dht) {
+                                                                              ContentAddressedStorage dht,
+                                                                              Hasher hasher) {
         return core.getPublicKeyHash(username)
                 .thenCompose(publicKeyHash -> publicKeyHash
-                        .map(h -> getOwnedKeysRecursive(h, h, mutable, dht))
+                        .map(h -> getOwnedKeysRecursive(h, h, mutable, dht, hasher))
                         .orElseGet(() -> CompletableFuture.completedFuture(Collections.emptySet())));
     }
 
     public static CompletableFuture<Set<PublicKeyHash>> getOwnedKeysRecursive(PublicKeyHash owner,
                                                                               PublicKeyHash writer,
                                                                               MutablePointers mutable,
-                                                                              ContentAddressedStorage ipfs) {
-        return getOwnedKeysRecursive(owner, writer, Collections.emptySet(), mutable, ipfs);
+                                                                              ContentAddressedStorage ipfs,
+                                                                              Hasher hasher) {
+        return getOwnedKeysRecursive(owner, writer, Collections.emptySet(), mutable, ipfs, hasher);
     }
 
     private static CompletableFuture<Set<PublicKeyHash>> getOwnedKeysRecursive(PublicKeyHash owner,
-                                                                              PublicKeyHash writer,
-                                                                              Set<PublicKeyHash> alreadyDone,
-                                                                              MutablePointers mutable,
-                                                                              ContentAddressedStorage ipfs) {
-        return getDirectOwnedKeys(owner, writer, mutable, ipfs)
+                                                                               PublicKeyHash writer,
+                                                                               Set<PublicKeyHash> alreadyDone,
+                                                                               MutablePointers mutable,
+                                                                               ContentAddressedStorage ipfs,
+                                                                               Hasher hasher) {
+        return getDirectOwnedKeys(owner, writer, mutable, ipfs, hasher)
                 .thenCompose(directOwned -> {
                     Set<PublicKeyHash> newKeys = directOwned.stream().
                             filter(h -> ! alreadyDone.contains(h))
@@ -344,7 +356,7 @@ public class WriterData implements Cborable {
                     Set<PublicKeyHash> done = new HashSet<>(alreadyDone);
                     done.add(writer);
                     BiFunction<Set<PublicKeyHash>, PublicKeyHash, CompletableFuture<Set<PublicKeyHash>>> composer =
-                            (a, w) -> getOwnedKeysRecursive(owner, w, a, mutable, ipfs)
+                            (a, w) -> getOwnedKeysRecursive(owner, w, a, mutable, ipfs, hasher)
                                     .thenApply(ws ->
                                             Stream.concat(ws.stream(), a.stream())
                                                     .collect(Collectors.toSet()));
@@ -358,14 +370,16 @@ public class WriterData implements Cborable {
     public static CompletableFuture<Set<PublicKeyHash>> getDirectOwnedKeys(PublicKeyHash owner,
                                                                            PublicKeyHash writer,
                                                                            MutablePointers mutable,
-                                                                           ContentAddressedStorage ipfs) {
+                                                                           ContentAddressedStorage ipfs,
+                                                                           Hasher hasher) {
         return mutable.getPointerTarget(owner, writer, ipfs)
-                .thenCompose(h -> getDirectOwnedKeys(writer, h, ipfs));
+                .thenCompose(h -> getDirectOwnedKeys(writer, h, ipfs, hasher));
     }
 
     public static CompletableFuture<Set<PublicKeyHash>> getDirectOwnedKeys(PublicKeyHash writer,
                                                                            MaybeMultihash root,
-                                                                           ContentAddressedStorage ipfs) {
+                                                                           ContentAddressedStorage ipfs,
+                                                                           Hasher hasher) {
         if (! root.isPresent())
             return CompletableFuture.completedFuture(Collections.emptySet());
 
@@ -381,7 +395,7 @@ public class WriterData implements Cborable {
 
         return getWriterData(root.get(), ipfs)
                 .thenCompose(wd -> wd.props.applyToOwnedKeys(owned ->
-                        owned.applyToAllMappings(Collections.emptySet(), composer, ipfs), ipfs)
+                        owned.applyToAllMappings(Collections.emptySet(), composer, ipfs), ipfs, hasher)
                         .thenApply(owned -> Stream.concat(owned.stream(),
                                 wd.props.namedOwnedKeys.values().stream()).collect(Collectors.toSet())))
                 .thenCompose(all -> Futures.reduceAll(all, Collections.emptySet(),

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1326,7 +1326,7 @@ public class FileWrapper {
 
         return current.withWriter(owner, parentWriter, network)
                 .thenCompose(s -> s.get(parentSigner).props
-                        .removeOwnedKey(owner, parentSigner, signerToRemove, network.dhtClient)
+                        .removeOwnedKey(owner, parentSigner, signerToRemove, network.dhtClient, network.hasher)
                         .thenCompose(removed -> IpfsTransaction.call(
                                 owner,
                                 tid -> committer.commit(owner, parentSigner, removed, s.get(parentSigner), tid),

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -511,7 +511,8 @@ public class CryptreeNode implements Cborable {
                             CommittedWriterData cwd = version.get(parentSigner);
                             OwnerProof proof = OwnerProof.build(newSigner, parentSigner.publicKeyHash);
                             return cwd.props.addOwnedKeyAndCommit(owner, parentSigner, proof, cwd.hash, network, tid)
-                                    .thenCompose(v -> WriterData.createEmpty(owner, newSigner, network.dhtClient, tid)
+                                    .thenCompose(v -> WriterData.createEmpty(owner, newSigner, network.dhtClient,
+                                            network.hasher, tid)
                                             .thenCompose(wd -> committer.commit(owner, newSigner, wd, new CommittedWriterData(MaybeMultihash.empty(), null), tid))
                                             .thenApply(s -> new Pair<>(version.mergeAndOverwriteWith(v).mergeAndOverwriteWith(s), newSigner)));
                         }), network.dhtClient);
@@ -526,7 +527,8 @@ public class CryptreeNode implements Cborable {
             Committer committer) {
         PublicKeyHash parentWriter = parentSigner.publicKeyHash;
         CommittedWriterData cwd = version.get(parentSigner);
-        return IpfsTransaction.call(owner, tid -> cwd.props.removeOwnedKey(owner, parentSigner, signer, network.dhtClient)
+        return IpfsTransaction.call(owner, tid -> cwd.props.removeOwnedKey(owner, parentSigner, signer,
+                network.dhtClient, network.hasher)
                 .thenCompose(wd -> committer.commit(owner, parentSigner, wd, cwd, tid)), network.dhtClient)
                 .thenApply(committed -> version.withVersion(parentWriter, committed.get(parentWriter)));
     }

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -39,8 +39,12 @@ public class Futures {
         CompletableFuture<List<T>> identity = CompletableFuture.completedFuture(Collections.emptyList());
         return futures.stream().reduce(identity,
                 (a, b) -> b.thenCompose(opt ->
-                        a.thenApply(set -> Stream.concat(set.stream(), Stream.of(opt))
-                                .collect(Collectors.toList()))),
+                        a.thenApply(set -> {
+                            ArrayList<T> combined = new ArrayList<>(set.size() + 1);
+                            combined.addAll(set);
+                            combined.add(opt);
+                            return combined;
+                        })),
                 (a, b) -> b.thenCompose(setb ->
                         a.thenApply(seta -> Stream.concat(seta.stream(), setb.stream()).collect(Collectors.toList()))));
     }


### PR DESCRIPTION
This makes block.put only sign the hash of the fragment rather than the entire fragment. 

This results in ~25% speed up to uploads, and reduces cpu pressure on both the client and the server. 