### PR TITLE
Feat/pre authed s3 reads

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -482,7 +482,8 @@ public class Main {
                     Optional<String> publicReadUrl = Optional.ofNullable(a.getArg("blockstore-url", null));
                     boolean directWrites = a.getBoolean("direct-s3-writes", false);
                     boolean publicReads = a.getBoolean("public-s3-reads", false);
-                    BlockStoreProperties props = new BlockStoreProperties(directWrites, publicReads, publicReadUrl);
+                    boolean authedReads = a.getBoolean("authed-s3-reads", false);
+                    BlockStoreProperties props = new BlockStoreProperties(directWrites, publicReads, authedReads, publicReadUrl);
                     localDht = new S3BlockStorage(S3Config.build(a), Cid.decode(a.getArg("ipfs.id")),
                             props, transactions, ipfs);
                 } else

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -91,6 +91,15 @@ public class DHTHandler implements HttpHandler {
                     }).exceptionally(Futures::logAndThrow).get();
                     break;
                 }
+                case AUTH_READS: {
+                    List<Multihash> blockHashes = Arrays.stream(last.apply("hashes").split(","))
+                            .map(Cid::decode)
+                            .collect(Collectors.toList());
+                    dht.authReads(blockHashes).thenAccept(res -> {
+                        replyBytes(httpExchange, new CborObject.CborList(res).serialize(), Optional.empty());
+                    }).exceptionally(Futures::logAndThrow).get();
+                    break;
+                }
                 case TRANSACTION_START: {
                     AggregatedMetrics.DHT_TRANSACTION_START.inc();
                     PublicKeyHash ownerHash = PublicKeyHash.fromString(last.apply("owner"));

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -93,6 +93,20 @@ public class S3BlockStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+        if (blocks.size() > 50)
+            throw new IllegalStateException("Too many reads to auth!");
+        List<PresignedUrl> res = new ArrayList<>();
+        String host = bucket + "." + regionEndpoint;
+
+        for (Multihash block : blocks) {
+            String s3Key = hashToKey(block);
+            res.add(S3Request.preSignGet(s3Key, ZonedDateTime.now(), host, region, accessKeyId, secretKey));
+        }
+        return Futures.of(res);
+    }
+
+    @Override
     public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
                                                             PublicKeyHash writerHash,
                                                             List<byte[]> signedHashes,

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -121,7 +121,7 @@ public class S3BlockStorage implements ContentAddressedStorage {
                 String host = bucket + "." + regionEndpoint;
                 Map<String, String> extraHeaders = new LinkedHashMap<>();
                 extraHeaders.put("Content-Type", "application/octet-stream");
-                res.add(S3Request.preSignUrl(s3Key, props.right, contentSha256, false,
+                res.add(S3Request.preSignPut(s3Key, props.right, contentSha256, false,
                         ZonedDateTime.now(), "PUT", host, extraHeaders, region, accessKeyId, secretKey));
             }
             return Futures.of(res);

--- a/src/peergos/server/storage/S3Exploration.java
+++ b/src/peergos/server/storage/S3Exploration.java
@@ -18,25 +18,32 @@ class S3Exploration {
 
         for (boolean useIllegalPayload: Arrays.asList(false)) {
 
+            // test a authed PUT
             byte[] payload = "Hi Linode!".getBytes();
             Multihash content = new RAMStorage().put(null, null, null, Arrays.asList(payload), null).join().get(0);
             String s3Key = DirectS3BlockStore.hashToKey(content);
             String host = bucketName + "." + region + ".linodeobjects.com";
             Map<String, String> extraHeaders = new TreeMap<>();
-//            extraHeaders.put("Origin", "https://test.peergos.net");
             extraHeaders.put("Content-Type", "application/octet-stream");
             extraHeaders.put("User-Agent", "Bond, James Bond");
 
             boolean hashContent = true;
             String contentHash = hashContent ? ArrayOps.bytesToHex(content.getHash()) : "UNSIGNED-PAYLOAD";
             String method = "PUT";
-            PresignedUrl url = S3Request.preSignUrl(s3Key, payload.length, contentHash, false,
+            PresignedUrl putUrl = S3Request.preSignPut(s3Key, payload.length, contentHash, false,
                     ZonedDateTime.now().minusMinutes(14), method, host, extraHeaders, region, accessKey, secretKey);
 
-            String res = new String(write(new URI(url.base).toURL(), method, url.fields, useIllegalPayload ? new byte[payload.length] : payload));
+            String res = new String(write(new URI(putUrl.base).toURL(), method, putUrl.fields, useIllegalPayload ? new byte[payload.length] : payload));
             System.out.println(res);
+            // test an authed read
+            PresignedUrl getUrl = S3Request.preSignGet(s3Key, ZonedDateTime.now(), host,
+                    Collections.emptyMap(), region, accessKey, secretKey);
+            String readRes = new String(get(new URI(getUrl.base).toURL(), getUrl.fields));
+            System.out.println(readRes);
+
+            // test a public read
             String webUrl = "https://" + bucketName + ".website-" + region + ".linodeobjects.com/" + s3Key;
-            byte[] getResult = get(new URI(webUrl).toURL());
+            byte[] getResult = get(new URI(webUrl).toURL(), Collections.emptyMap());
             if (! Arrays.equals(getResult, payload))
                 System.out.println("Incorrect contents!");
         }
@@ -73,7 +80,7 @@ class S3Exploration {
         }
     }
 
-    private static byte[] get(URL target) throws Exception {
+    private static byte[] get(URL target, Map<String, String> headers) throws Exception {
         HttpURLConnection conn = (HttpURLConnection) target.openConnection();
         conn.setRequestMethod("GET");
 

--- a/src/peergos/server/storage/S3Exploration.java
+++ b/src/peergos/server/storage/S3Exploration.java
@@ -36,8 +36,7 @@ class S3Exploration {
             String res = new String(write(new URI(putUrl.base).toURL(), method, putUrl.fields, useIllegalPayload ? new byte[payload.length] : payload));
             System.out.println(res);
             // test an authed read
-            PresignedUrl getUrl = S3Request.preSignGet(s3Key, ZonedDateTime.now(), host,
-                    Collections.emptyMap(), region, accessKey, secretKey);
+            PresignedUrl getUrl = S3Request.preSignGet(s3Key, ZonedDateTime.now(), host, region, accessKey, secretKey);
             String readRes = new String(get(new URI(getUrl.base).toURL(), getUrl.fields));
             System.out.println(readRes);
 

--- a/src/peergos/server/tests/S3V4SignatureTests.java
+++ b/src/peergos/server/tests/S3V4SignatureTests.java
@@ -6,7 +6,6 @@ import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
 import peergos.shared.util.*;
 
-import java.security.*;
 import java.time.*;
 import java.util.*;
 
@@ -94,7 +93,7 @@ public class S3V4SignatureTests {
         String signature = S3Request.computeSignature(policy, secretKey);
         Assert.assertTrue(signature.equals("5cc3daea623ac6d43b482209892cc6eb95e46b068e232eabd85343caf79bb17e"));
 
-        PresignedUrl url = S3Request.preSignUrl(s3Key, payload.length, contentSha256, false, timestamp,
+        PresignedUrl url = S3Request.preSignPut(s3Key, payload.length, contentSha256, false, timestamp,
                 "PUT", host, extraHeaders, region, accessKey, secretKey);
         Assert.assertTrue(("AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20200425/us-east-1/s3/aws4_request," +
                 "SignedHeaders=amz-sdk-invocation-id;amz-sdk-retry;content-length;content-type;host;user-agent;x-amz-content-sha256;x-amz-date," +

--- a/src/peergos/shared/storage/BlockStoreProperties.java
+++ b/src/peergos/shared/storage/BlockStoreProperties.java
@@ -5,12 +5,13 @@ import peergos.shared.cbor.*;
 import java.util.*;
 
 public class BlockStoreProperties implements Cborable {
-    public final boolean directWrites, publicReads;
+    public final boolean directWrites, publicReads, authedReads;
     public final Optional<String> baseUrl;
 
-    public BlockStoreProperties(boolean directWrites, boolean publicReads, Optional<String> baseUrl) {
+    public BlockStoreProperties(boolean directWrites, boolean publicReads, boolean authedReads, Optional<String> baseUrl) {
         this.directWrites = directWrites;
         this.publicReads = publicReads;
+        this.authedReads = authedReads;
         this.baseUrl = baseUrl;
     }
 
@@ -19,7 +20,7 @@ public class BlockStoreProperties implements Cborable {
     }
 
     public static BlockStoreProperties empty() {
-        return new BlockStoreProperties(false, false, Optional.empty());
+        return new BlockStoreProperties(false, false, false, Optional.empty());
     }
 
     @Override
@@ -27,6 +28,7 @@ public class BlockStoreProperties implements Cborable {
         Map<String, CborObject> props = new TreeMap<>();
         props.put("w", new CborObject.CborBoolean(directWrites));
         props.put("pr", new CborObject.CborBoolean(publicReads));
+        props.put("ar", new CborObject.CborBoolean(authedReads));
         baseUrl.ifPresent(base -> props.put("b", new CborObject.CborString(base)));
         return CborObject.CborMap.build(props);
     }
@@ -36,6 +38,7 @@ public class BlockStoreProperties implements Cborable {
         Optional<String> base = map.getOptional("b", c -> ((CborObject.CborString)c).value);
         boolean directWrites = map.getBoolean("w");
         boolean publicReads = map.getBoolean("pr");
-        return new BlockStoreProperties(directWrites, publicReads, base);
+        boolean authedReads = map.getBoolean("ar");
+        return new BlockStoreProperties(directWrites, publicReads, authedReads, base);
     }
 }

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -135,6 +135,11 @@ public class CachingStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+        return target.authReads(blocks);
+    }
+
+    @Override
     public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -346,6 +346,18 @@ public interface ContentAddressedStorage {
         }
 
         @Override
+        public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+            if (! isPeergosServer)
+                return Futures.errored(new IllegalStateException("Cannot auth reads when not talking to a Peergos server!"));
+            return poster.get(apiPrefix + AUTH_READS
+                    + "?hashes=" + blocks.stream().map(x -> x.toString()).collect(Collectors.joining(",")))
+                    .thenApply(raw -> ((CborObject.CborList)CborObject.fromByteArray(raw)).value
+                            .stream()
+                            .map(PresignedUrl::fromCbor)
+                            .collect(Collectors.toList()));
+        }
+
+        @Override
         public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
                                                                 PublicKeyHash writer,
                                                                 List<byte[]> signedHashes,

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -28,6 +28,10 @@ public interface ContentAddressedStorage {
         return Futures.of(BlockStoreProperties.empty());
     }
 
+    default CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+        return Futures.errored(new IllegalStateException("Unimplemented call!"));
+    }
+
     default CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
                                                              PublicKeyHash writer,
                                                              List<byte[]> signedHashes,
@@ -283,6 +287,7 @@ public interface ContentAddressedStorage {
         private static final String apiPrefix = "api/v0/";
         public static final String ID = "id";
         public static final String BLOCKSTORE_PROPERTIES = "blockstore/props";
+        public static final String AUTH_READS = "blockstore/auth-reads";
         public static final String AUTH_WRITES = "blockstore/auth";
         public static final String TRANSACTION_START = "transaction/start";
         public static final String TRANSACTION_CLOSE = "transaction/close";
@@ -520,6 +525,11 @@ public interface ContentAddressedStorage {
         @Override
         public CompletableFuture<BlockStoreProperties> blockStoreProperties() {
             return local.blockStoreProperties();
+        }
+
+        @Override
+        public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+            return local.authReads(blocks);
         }
 
         @Override

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -50,6 +50,11 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+        return source.authReads(blocks);
+    }
+
+    @Override
     public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -30,6 +30,11 @@ public class WriteFilter implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+        return dht.authReads(blocks);
+    }
+
+    @Override
     public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,


### PR DESCRIPTION
This is a fallback in case we are using a S3 that charges for egress, and we get DOSsed. 

This gracefully degrades to authing reads with the Peergos server, thus keeping most of the bandwidth on S3, but giving a point to filter the DOS. 