### PR TITLE
Expose direct file modification without going via the parent.

### DIFF
--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -354,14 +354,13 @@ public abstract class UserTests {
         SigningPrivateKeyAndPublicHash writer = fileV2.signingPair();
         network.synchronizer.applyComplexUpdate(owner, writer,
                 (v, c) -> fileV2.overwriteSection(v, c, AsyncReader.build(section1),
-                        1024, 1024 + section1.length, userRoot.getLocation(), network, crypto, x -> {})).join();
+                        1024, 1024 + section1.length, network, crypto, x -> {})).join();
         System.out.println();
         byte[] section2 = "22222222".getBytes();
         try {
             network.synchronizer.applyComplexUpdate(owner, writer,
                     (v, c) -> fileV1.overwriteSection(v, c, AsyncReader.build(section2),
-                            1024, 1024 + section2.length, userRoot.getLocation(), network, crypto, x -> {
-                            })).join();
+                            1024, 1024 + section2.length, network, crypto, x -> {})).join();
             throw new RuntimeException("Concurrentmodification should have failed!");
         } catch (CompletionException c) {
             if (!(c.getCause() instanceof MutableTree.CasException))

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -562,7 +562,6 @@ public class FileWrapper {
                                                         AsyncReader fileData,
                                                         long inputStartIndex,
                                                         long endIndex,
-                                                        Location parentLocation,
                                                         NetworkAccess network,
                                                         Crypto crypto,
                                                         ProgressConsumer<Long> monitor) {
@@ -578,6 +577,7 @@ public class FileWrapper {
         Supplier<Location> locationSupplier = () -> new Location(getLocation().owner, getLocation().writer, crypto.random.randomBytes(32));
 
         SymmetricKey parentParentKey = getPointer().getParentParentKey();
+        Location parentLocation = getPointer().getParentCap().getLocation(owner(), writer());
         WritableAbsoluteCapability childCap = writableFilePointer();
         return current.withWriter(owner(), writer(), network)
                 .thenCompose(base -> {
@@ -968,7 +968,7 @@ public class FileWrapper {
                                         .thenApply(cleanedChild -> cleanedChild.get())) :
                         CompletableFuture.completedFuture(existingChild))
                 ).thenCompose(updatedChild -> updatedChild.overwriteSection(updatedChild.version, committer, fileData,
-                        inputStartIndex, endIndex, getLocation(), network, crypto, monitor));
+                        inputStartIndex, endIndex, network, crypto, monitor));
     }
 
     static boolean isLegalName(String name) {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -520,7 +520,7 @@ public class FileWrapper {
                                                        Crypto crypto,
                                                        ProgressConsumer<Long> monitor,
                                                        TransactionService transactions) {
-        long fileSize = (lengthLow & 0xFFFFFFFFL) + ((lengthHi & 0xFFFFFFFFL) << 32);
+        long fileSize = LongUtil.intsToLong(lengthHi, lengthLow);
         if (transactions == null) // we are in a public writable link
             return network.synchronizer.applyComplexUpdate(owner(), signingPair(),
                     (s, committer) -> uploadFileSection(s, committer, filename, fileData,
@@ -555,6 +555,21 @@ public class FileWrapper {
                                                                 byte[] firstChunkMapKey) {
         return uploadFileSection(filename, fileData, false, 0, length, Optional.empty(),
                 true, network, crypto, monitor, firstChunkMapKey);
+    }
+
+    @JsMethod
+    public CompletableFuture<Snapshot> overwriteSectionJS(AsyncReader fileData,
+                                                          int startHigh,
+                                                          int startLow,
+                                                          int endHigh,
+                                                          int endLow,
+                                                          NetworkAccess network,
+                                                          Crypto crypto,
+                                                          ProgressConsumer<Long> monitor) {
+        return network.synchronizer.applyComplexUpdate(owner(), signingPair(),
+                (s, committer) -> overwriteSection(s, committer, fileData,
+                        LongUtil.intsToLong(startHigh, startLow),
+                        LongUtil.intsToLong(endHigh, endLow), network, crypto, monitor));
     }
 
     public CompletableFuture<Snapshot> overwriteSection(Snapshot current,

--- a/src/peergos/shared/user/fs/RetrievedCapability.java
+++ b/src/peergos/shared/user/fs/RetrievedCapability.java
@@ -35,6 +35,10 @@ public class RetrievedCapability {
         return fileAccess.getParentCapability(capability.rBaseKey).get().rBaseKey;
     }
 
+    public RelativeCapability getParentCap() {
+        return fileAccess.getParentCapability(capability.rBaseKey).get();
+    }
+
     private static SymmetricKey getParentKey(CryptreeNode node, SymmetricKey baseKey) {
         if (node.isDirectory())
             try {

--- a/src/peergos/shared/user/fs/RetrievedCapability.java
+++ b/src/peergos/shared/user/fs/RetrievedCapability.java
@@ -31,6 +31,10 @@ public class RetrievedCapability {
         return fileAccess.getProperties(getParentKey());
     }
 
+    public SymmetricKey getParentParentKey() {
+        return fileAccess.getParentCapability(capability.rBaseKey).get().rBaseKey;
+    }
+
     private static SymmetricKey getParentKey(CryptreeNode node, SymmetricKey baseKey) {
         if (node.isDirectory())
             try {
@@ -40,8 +44,6 @@ public class RetrievedCapability {
             }
         return baseKey;
     }
-
-
 
     public RetrievedCapability withCryptree(CryptreeNode fileAccess) {
         return new RetrievedCapability(capability, fileAccess);

--- a/src/peergos/shared/util/LongUtil.java
+++ b/src/peergos/shared/util/LongUtil.java
@@ -1,0 +1,8 @@
+package peergos.shared.util;
+
+public class LongUtil {
+
+    public static long intsToLong(int high, int low) {
+        return (low & 0xFFFFFFFFL) + ((high & 0xFFFFFFFFL) << 32);
+    }
+}


### PR DESCRIPTION
This is largely a refactor, though I did catch one bug in the refactor. 

It allows us to modify a file directly, without a reference to the parent. If the file has been modified concurrently in an overlapping chunk then it will fail with a CasException