### PR TITLE
Implement CommittableStorage which removes the linear sequential chain

### DIFF
--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -65,10 +65,10 @@ public class FileContentAddressedStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return put(owner, writer, signatures, blocks, false, tid);
+        return put(owner, writer, signedHashes, blocks, false, tid);
     }
 
     @Override

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -97,10 +97,10 @@ public class GarbageCollector implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return target.put(owner, writer, signatures, blocks, tid);
+        return target.put(owner, writer, signedHashes, blocks, tid);
     }
 
     @Override

--- a/src/peergos/server/storage/IpfsDHT.java
+++ b/src/peergos/server/storage/IpfsDHT.java
@@ -64,10 +64,10 @@ public class IpfsDHT implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return put(writer, signatures, blocks, "cbor", tid);
+        return put(writer, signedHashes, blocks, "cbor", tid);
     }
 
     @Override

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -41,10 +41,10 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return modifications.put(owner, writer, signatures, blocks, tid);
+        return modifications.put(owner, writer, signedHashes, blocks, tid);
     }
 
     @Override

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -43,7 +43,7 @@ public class RAMStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
         return put(writer, blocks, false);

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -312,10 +312,10 @@ public class S3BlockStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return put(owner, writer, signatures, blocks, false, tid);
+        return put(owner, writer, signedHashes, blocks, false, tid);
     }
 
     @Override

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -219,7 +219,7 @@ public class NetworkAccess {
                     SpaceUsage p2pUsage = isPeergosServer ?
                             httpUsage :
                             new ProxyingSpaceUsage(nodeId, core, httpUsage, httpUsage);
-                    return build(p2pDht, core, p2pMutable, p2pSocial, new HttpInstanceAdmin(apiPoster), p2pUsage, usernames, isJavascript);
+                    return build(new CommittableStorage(p2pDht), core, p2pMutable, p2pSocial, new HttpInstanceAdmin(apiPoster), p2pUsage, usernames, isJavascript);
                 });
     }
 

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -27,10 +27,10 @@ public class CachingStorage extends DelegatingStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return target.put(owner, writer, signatures, blocks, tid)
+        return target.put(owner, writer, signedHashes, blocks, tid)
                 .thenApply(res -> {
                     for (int i=0; i < blocks.size(); i++) {
                         byte[] block = blocks.get(i);

--- a/src/peergos/shared/storage/CommittableStorage.java
+++ b/src/peergos/shared/storage/CommittableStorage.java
@@ -20,9 +20,12 @@ public class CommittableStorage extends DelegatingStorage {
         this.target = target;
     }
 
-    public synchronized CompletableFuture<Boolean> flush() {
-        List<PutArgs> local = new ArrayList<>(pending);
-        pending.clear();
+    public CompletableFuture<Boolean> flush() {
+        List<PutArgs> local;
+        synchronized (pending) {
+            local = new ArrayList<>(pending);
+            pending.clear();
+        }
         List<CompletableFuture<Multihash>> uploads = local.stream()
                 .map(p -> target.put(p.owner, p.writer, p.signature, p.block, p.tid)
                         .thenApply(h -> {

--- a/src/peergos/shared/storage/CommittableStorage.java
+++ b/src/peergos/shared/storage/CommittableStorage.java
@@ -1,0 +1,71 @@
+package peergos.shared.storage;
+
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.cid.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+
+public class CommittableStorage extends DelegatingStorage {
+    private static final int CID_V1 = 1;
+
+    private final ContentAddressedStorage target;
+    private final List<PutArgs> pending = new ArrayList<>();
+
+    public CommittableStorage(ContentAddressedStorage target) {
+        super(target);
+        this.target = target;
+    }
+
+    public synchronized CompletableFuture<Boolean> flush() {
+        List<PutArgs> local = new ArrayList<>(pending);
+        pending.clear();
+        List<CompletableFuture<Multihash>> uploads = local.stream()
+                .map(p -> target.put(p.owner, p.writer, p.signature, p.block, p.tid)
+                        .thenApply(h -> {
+                            if (! h.equals(p.expected))
+                                throw new IllegalStateException("Different hash returned from block write than expected!");
+                            return h;
+                        }))
+                .collect(Collectors.toList());
+        return Futures.combineAllInOrder(uploads)
+                .thenApply(x -> true);
+    }
+
+    @Override
+    public CompletableFuture<Multihash> put(PublicKeyHash owner,
+                                            PublicKeyHash writer,
+                                            byte[] signature,
+                                            byte[] block,
+                                            TransactionId tid) {
+        byte[] sha256 = Arrays.copyOfRange(signature, signature.length - 32, signature.length);
+        Cid cid = hashToCid(sha256, false);
+        synchronized (pending) {
+            pending.add(new PutArgs(owner, writer, cid, signature, block, tid));
+        }
+        return Futures.of(cid);
+    }
+
+    public static Cid hashToCid(byte[] sha256, boolean isRaw) {
+        return new Cid(CID_V1, isRaw ? Cid.Codec.Raw : Cid.Codec.DagCbor, Multihash.Type.sha2_256, sha256);
+    }
+
+    private static class PutArgs {
+        public final PublicKeyHash owner, writer;
+        public final Multihash expected;
+        public final byte[] signature, block;
+        public final TransactionId tid;
+
+        public PutArgs(PublicKeyHash owner, PublicKeyHash writer, Multihash expected, byte[] signature, byte[] block, TransactionId tid) {
+            this.owner = owner;
+            this.writer = writer;
+            this.expected = expected;
+            this.signature = signature;
+            this.block = block;
+            this.tid = tid;
+        }
+    }
+}

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -37,8 +37,8 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<Multihash>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signatures, List<byte[]> blocks, TransactionId tid) {
-        return target.put(owner, writer, signatures, blocks, tid);
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid) {
+        return target.put(owner, writer, signedHashes, blocks, tid);
     }
 
     @Override
@@ -54,6 +54,11 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
                                                      TransactionId tid,
                                                      ProgressConsumer<Long> progressCounter) {
         return target.putRaw(owner, writer, signatures, blocks, tid, progressCounter);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> flush() {
+        return target.flush();
     }
 
     @Override

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -71,13 +71,13 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
         return onOwnersNode(owner).thenCompose(ownersNode -> {
             if (ownersNode && directWrites) {
                 CompletableFuture<List<Multihash>> res = new CompletableFuture<>();
-                fallback.authWrites(owner, writer, signatures, blocks.stream().map(x -> x.length).collect(Collectors.toList()), false, tid)
+                fallback.authWrites(owner, writer, signedHashes, blocks.stream().map(x -> x.length).collect(Collectors.toList()), false, tid)
                         .thenCompose(preAuthed -> {
                             List<CompletableFuture<Multihash>> futures = new ArrayList<>();
                             for (int i = 0; i < blocks.size(); i++) {
@@ -91,7 +91,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
                         .exceptionally(res::completeExceptionally);
                 return res;
             }
-            return fallback.put(owner, writer, signatures, blocks, tid);
+            return fallback.put(owner, writer, signedHashes, blocks, tid);
         });
     }
 

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -47,10 +47,10 @@ public class HashVerifyingStorage extends DelegatingStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
-        return source.put(owner, writer, signatures, blocks, tid)
+        return source.put(owner, writer, signedHashes, blocks, tid)
                 .thenCompose(hashes -> Futures.combineAllInOrder(hashes.stream()
                         .map(h -> verify(blocks.get(hashes.indexOf(h)), h, () -> h))
                         .collect(Collectors.toList())));

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -34,12 +34,12 @@ public class WriteFilter extends DelegatingStorage {
     @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
-                                                  List<byte[]> signatures,
+                                                  List<byte[]> signedHashes,
                                                   List<byte[]> blocks,
                                                   TransactionId tid) {
         if (! keyFilter.apply(writer, blocks.stream().mapToInt(x -> x.length).sum()))
             throw new IllegalStateException("Key not allowed to write to this server: " + writer);
-        return dht.put(owner, writer, signatures, blocks, tid);
+        return dht.put(owner, writer, signedHashes, blocks, tid);
     }
 
     @Override

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -263,6 +263,7 @@ public class WriterData implements Cborable {
 
         return hasher.sha256(raw)
                 .thenCompose(hash -> immutable.put(owner, signer.publicKeyHash, signer.secret.signMessage(hash), raw, tid))
+                .thenCompose(blobHash -> immutable.flush().thenApply(x -> blobHash))
                 .thenCompose(blobHash -> {
                     MaybeMultihash newHash = MaybeMultihash.of(blobHash);
                     if (newHash.equals(currentHash)) {


### PR DESCRIPTION
of block puts after each chunk to update the champ.

It does this by evaluating the writes locally, and then pushing all the
blocks just before committing them with a mutable pointer write.