### PR TITLE
Bulk auth direct s3 reads

### DIFF
--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -544,9 +544,10 @@ public class NetworkAccess {
                 .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
     }
 
-    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
-                                                                       ProgressConsumer<Long> monitor,
-                                                                       double spaceIncreaseFactor) {
+    public static CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
+                                                                              ContentAddressedStorage dhtClient,
+                                                                              ProgressConsumer<Long> monitor,
+                                                                              double spaceIncreaseFactor) {
         List<CompletableFuture<Optional<FragmentWithHash>>> futures = hashes.stream().parallel()
                 .map(h -> (h.isIdentity() ?
                         CompletableFuture.completedFuture(Optional.of(h.getHash())) :

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -92,7 +92,7 @@ public class FragmentedPaddedCipherText implements Cborable {
                                                   Function<CborObject, T> fromCbor,
                                                   NetworkAccess network,
                                                   ProgressConsumer<Long> monitor) {
-        return network.downloadFragments(cipherTextFragments, monitor, 1.0)
+        return network.dhtClient.downloadFragments(cipherTextFragments, monitor, 1.0)
                 .thenApply(fargs -> new CipherText(nonce, recombine(fargs)).decrypt(from, fromCbor));
     }
 

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -2,8 +2,8 @@ package peergos.shared.storage;
 
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.io.ipfs.multiaddr.*;
 import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -132,6 +132,13 @@ public class CachingStorage implements ContentAddressedStorage {
             pipe.completeExceptionally(t);
             return null;
         });
+    }
+
+    @Override
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
+                                                                       ProgressConsumer<Long> monitor,
+                                                                       double spaceIncreaseFactor) {
+        return target.downloadFragments(hashes, monitor, spaceIncreaseFactor);
     }
 
     @Override

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -10,6 +10,7 @@ import peergos.shared.io.ipfs.api.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.io.*;
@@ -179,6 +180,12 @@ public interface ContentAddressedStorage {
      * @return The size in bytes, or Optional.empty() if it cannot be found.
      */
     CompletableFuture<Optional<Integer>> getSize(Multihash block);
+
+    default CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
+                                                                        ProgressConsumer<Long> monitor,
+                                                                        double spaceIncreaseFactor) {
+        return NetworkAccess.downloadFragments(hashes, this, monitor, spaceIncreaseFactor);
+    }
 
     default CompletableFuture<PublicKeyHash> putSigningKey(byte[] signature,
                                                            PublicKeyHash owner,

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -1,0 +1,110 @@
+package peergos.shared.storage;
+
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public abstract class DelegatingStorage implements ContentAddressedStorage {
+
+    private final ContentAddressedStorage target;
+
+    public DelegatingStorage(ContentAddressedStorage target) {
+        this.target = target;
+    }
+
+    @Override
+    public CompletableFuture<BlockStoreProperties> blockStoreProperties() {
+        return target.blockStoreProperties();
+    }
+    @Override
+    public CompletableFuture<Multihash> id() {
+        return target.id();
+    }
+
+    @Override
+    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
+        return target.startTransaction(owner);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
+        return target.closeTransaction(owner, tid);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, TransactionId tid) {
+        return target.put(owner, writer, signatures, blocks, tid);
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(Multihash hash) {
+        return target.get(hash);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, TransactionId tid) {
+        return target.putRaw(owner, writer, signatures, blocks, tid);
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Multihash hash) {
+        return target.getRaw(hash);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> pinUpdate(PublicKeyHash owner, Multihash existing, Multihash updated) {
+        return target.pinUpdate(owner, existing, updated);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursivePin(PublicKeyHash owner, Multihash hash) {
+        return target.recursivePin(owner, hash);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursiveUnpin(PublicKeyHash owner, Multihash hash) {
+        return target.recursiveUnpin(owner, hash);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> gc() {
+        return target.gc();
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> getLinks(Multihash root) {
+        return target.getLinks(root);
+    }
+
+    @Override
+    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
+        return target.getSize(block);
+    }
+
+    @Override
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
+                                                                       ProgressConsumer<Long> monitor,
+                                                                       double spaceIncreaseFactor) {
+        return target.downloadFragments(hashes, monitor, spaceIncreaseFactor);
+    }
+
+    @Override
+    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
+        return target.authReads(blocks);
+    }
+
+    @Override
+    public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
+                                                            PublicKeyHash writer,
+                                                            List<byte[]> signedHashes,
+                                                            List<Integer> blockSizes,
+                                                            boolean isRaw,
+                                                            TransactionId tid) {
+        return target.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
+    }
+}

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -3,8 +3,8 @@ package peergos.shared.storage;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.cid.*;
-import peergos.shared.io.ipfs.multiaddr.*;
 import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -52,6 +52,13 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
         return source.authReads(blocks);
+    }
+
+    @Override
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
+                                                                       ProgressConsumer<Long> monitor,
+                                                                       double spaceIncreaseFactor) {
+        return source.downloadFragments(hashes, monitor, spaceIncreaseFactor);
     }
 
     @Override

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -4,7 +4,6 @@ import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multihash.*;
-import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -12,12 +11,13 @@ import java.util.concurrent.*;
 import java.util.function.*;
 import java.util.stream.*;
 
-public class HashVerifyingStorage implements ContentAddressedStorage {
+public class HashVerifyingStorage extends DelegatingStorage {
 
     private final ContentAddressedStorage source;
     private final Hasher hasher;
 
     public HashVerifyingStorage(ContentAddressedStorage source, Hasher hasher) {
+        super(source);
         this.source = source;
         this.hasher = hasher;
     }
@@ -42,48 +42,6 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
                 throw new IllegalStateException("Incorrect identity hash! This shouldn't ever  happen.");
             default: throw new IllegalStateException("Unimplemented hash algorithm: " + claimed.type);
         }
-    }
-
-    @Override
-    public CompletableFuture<Multihash> id() {
-        return source.id();
-    }
-
-    @Override
-    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
-        return source.authReads(blocks);
-    }
-
-    @Override
-    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
-                                                                       ProgressConsumer<Long> monitor,
-                                                                       double spaceIncreaseFactor) {
-        return source.downloadFragments(hashes, monitor, spaceIncreaseFactor);
-    }
-
-    @Override
-    public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
-                                                            PublicKeyHash writer,
-                                                            List<byte[]> signedHashes,
-                                                            List<Integer> blockSizes,
-                                                            boolean isRaw,
-                                                            TransactionId tid) {
-        return source.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
-    }
-
-    @Override
-    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
-        return source.startTransaction(owner);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
-        return source.closeTransaction(owner, tid);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> gc() {
-        return source.gc();
     }
 
     @Override
@@ -124,30 +82,5 @@ public class HashVerifyingStorage implements ContentAddressedStorage {
                 .thenCompose(arrOpt -> arrOpt.map(bytes -> verify(bytes, hash, () -> bytes)
                         .thenApply(Optional::of))
                         .orElseGet(() -> Futures.of(Optional.empty())));
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> pinUpdate(PublicKeyHash owner, Multihash existing, Multihash updated) {
-        return source.pinUpdate(owner, existing, updated);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> recursivePin(PublicKeyHash owner, Multihash h) {
-        return source.recursivePin(owner, h);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> recursiveUnpin(PublicKeyHash owner, Multihash h) {
-        return source.recursiveUnpin(owner, h);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> getLinks(Multihash root) {
-        return source.getLinks(root);
-    }
-
-    @Override
-    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
-        return source.getSize(block);
     }
 }

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -1,45 +1,21 @@
 package peergos.shared.storage;
 
-import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
-import peergos.shared.user.fs.*;
-import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
 
-public class WriteFilter implements ContentAddressedStorage {
+public class WriteFilter extends DelegatingStorage {
 
     private final ContentAddressedStorage dht;
     private final BiFunction<PublicKeyHash, Integer, Boolean> keyFilter;
 
     public WriteFilter(ContentAddressedStorage dht, BiFunction<PublicKeyHash, Integer, Boolean> keyFilter) {
+        super(dht);
         this.dht = dht;
         this.keyFilter = keyFilter;
-    }
-
-    @Override
-    public CompletableFuture<Multihash> id() {
-        return dht.id();
-    }
-
-    @Override
-    public CompletableFuture<BlockStoreProperties> blockStoreProperties() {
-        return dht.blockStoreProperties();
-    }
-
-    @Override
-    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
-                                                                       ProgressConsumer<Long> monitor,
-                                                                       double spaceIncreaseFactor) {
-        return dht.downloadFragments(hashes, monitor, spaceIncreaseFactor);
-    }
-
-    @Override
-    public CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
-        return dht.authReads(blocks);
     }
 
     @Override
@@ -52,41 +28,6 @@ public class WriteFilter implements ContentAddressedStorage {
         if (! keyFilter.apply(writer, blockSizes.stream().mapToInt(x -> x).sum()))
             throw new IllegalStateException("Key not allowed to write to this server: " + writer);
         return dht.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
-    }
-
-    @Override
-    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
-        return dht.startTransaction(owner);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
-        return dht.closeTransaction(owner, tid);
-    }
-
-    @Override
-    public CompletableFuture<Boolean> gc() {
-        return dht.gc();
-    }
-
-    @Override
-    public CompletableFuture<Optional<CborObject>> get(Multihash object) {
-        return dht.get(object);
-    }
-
-    @Override
-    public CompletableFuture<Optional<byte[]>> getRaw(Multihash object) {
-        return dht.getRaw(object);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> getLinks(Multihash root) {
-        return dht.getLinks(root);
-    }
-
-    @Override
-    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
-        return dht.getSize(block);
     }
 
     @Override
@@ -109,20 +50,5 @@ public class WriteFilter implements ContentAddressedStorage {
         if (! keyFilter.apply(writer, blocks.stream().mapToInt(x -> x.length).sum()))
             throw new IllegalStateException("Key not allowed to write to this server: " + writer);
         return dht.putRaw(owner, writer, signatures, blocks, tid);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> pinUpdate(PublicKeyHash owner, Multihash existing, Multihash updated) {
-        return dht.pinUpdate(owner, existing, updated);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> recursivePin(PublicKeyHash owner, Multihash h) {
-        return dht.recursivePin(owner, h);
-    }
-
-    @Override
-    public CompletableFuture<List<Multihash>> recursiveUnpin(PublicKeyHash owner, Multihash h) {
-        return dht.recursiveUnpin(owner, h);
     }
 }

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -2,8 +2,9 @@ package peergos.shared.storage;
 
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.io.ipfs.multiaddr.*;
 import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
@@ -27,6 +28,13 @@ public class WriteFilter implements ContentAddressedStorage {
     @Override
     public CompletableFuture<BlockStoreProperties> blockStoreProperties() {
         return dht.blockStoreProperties();
+    }
+
+    @Override
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Multihash> hashes,
+                                                                       ProgressConsumer<Long> monitor,
+                                                                       double spaceIncreaseFactor) {
+        return dht.downloadFragments(hashes, monitor, spaceIncreaseFactor);
     }
 
     @Override


### PR DESCRIPTION
Replace 40 auth read calls for direct (non public) S3 access with a single call per chunk