### PR TITLE
[print-test-errors]

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -114,7 +114,7 @@
       <map from="${test.sources}/" to="" />
     </pathconvert>
     <!-- run one particular test -->
-    <junit fork="true" printsummary="true" haltonfailure="yes">
+    <junit fork="true" printsummary="true" haltonfailure="no">
       <jvmarg value="-Xmx2g"/>
       <jvmarg value="-Djava.library.path=native-lib"/>
       <classpath>

--- a/build.xml
+++ b/build.xml
@@ -103,6 +103,8 @@
   </target>
 
   <target name="test" depends="parallel_test">
+    <exec executable="./print_test_errors.sh">
+    </exec>
   </target> 
 
   <target name="execute.test">

--- a/print_test_errors.sh
+++ b/print_test_errors.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+awk '/<error/,/\/error/ {print prev} {prev=$0}'  test.reports/*

--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -18,7 +18,6 @@ public class CborObjects {
 
     @Test
     public void dosCborObject() throws Throwable {
-        if(true)throw new RuntimeException();
         // make a header for a byte[] that is 2^50 long
         byte[] raw = ArrayOps.hexToBytes("5b0004000000000000");
         try {

--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -18,6 +18,7 @@ public class CborObjects {
 
     @Test
     public void dosCborObject() throws Throwable {
+        if(true)throw new RuntimeException();
         // make a header for a byte[] that is 2^50 long
         byte[] raw = ArrayOps.hexToBytes("5b0004000000000000");
         try {


### PR DESCRIPTION
This  script  parses the junit logs in  test.reports and prints any
testcase that had an error, including the stacktrace.