### PR TITLE
Simplify createFiletree during login

### DIFF
--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -10,7 +10,7 @@ import java.util.function.*;
 
 public class FriendSourcedTrieNode implements TrieNode {
 
-    private final String ownerName;
+    public final String ownerName;
     private final Supplier<CompletableFuture<FileWrapper>> homeDirSupplier;
     private final EntryPoint sharedDir;
     private final Crypto crypto;


### PR DESCRIPTION
Ensure we build our friend sourced entrie nodes in parallel during login, even on the JVM.

This halves createFileTree time from 12s to 6s for a user with 20 friends