### PR TITLE
Rewrite shared-with cache

### DIFF
--- a/src/peergos/client/PathUtils.java
+++ b/src/peergos/client/PathUtils.java
@@ -1,0 +1,40 @@
+package peergos.client;
+
+import jsinterop.annotations.JsMethod;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PathUtils {
+
+    @JsMethod
+    public static Path directoryToPath(String[] parts) {
+        if (parts == null || parts.length == 0) {
+            throw new IllegalArgumentException("Invalid params");
+        }else if (parts.length == 1) {
+            return Paths.get(parts[0]);
+        } else {
+            List<String> pathFragments = Stream.of(parts).skip(1).collect(Collectors.toList());
+            String[] remainder = pathFragments.toArray(new String[1]);
+            return Paths.get(parts[0], remainder);
+        }
+    }
+
+    @JsMethod
+    public static Path toPath(String[] parts, String filename) {
+        if (parts == null || parts.length == 0 || filename == null) {
+            throw new IllegalArgumentException("Invalid params");
+        }else if (parts.length == 1) {
+            return Paths.get(parts[0], filename);
+        } else {
+            List<String> pathFragments = Stream.of(parts).skip(1).collect(Collectors.toList());
+            pathFragments.add(filename);
+            String[] remainder = pathFragments.toArray(new String[1]);
+            return Paths.get(parts[0], remainder);
+        }
+    }
+
+}

--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -22,7 +22,7 @@ public class Path {
 
         int index = pathString.lastIndexOf(SEPARATOR);
         if (index == -1) {
-            throw new IllegalArgumentException("Illegal path");
+            return null;
         } else if (index == 0) {
             String name = pathString.substring(index);
             if(name.equals(SEPARATOR)) {
@@ -57,15 +57,27 @@ public class Path {
     }
 
     public File toFile() {
-        throw new IllegalArgumentException("Not implemented!");
+        return new File(toString());
     }
 
     public Path getName(int index) {
-        throw new IllegalArgumentException("Not implemented!");
+        if (index < 0) {
+            throw new IllegalArgumentException();
+        }
+        String withoutLeadingSlash = pathString.startsWith(SEPARATOR) ? pathString.substring(1)
+                : pathString;
+        String[] parts = withoutLeadingSlash.split(SEPARATOR);
+        if (index >= parts.length) {
+            throw new IllegalArgumentException();
+        }
+        return new Path(parts[index]);
     }
 
     public int getNameCount() {
-        throw new IllegalArgumentException("Not implemented!");
+        if (pathString.length() == 0) {
+            return 1;
+        }
+        return pathString.length() - pathString.replace(SEPARATOR, "").length();
     }
 
     public Path subpath(int from, int to) {

--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -77,7 +77,9 @@ public class Path {
         if (pathString.length() == 0) {
             return 1;
         }
-        return pathString.length() - pathString.replace(SEPARATOR, "").length();
+        String withoutLeadingSlash = pathString.startsWith(SEPARATOR) ? pathString.substring(1)
+                : pathString;
+        return 1 + withoutLeadingSlash.length() - withoutLeadingSlash.replace(SEPARATOR, "").length();
     }
 
     public Path subpath(int from, int to) {

--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -44,6 +44,9 @@ public class Path {
     }
 
     public Path resolve(String other) {
+        if(other.startsWith(SEPARATOR)) {
+            return new Path(other);
+        }
         if (pathString.endsWith(SEPARATOR))
             return new Path(pathString + other);
         return new Path(pathString + "/" + other);
@@ -88,7 +91,23 @@ public class Path {
     }
 
     public Path subpath(int from, int to) {
-        throw new IllegalArgumentException("Not implemented!");
+        if (from < 0) {
+            throw new IllegalArgumentException();
+        }
+        String withoutLeadingSlash = pathString.startsWith(SEPARATOR) ? pathString.substring(1)
+                : pathString;
+        String[] parts = withoutLeadingSlash.split(SEPARATOR);
+        if (to > parts.length) {
+            throw new IllegalArgumentException();
+        }
+        StringBuilder sb = new StringBuilder();
+        for(int i = from; i < to; i++) {
+            sb.append(parts[i]);
+            if(i < to -1){
+                sb.append(SEPARATOR);
+            }
+        }
+        return new Path(sb.toString());
     }
 
 

--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -35,7 +35,12 @@ public class Path {
     }
 
     public Path getFileName() {
-        throw new IllegalArgumentException("Not implemented!");
+        int idx = pathString.lastIndexOf(SEPARATOR);
+        if (idx == -1) {
+            return new Path(pathString);
+        }
+        String filename = pathString.substring(idx+1);
+        return new Path(filename);
     }
 
     public Path resolve(String other) {

--- a/src/peergos/gwt/emu/java/nio/file/Paths.java
+++ b/src/peergos/gwt/emu/java/nio/file/Paths.java
@@ -1,6 +1,8 @@
 package java.nio.file;
 
 
+import jsinterop.annotations.*;
+
 import java.util.*;
 import java.util.stream.*;
 
@@ -10,6 +12,7 @@ public class Paths {
     private static final String ERROR_MSG_VARARGS = "Paths.get() does not support varargs";
     private static final String ERROR_MSG_UNINITIALISED = "Paths.get() does not support uninitialised path string";
 
+    @JsMethod
     public static Path get(String firstPath, String... pathString) {
         if (firstPath == null) {
             throw new IllegalArgumentException(ERROR_MSG_NULL_PATH);

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -176,7 +176,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
                 return -ErrorCodes.ENOENT();
 
             FileWrapper parent = sourceParent.treeNode;
-            FileWrapper updatedParent = source.treeNode.rename(targetFilename, parent, context).get();
+            FileWrapper updatedParent = source.treeNode.rename(targetFilename, parent, Paths.get(sourcePath), context).get();
             // TODO clean up on error conditions
             if (! parent.equals(newParent.get())) {
                 Path renamedInPlacePath = Paths.get(sourcePath).getParent().resolve(requested.getFileName().toString());

--- a/src/peergos/server/fuse/PeergosFS.java
+++ b/src/peergos/server/fuse/PeergosFS.java
@@ -142,11 +142,11 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             if (!file.isPresent())
                 return -ErrorCodes.ENOENT();
 
-            Optional<FileWrapper> parent = context.getByPath(requested.getParent().toString()).get();;
+            Optional<FileWrapper> parent = context.getByPath(requested.getParent()).get();;
             if (!parent.isPresent())
                 return -ErrorCodes.ENOENT();
 
-            FileWrapper updatedParent = file.get().remove(parent.get(), context).get();
+            FileWrapper updatedParent = file.get().remove(parent.get(), requested, context).get();
             return 0;
         } catch (Exception ioe) {
             LOG.log(Level.WARNING, ioe.getMessage(), ioe);
@@ -158,7 +158,7 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
     public int rmdir(String s) {
         ensureNotClosed();
         Path dir = Paths.get(s);
-        return applyIfPresent(s, (stat) -> applyIfPresent(dir.getParent().toString(), parentStat -> rmdir(stat, parentStat)));
+        return applyIfPresent(s, (stat) -> applyIfPresent(dir.getParent().toString(), parentStat -> rmdir(stat, dir, parentStat)));
     }
 
     @Override
@@ -180,11 +180,11 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
             // TODO clean up on error conditions
             if (! parent.equals(newParent.get())) {
                 Path renamedInPlacePath = Paths.get(sourcePath).getParent().resolve(requested.getFileName().toString());
-                Optional<FileWrapper> renamedOriginal = context.getByPath(renamedInPlacePath.toString()).get();
+                Optional<FileWrapper> renamedOriginal = context.getByPath(renamedInPlacePath).get();
                 if (! renamedOriginal.isPresent())
                     return -ErrorCodes.ENOENT();
                 renamedOriginal.get().copyTo(newParent.get(), context).get();
-                FileWrapper updatedParent2 = renamedOriginal.get().remove(parent, context).get();
+                FileWrapper updatedParent2 = renamedOriginal.get().remove(parent, renamedInPlacePath, context).get();
             }
             return 0;
         } catch (Exception ioe) {
@@ -485,10 +485,10 @@ public class PeergosFS extends FuseStubFS implements AutoCloseable {
         return applyIfPresent(parentPath, parentStat -> applyIfPresent(filePath, fileStat -> func.apply(parentStat, fileStat)), aDefault);
     }
 
-    private int rmdir(PeergosStat stat, PeergosStat parentStat) {
+    private int rmdir(PeergosStat stat, Path dir, PeergosStat parentStat) {
         FileWrapper treeNode = stat.treeNode;
         try {
-            FileWrapper updatedParent = treeNode.remove(parentStat.treeNode, context).get();
+            FileWrapper updatedParent = treeNode.remove(parentStat.treeNode, dir, context).get();
             return 0;
         } catch (Exception ioe) {
             LOG.log(Level.WARNING, ioe.getMessage(), ioe);

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -165,7 +165,7 @@ public class PeergosFileSystemImpl implements FileSystem {
 
     @Override
     public List<String> getSharees(Path path, Permission permission) {
-        FileSharedWithState sharing = userContext.sharedWith(path, getPath(path)).join();
+        FileSharedWithState sharing = userContext.sharedWith(path).join();
         switch (permission) {
             case READ:
                 return new ArrayList<>(sharing.readAccess);

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -1,7 +1,7 @@
 package peergos.server.simulation;
 
 import peergos.shared.social.FollowRequestWithCipherText;
-import peergos.shared.user.UserContext;
+import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.Pair;
 import peergos.shared.util.ProgressConsumer;
@@ -65,7 +65,7 @@ public class PeergosFileSystemImpl implements FileSystem {
     @Override
     public void delete(Path path) {
         FileWrapper directory = getDirectory(path);
-        FileWrapper updatedParent = getPath(path).remove(directory, userContext).join();
+        FileWrapper updatedParent = getPath(path).remove(directory, path, userContext).join();
     }
 
     @Override
@@ -166,12 +166,12 @@ public class PeergosFileSystemImpl implements FileSystem {
 
     @Override
     public List<String> getSharees(Path path, Permission permission) {
-        Pair<Set<String>, Set<String>> readersAndWriters = userContext.sharedWith(getPath(path));
+        SharedWithCache.FileSharedWithState sharing = userContext.sharedWith(path, getPath(path)).join();
         switch (permission) {
             case READ:
-                return new ArrayList<>(readersAndWriters.left);
+                return new ArrayList<>(sharing.readAccess);
             case WRITE:
-                return new ArrayList<>(readersAndWriters.right);
+                return new ArrayList<>(sharing.writeAccess);
             default:
                 throw new IllegalStateException();
         }

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -3,7 +3,6 @@ package peergos.server.simulation;
 import peergos.shared.social.FollowRequestWithCipherText;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
-import peergos.shared.util.Pair;
 import peergos.shared.util.ProgressConsumer;
 import peergos.shared.util.Serialize;
 
@@ -166,7 +165,7 @@ public class PeergosFileSystemImpl implements FileSystem {
 
     @Override
     public List<String> getSharees(Path path, Permission permission) {
-        SharedWithCache.FileSharedWithState sharing = userContext.sharedWith(path, getPath(path)).join();
+        FileSharedWithState sharing = userContext.sharedWith(path, getPath(path)).join();
         switch (permission) {
             case READ:
                 return new ArrayList<>(sharing.readAccess);

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -106,7 +106,7 @@ public class GarbageCollector {
         }
         long t5 = System.nanoTime();
         System.out.println("Deleting blocks took " + (t5-t4)/1_000_000_000 + "s");
-        System.out.println("GC complete. Freed " + deletedBlocks + " blocks totalling " + deletedSize + " bytes");
+        System.out.println("GC complete. Freed " + deletedBlocks + " blocks totalling " + deletedSize + " bytes in " + (t5-t0)/1_000_000_000 + "s");
     }
 
     private static void markReachable(ContentAddressedStorage storage, Multihash root, List<Multihash> present, BitSet reachable) {

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -445,7 +445,7 @@ public class MultiUserTests {
         Assert.assertTrue("file shared", ! sharedAccessWithBefore.isEmpty());
 
         String newFilename = "newfilename.txt";
-        theFile.rename(newFilename, parentFolder, u1).get();
+        theFile.rename(newFilename, parentFolder, filePath, u1).get();
 
         filePath = Paths.get(u1.username, subdirName, newFilename);
 
@@ -500,7 +500,7 @@ public class MultiUserTests {
         Assert.assertTrue("directory shared", ! sharedAccessWithBefore.isEmpty());
 
         String newDirectoryName = "newDir";
-        theDir.rename(newDirectoryName, parentFolder, u1).get();
+        theDir.rename(newDirectoryName, parentFolder, filePath, u1).get();
 
         filePath = Paths.get(u1.username, newDirectoryName);
 
@@ -819,7 +819,7 @@ public class MultiUserTests {
 
         String newname = "newname.txt";
         FileWrapper updatedParent = u1.getByPath(originalPath).get().get()
-                .rename(newname, u1.getUserRoot().get(), u1).get();
+                .rename(newname, u1.getUserRoot().get(), Paths.get(originalPath), u1).get();
         Path newPath = Paths.get(u1.username, newname);
         AbsoluteCapability newCap = u1.getByPath(newPath).join().get().getPointer().capability;
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -114,6 +114,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void renameSharedwithFolder() throws Exception {
+        PeergosNetworkUtils.renameSharedwithFolder(network, random);
+    }
+
+    @Test
     public void grantAndRevokeFileWriteAccess() throws Exception {
         PeergosNetworkUtils.grantAndRevokeFileWriteAccess(network, network, userCount, random);
     }

--- a/src/peergos/server/tests/QuotaTests.java
+++ b/src/peergos/server/tests/QuotaTests.java
@@ -80,8 +80,9 @@ public class QuotaTests {
             String filename = "file-1";
             home = home.uploadOrReplaceFile(filename, new AsyncReader.ArrayBacked(data), data.length,
                     network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
-            FileWrapper file = context.getByPath("/" + username + "/" + filename).get().get();
-            home = file.remove(home, context).get();
+            Path filePath = Paths.get(username, filename);
+            FileWrapper file = context.getByPath(filePath).get().get();
+            home = file.remove(home, filePath, context).get();
         }
     }
 
@@ -99,8 +100,9 @@ public class QuotaTests {
         String filename = "file-1";
         home = home.uploadOrReplaceFile(filename, new AsyncReader.ArrayBacked(data), data.length,
                 network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
-        FileWrapper file = context.getByPath("/" + username + "/" + filename).get().get();
-        file.remove(home, context).get();
+        Path filePath = Paths.get(username, filename);
+        FileWrapper file = context.getByPath(filePath).get().get();
+        file.remove(home, filePath, context).get();
     }
 
     @Test
@@ -117,12 +119,13 @@ public class QuotaTests {
         String filename = "file-1";
         home = home.uploadOrReplaceFile(filename, new AsyncReader.ArrayBacked(data), data.length,
                 network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
-        FileWrapper file = context.getByPath("/" + username + "/" + filename).get().get();
+        Path filePath = Paths.get(username, filename);
+        FileWrapper file = context.getByPath(filePath).get().get();
         try {
             home = home.uploadOrReplaceFile("file-2", new AsyncReader.ArrayBacked(data), data.length,
                     network, crypto, x -> {}, crypto.random.randomBytes(32)).get();
             Assert.fail();
         } catch (Exception e) {}
-        file.remove(home, context).get();
+        file.remove(home, filePath, context).get();
     }
 }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -430,7 +430,7 @@ public abstract class UserTests {
         //rename
         String newname = "newname.txt";
         FileWrapper updatedRoot5 = updatedRoot4.getDescendentByPath(otherName, crypto.hasher, context.network).get().get()
-                .rename(newname, updatedRoot4, context).get();
+                .rename(newname, updatedRoot4, Paths.get(username, otherName), context).get();
         checkFileContents(data3, updatedRoot5.getDescendentByPath(newname, crypto.hasher, context.network).get().get(), context);
         // check from the root as well
         checkFileContents(data3, context.getByPath(username + "/" + newname).get().get(), context);
@@ -478,9 +478,9 @@ public abstract class UserTests {
         //rename
         String newname = "newname.txt";
         FileWrapper parent = context.getUserRoot().get();
-        FileWrapper file = context.getByPath(parent.getName() + "/" + filename).get().get();
+        FileWrapper file = context.getByPath(username + "/" + filename).get().get();
 
-        file.rename(newname, parent, context).get();
+        file.rename(newname, parent, Paths.get(username, filename), context).get();
 
         FileWrapper updatedRoot = context.getUserRoot().get();
         FileWrapper updatedFile = context.getByPath(updatedRoot.getName() + "/" + newname).get().get();
@@ -1091,7 +1091,7 @@ public abstract class UserTests {
         String path = "/" + username + "/" + dirName;
         FileWrapper theDir = context.getByPath(path).get().get();
         FileWrapper userRoot2 = context.getByPath("/" + username).get().get();
-        FileWrapper renamed = theDir.rename("subdir2", userRoot2, context).get();
+        FileWrapper renamed = theDir.rename("subdir2", userRoot2, Paths.get(username, dirName), context).get();
     }
 
     // This one takes a while, so disable most of the time

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -1064,9 +1064,10 @@ public abstract class UserTests {
 
         String subfoldername = "subfolder";
         folder = folder.mkdir(subfoldername, context.network, false, crypto).join();
-        FileWrapper subfolder = context.getByPath(home.resolve(foldername).resolve(subfoldername)).join().get();
+        Path subfolderPath = Paths.get(username, foldername, subfoldername);
+        FileWrapper subfolder = context.getByPath(subfolderPath).join().get();
 
-        folder.remove(context.getUserRoot().join(), context).join();
+        folder.remove(context.getUserRoot().join(), subfolderPath, context).join();
 
         AbsoluteCapability pointer = subfolder.getPointer().capability;
         CommittedWriterData cwd = network.synchronizer.getValue(pointer.owner, pointer.writer).join().get(pointer.writer);
@@ -1227,7 +1228,7 @@ public abstract class UserTests {
         assertTrue("retrieved same data", dataEquals);
 
         //delete the file
-        fileWrapper.remove(updatedRoot2, context).get();
+        fileWrapper.remove(updatedRoot2, Paths.get(username, name), context).get();
 
         //re-create user-context
         UserContext context2 = PeergosNetworkUtils.ensureSignedUp(username, password, network.clear(), crypto);
@@ -1383,7 +1384,7 @@ public abstract class UserTests {
                 ! toParent.writer.isPresent());
 
         //remove the directory
-        directory.remove(updatedUserRoot, context).get();
+        directory.remove(updatedUserRoot, Paths.get(username, folderName), context).get();
 
         //ensure folder directory not  present
         boolean isPresent = context.getUserRoot().get().getChildren(crypto.hasher, context.network)

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -13,7 +13,6 @@ import peergos.shared.user.fs.*;
 import peergos.shared.user.fs.FileWrapper;
 import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.ArrayOps;
-import peergos.shared.util.Pair;
 import peergos.shared.util.Serialize;
 
 import java.io.File;
@@ -400,7 +399,7 @@ public class PeergosNetworkUtils {
         System.out.println("PATH "+ path);
         FileWrapper file = sharer.getByPath(path).join().get();
 
-        SharedWithCache.FileSharedWithState result = sharer.sharedWith(p, file).join();
+        FileSharedWithState result = sharer.sharedWith(p, file).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 
 

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -217,7 +217,8 @@ public class PeergosNetworkUtils {
             checkFileContents(originalFileContents, sharedFile.get(), userContext);
             // check the other user can't rename the file
             FileWrapper parent = userContext.getByPath(sharerUser.username).get().get();
-            CompletableFuture<FileWrapper> rename = sharedFile.get().rename("Somenew name.dat", parent, userContext);
+            CompletableFuture<FileWrapper> rename = sharedFile.get()
+                    .rename("Somenew name.dat", parent, Paths.get(filePath), userContext);
             assertTrue("Cannot rename", rename.isCompletedExceptionally());
         }
 

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -392,45 +392,39 @@ public class PeergosNetworkUtils {
         String folderName = "afolder";
         u1Root.mkdir(folderName, sharer.network, SymmetricKey.random(), false, crypto).get();
         Path p = Paths.get(sharerUsername, folderName);
-        FileWrapper file = sharer.getByPath(p).join().get();
 
-        FileSharedWithState result = sharer.sharedWith(p, file).join();
+        FileSharedWithState result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 
         sharer.shareReadAccessWith(p, Collections.singleton(sharee.username)).join();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1);
 
         sharer.shareWriteAccessWith(p, Collections.singleton(sharee2.username)).join();
 
-        file = sharer.getByPath(p).join().get();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 1);
 
         sharer.unShareReadAccess(p, Set.of(sharee.username)).join();
-        file = sharer.getByPath(p).join().get();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 1);
 
         sharer.unShareWriteAccess(p, Set.of(sharee2.username)).join();
-        file = sharer.getByPath(p).join().get();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 
         // now try again, but after adding read, write sharees, remove the write sharee
         sharer.shareReadAccessWith(p, Collections.singleton(sharee.username)).join();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1);
 
         sharer.shareWriteAccessWith(p, Collections.singleton(sharee2.username)).join();
 
-        file = sharer.getByPath(p).join().get();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 1);
 
         sharer.unShareWriteAccess(p, Set.of(sharee2.username)).join();
-        file = sharer.getByPath(p).join().get();
-        result = sharer.sharedWith(p, file).join();
+        result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 0);
 
     }

--- a/src/peergos/server/util/PeergosNetworkUtils.java
+++ b/src/peergos/server/util/PeergosNetworkUtils.java
@@ -395,17 +395,18 @@ public class PeergosNetworkUtils {
         FileWrapper u1Root = sharer.getUserRoot().get();
         String folderName = "afolder";
         u1Root.mkdir(folderName, sharer.network, SymmetricKey.random(), false, crypto).get();
-        String path = Paths.get(sharerUsername, folderName).toString();
+        Path p = Paths.get(sharerUsername, folderName);
+        String path = p.toString();
         System.out.println("PATH "+ path);
         FileWrapper file = sharer.getByPath(path).join().get();
 
-        Pair<Set<String>, Set<String>> result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 0 && result.right.size() == 0);
+        SharedWithCache.FileSharedWithState result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 
 
         sharer.shareReadAccessWith(file, path, Collections.singletonList(sharee.username).toArray(new String[1])).join();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 1);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 1);
 
         file = sharer.getByPath(path).join().get();
         FileWrapper parent = sharer.getUserRoot().get();
@@ -413,26 +414,26 @@ public class PeergosNetworkUtils {
         sharer.shareWriteAccessWith(file, path, parent, Collections.singletonList(sharee2.username).toArray(new String[1])).join();
 
         file = sharer.getByPath(path).join().get();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 1 && result.right.size() == 1);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 1);
 
         file = sharer.getByPath(path).join().get();
         String[] names = new String[] {sharee.username };
         sharer.unShareReadAccess(file, names).join();
         file = sharer.getByPath(path).join().get();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 0 && result.right.size() == 1);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 1);
 
         names = new String[] {sharee2.username };
         sharer.unShareWriteAccess(file, names).join();
         file = sharer.getByPath(path).join().get();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 0 && result.right.size() == 0);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 
         // now try again, but after adding read, write sharees, remove the write sharee
         sharer.shareReadAccessWith(file, path, Collections.singletonList(sharee.username).toArray(new String[1])).join();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 1);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 1);
 
         file = sharer.getByPath(path).join().get();
         parent = sharer.getUserRoot().get();
@@ -440,15 +441,15 @@ public class PeergosNetworkUtils {
         sharer.shareWriteAccessWith(file, path, parent, Collections.singletonList(sharee2.username).toArray(new String[1])).join();
 
         file = sharer.getByPath(path).join().get();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 1 && result.right.size() == 1);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 1);
 
         file = sharer.getByPath(path).join().get();
         names = new String[] {sharee2.username };
         sharer.unShareWriteAccess(file, names).join();
         file = sharer.getByPath(path).join().get();
-        result = sharer.sharedWith(file);
-        Assert.assertTrue(result.left.size() == 1 && result.right.size() == 0);
+        result = sharer.sharedWith(p, file).join();
+        Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 0);
 
     }
 

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -3,7 +3,6 @@ package peergos.shared.corenode;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.crypto.random.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 
@@ -11,57 +10,76 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 
+/** The TOFU core node stores a local copy of all identity key mappings retrieved from the pki ina TOFU manner.
+ *  The store is at /$username/.keystore in the user's Peergos space.
+ */
 public class TofuCoreNode implements CoreNode {
 
     public static final String KEY_STORE_NAME = ".keystore";
     private final CoreNode source;
     private final TofuKeyStore tofu;
-    private UserContext context;
+    private final NetworkAccess network;
+    private final Crypto crypto;
+    private FileWrapper backingFile;
 
-    public TofuCoreNode(CoreNode source, TofuKeyStore tofu) {
+    public TofuCoreNode(CoreNode source, TofuKeyStore tofu, FileWrapper backingFile, NetworkAccess network, Crypto crypto) {
         this.source = source;
         this.tofu = tofu;
+        this.backingFile = backingFile;
+        this.network = network;
+        this.crypto = crypto;
     }
 
-    public void setContext(UserContext context) {
-        this.context = context;
-    }
-
-    private static String getStorePath(String username) {
-        return "/" + username + "/" + KEY_STORE_NAME;
-    }
-
-    public static CompletableFuture<TofuKeyStore> load(String username, TrieNode root, NetworkAccess network, Crypto crypto) {
+    /**
+     *
+     * @param username
+     * @param root
+     * @param network
+     * @param crypto
+     * @return The TOFU core node for this user
+     */
+    public static CompletableFuture<TofuCoreNode> load(String username, TrieNode root, NetworkAccess network, Crypto crypto) {
         if (username == null)
-            return CompletableFuture.completedFuture(new TofuKeyStore());
+            throw new IllegalStateException("Cannot build a tofu keystore if not logged in!");
 
-        return root.getByPath(getStorePath(username), crypto.hasher, network).thenCompose(fileOpt -> {
-            if (! fileOpt.isPresent())
-                return CompletableFuture.completedFuture(new TofuKeyStore());
+        return root.getByPath(username, crypto.hasher, network)
+                .thenApply(Optional::get)
+                .thenCompose(homeDir -> homeDir.getChildrenWithSameWriter(crypto.hasher, network)
+                        .thenCompose(children -> {
+                            Optional<FileWrapper> keystoreOpt = children.stream().filter(c -> c.getName().equals(KEY_STORE_NAME)).findFirst();
+                            if (keystoreOpt.isEmpty()) {
+                                // initialize empty keystore
+                                TofuKeyStore store = new TofuKeyStore();
+                                byte[] raw = store.serialize();
+                                return homeDir.uploadAndReturnFile(KEY_STORE_NAME, AsyncReader.build(raw), raw.length,
+                                        network, crypto)
+                                        .thenApply(f -> new TofuCoreNode(network.coreNode, store, f, network, crypto));
+                            }
 
-            return fileOpt.get().getInputStream(network, crypto, x -> {}).thenCompose(reader -> {
-                byte[] storeData = new byte[(int) fileOpt.get().getSize()];
-                return reader.readIntoArray(storeData, 0, storeData.length)
-                        .thenApply(x -> TofuKeyStore.fromCbor(CborObject.fromByteArray(storeData)));
-            });
-        });
+                            return keystoreOpt.get().getInputStream(network, crypto, x -> {}).thenCompose(reader -> {
+                                byte[] storeData = new byte[(int) keystoreOpt.get().getSize()];
+                                return reader.readIntoArray(storeData, 0, storeData.length)
+                                        .thenApply(x -> new TofuCoreNode(network.coreNode,
+                                                TofuKeyStore.fromCbor(CborObject.fromByteArray(storeData)),
+                                                keystoreOpt.get(), network, crypto));
+                            });
+                        }));
     }
 
-    private CompletableFuture<Boolean> commit() {
-        return context.getUserRoot()
-                .thenCompose(home -> {
-                    byte[] data = tofu.serialize();
-                    AsyncReader.ArrayBacked dataReader = new AsyncReader.ArrayBacked(data);
-                    return home.uploadFileSection(KEY_STORE_NAME, dataReader, true, 0, (long) data.length,
-                            Optional.empty(), true, context.network, context.crypto, x -> {},
-                            context.crypto.random.randomBytes(32));
-                }).thenApply(x -> true);
+    private synchronized CompletableFuture<Boolean> commit() {
+        byte[] data = tofu.serialize();
+        AsyncReader.ArrayBacked dataReader = new AsyncReader.ArrayBacked(data);
+        return backingFile.overwriteFile(dataReader, data.length, network, crypto, x -> {})
+                .thenApply(f -> {
+                    this.backingFile = f;
+                    return true;
+                });
     }
 
     @Override
     public CompletableFuture<Boolean> updateUser(String username) {
         return source.getChain(username)
-                .thenCompose(chain -> tofu.updateChain(username, chain, context.network.dhtClient)
+                .thenCompose(chain -> tofu.updateChain(username, chain, network.dhtClient)
                         .thenCompose(x -> commit()));
     }
 
@@ -75,7 +93,7 @@ public class TofuCoreNode implements CoreNode {
                         if(chain.isEmpty()) {
                             return CompletableFuture.completedFuture(false);
                         } else {
-                            return tofu.updateChain(username, chain, context.network.dhtClient)
+                            return tofu.updateChain(username, chain, network.dhtClient)
                                     .thenCompose(x -> commit());
                         }
                     }
@@ -89,7 +107,7 @@ public class TofuCoreNode implements CoreNode {
             return CompletableFuture.completedFuture(local.get());
         return source.getUsername(key)
                 .thenCompose(username -> source.getChain(username)
-                        .thenCompose(chain -> tofu.updateChain(username, chain, context.network.dhtClient)
+                        .thenCompose(chain -> tofu.updateChain(username, chain, network.dhtClient)
                                 .thenCompose(x -> commit())
                                 .thenApply(x -> username)));
     }
@@ -100,14 +118,14 @@ public class TofuCoreNode implements CoreNode {
         if (! localChain.isEmpty())
             return CompletableFuture.completedFuture(localChain);
         return source.getChain(username)
-                .thenCompose(chain -> tofu.updateChain(username, chain, context.network.dhtClient)
+                .thenCompose(chain -> tofu.updateChain(username, chain, network.dhtClient)
                         .thenCompose(x -> commit())
                         .thenApply(x -> tofu.getChain(username)));
     }
 
     @Override
     public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
-        return tofu.updateChain(username, chain, context.network.dhtClient)
+        return tofu.updateChain(username, chain, network.dhtClient)
                 .thenCompose(x -> commit())
                 .thenCompose(x -> source.updateChain(username, chain));
     }

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -53,7 +53,7 @@ public class TofuCoreNode implements CoreNode {
                                 TofuKeyStore store = new TofuKeyStore();
                                 byte[] raw = store.serialize();
                                 return homeDir.uploadAndReturnFile(KEY_STORE_NAME, AsyncReader.build(raw), raw.length,
-                                        network, crypto)
+                                        true, network, crypto)
                                         .thenApply(f -> new TofuCoreNode(network.coreNode, store, f, network, crypto));
                             }
 

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -23,7 +23,8 @@ public class TofuCoreNode implements CoreNode {
     private FileWrapper backingFile;
 
     public TofuCoreNode(CoreNode source, TofuKeyStore tofu, FileWrapper backingFile, NetworkAccess network, Crypto crypto) {
-        this.source = source;
+        // make sure we don't nest tofu core nodes, or their commits will clash
+        this.source = source instanceof TofuCoreNode ? ((TofuCoreNode) source).source : source;
         this.tofu = tofu;
         this.backingFile = backingFile;
         this.network = network;

--- a/src/peergos/shared/user/FileSharedWithState.java
+++ b/src/peergos/shared/user/FileSharedWithState.java
@@ -1,0 +1,19 @@
+package peergos.shared.user;
+
+import java.util.*;
+
+public class FileSharedWithState {
+    public static final FileSharedWithState EMPTY = new FileSharedWithState(Collections.emptySet(), Collections.emptySet());
+    public final Set<String> readAccess, writeAccess;
+
+    public FileSharedWithState(Set<String> readAccess, Set<String> writeAccess) {
+        this.readAccess = readAccess;
+        this.writeAccess = writeAccess;
+    }
+
+    public Set<String> get(SharedWithCache.Access type) {
+        if (type == SharedWithCache.Access.READ)
+            return readAccess;
+        return writeAccess;
+    }
+}

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -66,10 +66,10 @@ public class FriendSourcedTrieNode implements TrieNode {
                     if (!sharedDirOpt.isPresent())
                         return CompletableFuture.completedFuture(Optional.empty());
                     return CapabilityStore.loadReadOnlyLinks(homeDirSupplier, sharedDirOpt.get(), e.ownerName,
-                            network, crypto, true)
+                            network, crypto, true, true)
                             .thenCompose(readCaps -> {
                                 return CapabilityStore.loadWriteableLinks(homeDirSupplier, sharedDirOpt.get(), e.ownerName,
-                                        network, crypto, true)
+                                        network, crypto, true, true)
                                         .thenApply(writeCaps -> {
                                             List<CapabilityWithPath> allCaps = new ArrayList<>();
                                             allCaps.addAll(readCaps.getRetrievedCapabilities());
@@ -97,7 +97,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                                     return addEditableCapabilities(Optional.of(sharedDir.file), crypto, network);
                                 } else {
                                     return CapabilityStore.loadReadAccessSharingLinksFromIndex(homeDirSupplier, sharedDir.file,
-                                            ownerName, network, crypto, byteOffsetReadOnly, true)
+                                            ownerName, network, crypto, byteOffsetReadOnly, true, true)
                                             .thenCompose(newReadCaps -> {
                                                 byteOffsetReadOnly += newReadCaps.getBytesRead();
                                                 root = newReadCaps.getRetrievedCapabilities().stream()
@@ -119,7 +119,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                     if (editFilesize == byteOffsetWrite)
                         return CompletableFuture.completedFuture(true);
                     return CapabilityStore.loadWriteAccessSharingLinksFromIndex(homeDirSupplier, sharedDirOpt.get(),
-                            ownerName, network, crypto, byteOffsetWrite, true)
+                            ownerName, network, crypto, byteOffsetWrite, true, true)
                             .thenApply(newWriteCaps -> {
                                 byteOffsetWrite += newWriteCaps.getBytesRead();
                                 root = newWriteCaps.getRetrievedCapabilities().stream()

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -11,21 +11,21 @@ import java.util.function.*;
 public class FriendSourcedTrieNode implements TrieNode {
 
     public final String ownerName;
-    private final Supplier<CompletableFuture<FileWrapper>> homeDirSupplier;
+    private final FileWrapper cacheDir;
     private final EntryPoint sharedDir;
     private final Crypto crypto;
     private TrieNode root;
     private long byteOffsetReadOnly;
     private long byteOffsetWrite;
 
-    public FriendSourcedTrieNode(Supplier<CompletableFuture<FileWrapper>> homeDirSupplier,
+    public FriendSourcedTrieNode(FileWrapper cacheDir,
                                  String ownerName,
                                  EntryPoint sharedDir,
                                  TrieNode root,
                                  long byteOffsetReadOnly,
                                  long byteOffsetWrite,
                                  Crypto crypto) {
-        this.homeDirSupplier = homeDirSupplier;
+        this.cacheDir = cacheDir;
         this.ownerName = ownerName;
         this.sharedDir = sharedDir;
         this.root = root;
@@ -34,18 +34,18 @@ public class FriendSourcedTrieNode implements TrieNode {
         this.crypto = crypto;
     }
 
-    public static CompletableFuture<Optional<FriendSourcedTrieNode>> build(Supplier<CompletableFuture<FileWrapper>> homeDirSupplier,
+    public static CompletableFuture<Optional<FriendSourcedTrieNode>> build(FileWrapper cacheDir,
                                                                            EntryPoint e,
                                                                            NetworkAccess network,
                                                                            Crypto crypto) {
-        return CapabilityStore.loadCachedReadOnlyLinks(homeDirSupplier, e.ownerName, network, crypto)
+        return CapabilityStore.loadCachedReadOnlyLinks(cacheDir, e.ownerName, network, crypto)
                 .thenCompose(readCaps -> {
-                    return CapabilityStore.loadCachedWriteableLinks(homeDirSupplier, e.ownerName, network, crypto)
+                    return CapabilityStore.loadCachedWriteableLinks(cacheDir, e.ownerName, network, crypto)
                             .thenApply(writeCaps -> {
                                 List<CapabilityWithPath> allCaps = new ArrayList<>();
                                 allCaps.addAll(readCaps.getRetrievedCapabilities());
                                 allCaps.addAll(writeCaps.getRetrievedCapabilities());
-                                return Optional.of(new FriendSourcedTrieNode(homeDirSupplier,
+                                return Optional.of(new FriendSourcedTrieNode(cacheDir,
                                         e.ownerName,
                                         e,
                                         allCaps.stream()
@@ -57,24 +57,24 @@ public class FriendSourcedTrieNode implements TrieNode {
                 });
     }
 
-    public static CompletableFuture<Optional<FriendSourcedTrieNode>> buildAndUpdate(Supplier<CompletableFuture<FileWrapper>> homeDirSupplier,
-                                                                           EntryPoint e,
-                                                                           NetworkAccess network,
-                                                                           Crypto crypto) {
+    public static CompletableFuture<Optional<FriendSourcedTrieNode>> buildAndUpdate(FileWrapper cacheDir,
+                                                                                    EntryPoint e,
+                                                                                    NetworkAccess network,
+                                                                                    Crypto crypto) {
         return network.retrieveEntryPoint(e)
                 .thenCompose(sharedDirOpt -> {
                     if (!sharedDirOpt.isPresent())
                         return CompletableFuture.completedFuture(Optional.empty());
-                    return CapabilityStore.loadReadOnlyLinks(homeDirSupplier, sharedDirOpt.get(), e.ownerName,
+                    return CapabilityStore.loadReadOnlyLinks(cacheDir, sharedDirOpt.get(), e.ownerName,
                             network, crypto, true, true)
                             .thenCompose(readCaps -> {
-                                return CapabilityStore.loadWriteableLinks(homeDirSupplier, sharedDirOpt.get(), e.ownerName,
+                                return CapabilityStore.loadWriteableLinks(cacheDir, sharedDirOpt.get(), e.ownerName,
                                         network, crypto, true, true)
                                         .thenApply(writeCaps -> {
                                             List<CapabilityWithPath> allCaps = new ArrayList<>();
                                             allCaps.addAll(readCaps.getRetrievedCapabilities());
                                             allCaps.addAll(writeCaps.getRetrievedCapabilities());
-                                            return Optional.of(new FriendSourcedTrieNode(homeDirSupplier,
+                                            return Optional.of(new FriendSourcedTrieNode(cacheDir,
                                                     e.ownerName,
                                                     e,
                                                     allCaps.stream()
@@ -96,7 +96,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                                 if (bytes == byteOffsetReadOnly) {
                                     return addEditableCapabilities(Optional.of(sharedDir.file), crypto, network);
                                 } else {
-                                    return CapabilityStore.loadReadAccessSharingLinksFromIndex(homeDirSupplier, sharedDir.file,
+                                    return CapabilityStore.loadReadAccessSharingLinksFromIndex(cacheDir, sharedDir.file,
                                             ownerName, network, crypto, byteOffsetReadOnly, true, true)
                                             .thenCompose(newReadCaps -> {
                                                 byteOffsetReadOnly += newReadCaps.getBytesRead();
@@ -118,7 +118,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                 .thenCompose(editFilesize -> {
                     if (editFilesize == byteOffsetWrite)
                         return CompletableFuture.completedFuture(true);
-                    return CapabilityStore.loadWriteAccessSharingLinksFromIndex(homeDirSupplier, sharedDirOpt.get(),
+                    return CapabilityStore.loadWriteAccessSharingLinksFromIndex(cacheDir, sharedDirOpt.get(),
                             ownerName, network, crypto, byteOffsetWrite, true, true)
                             .thenApply(newWriteCaps -> {
                                 byteOffsetWrite += newWriteCaps.getBytesRead();

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -221,6 +221,18 @@ public class SharedWithCache {
         });
     }
 
+    public CompletableFuture<Boolean> rename(Path initial, Path after) {
+        if (! initial.getParent().equals(after.getParent()))
+            throw new IllegalStateException("Not a valid rename!");
+        String initialFilename = initial.toFile().getName();
+        String newFilename = after.toFile().getName();
+        return getSharedWith(initial)
+                .thenCompose(sharees -> applyAndCommit(after, current ->
+                        current.add(Access.READ, newFilename, sharees.readAccess)
+                                .add(Access.WRITE, newFilename, sharees.writeAccess)
+                                .clear(initialFilename)));
+    }
+
     public CompletableFuture<Boolean> addSharedWith(Access access, Path p, Set<String> names) {
         return applyAndCommit(p, current -> current.add(access, p.toFile().getName(), names));
     }

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -180,7 +180,7 @@ public class SharedWithCache {
         }
         return f.getChildren(crypto.hasher, network)
                 .thenCompose(children -> Futures.combineAll(children.stream()
-                        .map(c -> getAllDescendantSharesRecurse(c, toUs))
+                        .map(c -> getAllDescendantSharesRecurse(c, toUs.resolve(c.getName())))
                         .collect(Collectors.toList())))
                 .thenApply(s -> s.stream()
                         .flatMap(m -> m.entrySet().stream())

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -1,115 +1,353 @@
 package peergos.shared.user;
 
-import peergos.shared.user.fs.AbsoluteCapability;
-import peergos.shared.util.ByteArrayWrapper;
+import jsinterop.annotations.*;
+import peergos.shared.*;
+import peergos.shared.cbor.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
 
 import java.nio.file.*;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
+import java.util.function.*;
+import java.util.stream.*;
 
 public class SharedWithCache {
 
     public enum Access { READ, WRITE }
 
-    //K,V
-    // K = mapKey of absolute capability
-    // V = list of usernames the file/dir is shared with
-    private final Map<ByteArrayWrapper, Set<String>> sharedWithReadAccessCache = new ConcurrentHashMap<>();
-    private final Map<ByteArrayWrapper, Set<String>> sharedWithWriteAccessCache = new ConcurrentHashMap<>();
-    // These would be more space efficient in a trie
-    private final Map<Path, Set<String>> writeShares = new ConcurrentHashMap<>();
-    private final Map<Path, Set<String>> readShares = new ConcurrentHashMap<>();
+    private static final String DIR_CACHE_FILENAME = "sharedWith.cbor";
+    private static final String CACHE_BASE_NAME = "outbound";
+    private static final Path CACHE_BASE = Paths.get(CapabilityStore.CAPABILITY_CACHE_DIR, CACHE_BASE_NAME);
 
-    public SharedWithCache() {}
+    public static class FileSharedWithState {
+        public static final FileSharedWithState EMPTY = new FileSharedWithState(Collections.emptySet(), Collections.emptySet());
+        public final Set<String> readAccess, writeAccess;
+
+        public FileSharedWithState(Set<String> readAccess, Set<String> writeAccess) {
+            this.readAccess = readAccess;
+            this.writeAccess = writeAccess;
+        }
+
+        public Set<String> get(Access type) {
+            if (type == Access.READ)
+                return readAccess;
+            return writeAccess;
+        }
+    }
+
+    /** Holds the sharing state for all the children of a directory
+     *
+     */
+    public static class SharedWithState implements Cborable {
+        public static final SharedWithState EMPTY = new SharedWithState(Collections.emptyMap(), Collections.emptyMap());
+        private final Map<String, Set<String>> readShares;
+        private final Map<String, Set<String>> writeShares;
+
+        public SharedWithState(Map<String, Set<String>> readShares, Map<String, Set<String>> writeShares) {
+            this.readShares = readShares;
+            this.writeShares = writeShares;
+        }
+
+        public static SharedWithState empty() {
+            return new SharedWithState(new HashMap<>(), new HashMap<>());
+        }
+
+        public FileSharedWithState get(String filename) {
+            return new FileSharedWithState(
+                    readShares.getOrDefault(filename, Collections.emptySet()),
+                    writeShares.getOrDefault(filename, Collections.emptySet()));
+        }
+
+        public Optional<SharedWithState> filter(String childName) {
+            if (! readShares.containsKey(childName) && ! writeShares.containsKey(childName))
+                return Optional.empty();
+            Map<String, Set<String>> newReads = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+                if (e.getKey().equals(childName))
+                    newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+            Map<String, Set<String>> newWrites = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+                if (e.getKey().equals(childName))
+                    newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+
+            return Optional.of(new SharedWithState(newReads, newWrites));
+        }
+
+        public SharedWithState add(Access access, String filename, Set<String> names) {
+            Map<String, Set<String>> newReads = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+                newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+            Map<String, Set<String>> newWrites = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+                newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+
+            if (access == Access.READ) {
+                newReads.putIfAbsent(filename, new HashSet<>());
+                newReads.get(filename).addAll(names);
+            } else if (access == Access.WRITE) {
+                newWrites.putIfAbsent(filename, new HashSet<>());
+                newWrites.get(filename).addAll(names);
+            }
+
+            return new SharedWithState(newReads, newWrites);
+        }
+
+        public SharedWithState remove(Access access, String filename, Set<String> names) {
+            Map<String, Set<String>> newReads = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+                newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+            Map<String, Set<String>> newWrites = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+                newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+
+            Set<String> val = access == Access.READ ? newReads.get(filename) : newWrites.get(filename);
+            if (val != null)
+                val.removeAll(names);
+
+            return new SharedWithState(newReads, newWrites);
+        }
+
+        public SharedWithState clear(String filename) {
+            Map<String, Set<String>> newReads = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+                newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+            Map<String, Set<String>> newWrites = new HashMap<>();
+            for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+                newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+            }
+
+            newReads.remove(filename);
+            newWrites.remove(filename);
+
+            return new SharedWithState(newReads, newWrites);
+        }
+
+        @JsMethod
+        public boolean isShared(String filename) {
+            return readShares.containsKey(filename) || writeShares.containsKey(filename);
+        }
+
+        @Override
+        public CborObject toCbor() {
+            SortedMap<String, Cborable> state = new TreeMap<>();
+            SortedMap<String, Cborable> readState = new TreeMap<>();
+            for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+                readState.put(e.getKey(), new CborObject.CborList(e.getValue().stream().map(CborObject.CborString::new).collect(Collectors.toList())));
+            }
+            SortedMap<String, Cborable> writeState = new TreeMap<>();
+            for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+                writeState.put(e.getKey(), new CborObject.CborList(e.getValue().stream().map(CborObject.CborString::new).collect(Collectors.toList())));
+            }
+
+            state.put("r", CborObject.CborMap.build(readState));
+            state.put("w", CborObject.CborMap.build(writeState));
+            return CborObject.CborMap.build(state);
+        }
+
+        public static SharedWithState fromCbor(Cborable cbor) {
+            if (! (cbor instanceof CborObject.CborMap))
+                throw new IllegalStateException("Invalid cbor for SharedWithState!");
+            CborObject.CborMap m = (CborObject.CborMap) cbor;
+            CborObject.CborMap r = m.get("r", c -> (CborObject.CborMap) c);
+            Function<Cborable, String> getString = c -> ((CborObject.CborString) c).value;
+            Map<String, Set<String>> readShares = r.getMap(
+                    getString,
+                    c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
+
+            CborObject.CborMap w = m.get("w", c -> (CborObject.CborMap) c);
+            Map<String, Set<String>> writehares = w.getMap(
+                    getString,
+                    c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
+
+            return new SharedWithState(readShares, writehares);
+        }
+    }
+
+    private final Function<Path, CompletableFuture<Optional<FileWrapper>>> retriever;
+    private final String ourname;
+    private final NetworkAccess network;
+    private final Crypto crypto;
+
+    public SharedWithCache(Function<Path, CompletableFuture<Optional<FileWrapper>>> retriever,
+                           String ourname,
+                           NetworkAccess network,
+                           Crypto crypto) {
+        this.retriever = retriever;
+        this.ourname = ourname;
+        this.network = network;
+        this.crypto = crypto;
+    }
 
     private static Path canonicalise(Path p) {
         return p.isAbsolute() ? p : Paths.get("/").resolve(p);
     }
 
-    public Map<Path, Set<String>> getAllReadShares(Path start) {
-        Path startPath = canonicalise(start);
-        Map<Path, Set<String>> res = new HashMap<>();
-        for (Path path: readShares.keySet())
-        if (path.startsWith(startPath)) {
-            Set<String> names = readShares.get(path);
-            if (! names.isEmpty())
-                res.put(path, names);
-        }
+    private CompletableFuture<Optional<SharedWithState>> retrieve(Path dir) {
+        return retrieveWithFile(dir).thenApply(opt -> opt.map(p -> p.right));
+    }
+
+    private CompletableFuture<Optional<Pair<FileWrapper, SharedWithState>>> retrieveWithFile(Path dir) {
+        return retriever.apply(CACHE_BASE.resolve(dir).resolve(DIR_CACHE_FILENAME))
+                .thenCompose(opt -> opt.isEmpty() ?
+                        Futures.of(Optional.empty()) :
+                        parseCacheFile(opt.get())
+                                .thenApply(s -> new Pair<>(opt.get(), s))
+                                .thenApply(Optional::of)
+                );
+    }
+
+    /**
+     *
+     * @return root of cache
+     */
+    private CompletableFuture<FileWrapper> initializeCache() {
+        return retriever.apply(Paths.get(ourname))
+                .thenCompose(userRoot -> getOrMkdir(userRoot.get(), CapabilityStore.CAPABILITY_CACHE_DIR))
+                .thenCompose(cacheRoot -> getOrMkdir(cacheRoot, CACHE_BASE_NAME)); //TODO build from outbound cap files
+    }
+
+    private CompletableFuture<FileWrapper> getOrMkdir(FileWrapper parent, String dirName) {
+        return parent.getChild(dirName, crypto.hasher, network)
+                .thenCompose(opt -> opt.isPresent() ?
+                        Futures.of(opt.get()) :
+                        parent.mkdir(dirName, network, true, crypto)
+                                .thenCompose(p -> p.getChild(dirName, crypto.hasher, network))
+                                .thenApply(Optional::get));
+    }
+
+    private CompletableFuture<FileWrapper> getOrMkdirs(FileWrapper parent, List<String> remaining) {
+        if (remaining.isEmpty())
+            return Futures.of(parent);
+        return getOrMkdir(parent, remaining.get(0))
+                .thenCompose(child -> getOrMkdirs(child, remaining.subList(1, remaining.size())));
+    }
+
+    private CompletableFuture<Pair<FileWrapper, SharedWithState>> retrieveWithFileOrCreate(Path dir) {
+        return retriever.apply(CACHE_BASE)
+                .thenCompose(opt -> opt.isEmpty() ?
+                        initializeCache() :
+                        Futures.of(opt.get())
+                ).thenCompose(cacheRoot -> getOrMkdirs(cacheRoot, toList(dir)))
+                .thenCompose(parent -> parent.getChild(DIR_CACHE_FILENAME, crypto.hasher, network)
+                        .thenCompose(fopt -> {
+                            if (fopt.isPresent())
+                                return parseCacheFile(fopt.get())
+                                        .thenApply(c -> new Pair<>(fopt.get(), c));
+                            SharedWithState empty = SharedWithState.empty();
+                            byte[] raw = empty.serialize();
+                            return parent.uploadOrReplaceFile(DIR_CACHE_FILENAME, AsyncReader.build(raw), raw.length,
+                                    network, crypto, x -> {}, crypto.random.randomBytes(32))
+                                    .thenCompose(updatedParent -> updatedParent.getChild(DIR_CACHE_FILENAME, crypto.hasher, network))
+                                    .thenApply(copt -> new Pair<>(copt.get(), empty));
+                        }));
+    }
+
+    private List<String> toList(Path p) {
+        return Arrays.asList(p.toString().split("/"));
+    }
+
+    private CompletableFuture<SharedWithState> parseCacheFile(FileWrapper cache) {
+        return cache.getInputStream(network, crypto, x -> {})
+                .thenCompose(in -> Serialize.readFully(in, cache.getSize()))
+                .thenApply(CborObject::fromByteArray)
+                .thenApply(SharedWithState::fromCbor);
+    }
+
+    public CompletableFuture<Map<Path, SharedWithState>> getAllDescendantShares(Path start) {
+        return retriever.apply(CACHE_BASE.resolve(start.getParent()))
+                .thenCompose(opt -> {
+                    if (opt.isEmpty())
+                        return Futures.of(Collections.emptyMap());
+                    FileWrapper parent = opt.get();
+                    String filename = start.toFile().getName();
+                    return parent.getChild(DIR_CACHE_FILENAME, crypto.hasher, network)
+                            .thenCompose(fopt -> fopt.isEmpty() ?
+                                    Futures.of(Collections.<Path, SharedWithState>emptyMap()) :
+                                    parseCacheFile(fopt.get())
+                                            .thenApply(c -> c.filter(filename)
+                                                    .map(r -> Collections.singletonMap(start.getParent(), r))
+                                                    .orElse(Collections.emptyMap()))
+                            ).thenCompose(m -> parent.getChild(filename, crypto.hasher, network)
+                                    .thenCompose(copt -> copt.isEmpty() ?
+                                            Futures.of(m) :
+                                            getAllDescendantSharesRecurse(copt.get(), start)
+                                                    .thenApply(d -> merge(d, m))));
+                });
+    }
+
+    private <K, V> Map<K, V> merge(Map<K, V> a, Map<K, V> b) {
+        HashMap<K, V> res = new HashMap<>(a);
+        res.putAll(b); // no key conflicts
         return res;
     }
 
-    public Map<Path, Set<String>> getAllWriteShares(Path start) {
-        Path startPath = canonicalise(start);
-        Map<Path, Set<String>> res = new HashMap<>();
-        for (Path path: writeShares.keySet())
-            if (path.startsWith(startPath)) {
-                Set<String> names = writeShares.get(path);
-                if (! names.isEmpty())
-                    res.put(path, names);
-            }
-        return res;
-    }
-
-    private ByteArrayWrapper generateKey(AbsoluteCapability cap) {
-        return new ByteArrayWrapper(cap.getMapKey());
-    }
-
-    public boolean isShared(AbsoluteCapability cap) {
-        return ! getSharedWith(SharedWithCache.Access.READ, cap).isEmpty()
-                || ! getSharedWith(SharedWithCache.Access.WRITE, cap).isEmpty();
-    }
-
-    public Set<String> getSharedWith(Access access, AbsoluteCapability cap) {
-        return access == Access.READ ?
-            getSharedWith(sharedWithReadAccessCache, cap) : getSharedWith(sharedWithWriteAccessCache, cap);
-    }
-
-    private synchronized Set<String> getSharedWith(Map<ByteArrayWrapper, Set<String>> cache, AbsoluteCapability cap) {
-        return new HashSet<>(cache.getOrDefault(generateKey(cap), new HashSet<>()));
-    }
-
-    public void addSharedWith(Access access, String path, AbsoluteCapability cap, String name) {
-        Path p = Paths.get(path);
-        addSharedWith(access, p, cap, Collections.singleton(name));
-    }
-
-    public void addSharedWith(Access access, Path p, AbsoluteCapability cap, Set<String> names) {
-        Path filePath = canonicalise(p);
-        if (access == Access.READ) {
-            readShares.putIfAbsent(filePath, new HashSet<>());
-            readShares.get(filePath).addAll(names);
-            addCacheEntry(sharedWithReadAccessCache, cap, names);
-        } else if (access == Access.WRITE) {
-            writeShares.putIfAbsent(filePath, new HashSet<>());
-            writeShares.get(filePath).addAll(names);
-            addCacheEntry(sharedWithWriteAccessCache, cap, names);
+    public CompletableFuture<Map<Path, SharedWithState>> getAllDescendantSharesRecurse(FileWrapper f, Path toUs) {
+        if (! f.isDirectory()) {
+            if (! f.getName().equals(DIR_CACHE_FILENAME))
+                throw new IllegalStateException("Invalid shared with cache!");
+            return parseCacheFile(f)
+                    .thenApply(c -> Collections.singletonMap(toUs.getParent(), c));
         }
+        return f.getChildren(crypto.hasher, network)
+                .thenCompose(children -> Futures.combineAll(children.stream()
+                        .map(c -> getAllDescendantSharesRecurse(c, toUs))
+                        .collect(Collectors.toList())))
+                .thenApply(s -> s.stream()
+                        .flatMap(m -> m.entrySet().stream())
+                        .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
     }
 
-    private synchronized void addCacheEntry(Map<ByteArrayWrapper, Set<String>> cache, AbsoluteCapability cap, Set<String> names) {
-        cache.computeIfAbsent(generateKey(cap), k -> new HashSet<>()).addAll(names);
+    public CompletableFuture<Map<Path, Set<String>>> getAllReadShares(Path start) {
+        return getAllDescendantShares(start)
+                .thenApply(m -> m.entrySet().stream()
+                        .flatMap(e -> e.getValue().readShares.entrySet()
+                                .stream()
+                                .map(e2 -> new Pair<>(e.getKey().resolve(e2.getKey()), e2.getValue())))
+                        .collect(Collectors.toMap(p -> p.left, p -> p.right)));
     }
 
-    public void clearSharedWith(AbsoluteCapability cap) {
-        ByteArrayWrapper key = generateKey(cap);
-        sharedWithReadAccessCache.computeIfPresent(key, (k, v) -> new HashSet<>());
-        sharedWithWriteAccessCache.computeIfPresent(key, (k, v) -> new HashSet<>());
+    public CompletableFuture<Map<Path, Set<String>>> getAllWriteShares(Path start) {
+        return getAllDescendantShares(start)
+                .thenApply(m -> m.entrySet().stream()
+                        .flatMap(e -> e.getValue().writeShares.entrySet()
+                                .stream()
+                                .map(e2 -> new Pair<>(e.getKey().resolve(e2.getKey()), e2.getValue())))
+                        .collect(Collectors.toMap(p -> p.left, p -> p.right)));
     }
 
-    public void removeSharedWith(Access access, Path p, AbsoluteCapability cap, Set<String> names) {
-        Path filePath = canonicalise(p);
-        if (access == Access.READ) {
-            if (readShares.containsKey(filePath))
-                readShares.get(filePath).removeAll(names);
-            removeCacheEntry(sharedWithReadAccessCache, cap, names);
-        } else if (access == Access.WRITE) {
-            if (writeShares.containsKey(filePath))
-                writeShares.get(filePath).removeAll(names);
-            removeCacheEntry(sharedWithWriteAccessCache, cap, names);
-        }
+    public CompletableFuture<FileSharedWithState> getSharedWith(Path p) {
+        return retrieve(p.getParent())
+                .thenApply(opt -> opt.map(s -> s.get(p.toFile().getName())).orElse(FileSharedWithState.EMPTY));
     }
 
-    private synchronized void removeCacheEntry(Map<ByteArrayWrapper, Set<String>> cache, AbsoluteCapability cap, Set<String> names) {
-        cache.computeIfAbsent(generateKey(cap), k -> new HashSet<>()).removeAll(names);
+    public CompletableFuture<Boolean> applyAndCommit(Path toFile, Function<SharedWithState, SharedWithState> transform) {
+        return retrieveWithFileOrCreate(toFile.getParent()).thenCompose(p -> {
+            FileWrapper source = p.left;
+            SharedWithState current = p.right;
+            SharedWithState updated = transform.apply(current);
+            byte[] raw = updated.serialize();
+            return source.overwriteFile(AsyncReader.build(raw), raw.length, network, crypto, x -> {})
+                    .thenApply(x -> true);
+        });
+    }
+
+    public CompletableFuture<Boolean> addSharedWith(Access access, Path p, Set<String> names) {
+        return applyAndCommit(p, current -> current.add(access, p.toFile().getName(), names));
+    }
+
+    public CompletableFuture<Boolean> clearSharedWith(Path p) {
+        return applyAndCommit(p, current -> current.clear(p.toFile().getName()));
+    }
+
+    public CompletableFuture<Boolean> removeSharedWith(Access access, Path p, Set<String> names) {
+        return applyAndCommit(p, current -> current.remove(access, p.toFile().getName(), names));
     }
 }

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -30,7 +30,7 @@ public class SharedWithCache {
                            NetworkAccess network,
                            Crypto crypto) {
         this.retriever = retriever;
-        this.cacheBase = Paths.get(ourname).resolve(CACHE_BASE);
+        this.cacheBase = Paths.get("/" + ourname).resolve(CACHE_BASE);
         this.ourname = ourname;
         this.network = network;
         this.crypto = crypto;

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -112,6 +112,15 @@ public class SharedWithCache {
                 .thenCompose(child -> getOrMkdirs(child, remaining.subList(1, remaining.size())));
     }
 
+    public CompletableFuture<SharedWithState> getDirSharingState(Path dir) {
+        return retriever.apply(cacheBase)
+                .thenCompose(opt -> opt.isEmpty() ?
+                        initializeCache() :
+                        Futures.of(opt.get())
+                ).thenCompose(cacheRoot -> retriever.apply(cacheBase.resolve(dir).resolve(DIR_CACHE_FILENAME)))
+                .thenCompose(fopt -> fopt.map(this::parseCacheFile).orElse(Futures.of(SharedWithState.empty())));
+    }
+
     private CompletableFuture<Pair<FileWrapper, SharedWithState>> retrieveWithFileOrCreate(Path dir) {
         return retriever.apply(cacheBase)
                 .thenCompose(opt -> opt.isEmpty() ?

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -143,7 +143,7 @@ public class SharedWithCache {
     }
 
     private List<String> toList(Path p) {
-        return Arrays.asList(p.toString().split("/"));
+        return Arrays.asList(toRelative(p).toString().split("/"));
     }
 
     private CompletableFuture<SharedWithState> parseCacheFile(FileWrapper cache) {

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -40,12 +40,16 @@ public class SharedWithCache {
         return p.isAbsolute() ? p : Paths.get("/").resolve(p);
     }
 
+    private static Path toRelative(Path p) {
+        return p.isAbsolute() ? Paths.get(p.toString().substring(1)) : p;
+    }
+
     private CompletableFuture<Optional<SharedWithState>> retrieve(Path dir) {
         return retrieveWithFile(dir).thenApply(opt -> opt.map(p -> p.right));
     }
 
     private CompletableFuture<Optional<Pair<FileWrapper, SharedWithState>>> retrieveWithFile(Path dir) {
-        return retriever.apply(cacheBase.resolve(dir).resolve(DIR_CACHE_FILENAME))
+        return retriever.apply(cacheBase.resolve(toRelative(dir)).resolve(DIR_CACHE_FILENAME))
                 .thenCompose(opt -> opt.isEmpty() ?
                         Futures.of(Optional.empty()) :
                         parseCacheFile(opt.get())
@@ -112,7 +116,7 @@ public class SharedWithCache {
     }
 
     public CompletableFuture<Map<Path, SharedWithState>> getAllDescendantShares(Path start) {
-        return retriever.apply(cacheBase.resolve(start.getParent()))
+        return retriever.apply(cacheBase.resolve(toRelative(start.getParent())))
                 .thenCompose(opt -> {
                     if (opt.isEmpty())
                         return Futures.of(Collections.emptyMap());

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -73,12 +73,12 @@ public class SharedWithCache {
                                                     ourname, network, crypto, false, false)
                                                     .thenCompose(readCaps -> {
                                                         readCaps.getRetrievedCapabilities().stream()
-                                                                .forEach(rc -> addSharedWith(Access.READ, Paths.get(rc.path), Set.of(friendDirectory.getName())));
+                                                                .forEach(rc -> addSharedWith(Access.READ, Paths.get(rc.path), Collections.singleton(friendDirectory.getName())));
                                                         return CapabilityStore.loadWriteableLinks(cacheDirOpt.get(), friendDirectory,
                                                                 ourname, network, crypto, false, false)
                                                                 .thenApply(writeCaps -> {
                                                                     writeCaps.getRetrievedCapabilities().stream()
-                                                                            .forEach(rc -> addSharedWith(Access.WRITE, Paths.get(rc.path), Set.of(friendDirectory.getName())));
+                                                                            .forEach(rc -> addSharedWith(Access.WRITE, Paths.get(rc.path), Collections.singleton(friendDirectory.getName())));
                                                                     return true;
                                                                 });
                                                     });

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -31,6 +31,7 @@ public class SharedWithState implements Cborable {
         return writeShares;
     }
 
+    @JsMethod
     public FileSharedWithState get(String filename) {
         return new FileSharedWithState(
                 readShares.getOrDefault(filename, Collections.emptySet()),

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -56,6 +56,8 @@ public class SharedWithState implements Cborable {
     }
 
     public SharedWithState add(SharedWithCache.Access access, String filename, Set<String> names) {
+        if (names.isEmpty())
+            return this;
         Map<String, Set<String>> newReads = new HashMap<>();
         for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
             newReads.put(e.getKey(), new HashSet<>(e.getValue()));

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -1,0 +1,150 @@
+package peergos.shared.user;
+
+import jsinterop.annotations.*;
+import peergos.shared.cbor.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/** Holds the sharing state for all the children of a directory
+ *
+ */
+public class SharedWithState implements Cborable {
+    private final Map<String, Set<String>> readShares;
+    private final Map<String, Set<String>> writeShares;
+
+    public SharedWithState(Map<String, Set<String>> readShares, Map<String, Set<String>> writeShares) {
+        this.readShares = readShares;
+        this.writeShares = writeShares;
+    }
+
+    public static SharedWithState empty() {
+        return new SharedWithState(new HashMap<>(), new HashMap<>());
+    }
+
+    public Map<String, Set<String>> readShares() {
+        return readShares;
+    }
+
+    public Map<String, Set<String>> writeShares() {
+        return writeShares;
+    }
+
+    public FileSharedWithState get(String filename) {
+        return new FileSharedWithState(
+                readShares.getOrDefault(filename, Collections.emptySet()),
+                writeShares.getOrDefault(filename, Collections.emptySet()));
+    }
+
+    public Optional<SharedWithState> filter(String childName) {
+        if (! readShares.containsKey(childName) && ! writeShares.containsKey(childName))
+            return Optional.empty();
+        Map<String, Set<String>> newReads = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+            if (e.getKey().equals(childName))
+                newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+        Map<String, Set<String>> newWrites = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+            if (e.getKey().equals(childName))
+                newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+
+        return Optional.of(new SharedWithState(newReads, newWrites));
+    }
+
+    public SharedWithState add(SharedWithCache.Access access, String filename, Set<String> names) {
+        Map<String, Set<String>> newReads = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+            newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+        Map<String, Set<String>> newWrites = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+            newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+
+        if (access == SharedWithCache.Access.READ) {
+            newReads.putIfAbsent(filename, new HashSet<>());
+            newReads.get(filename).addAll(names);
+        } else if (access == SharedWithCache.Access.WRITE) {
+            newWrites.putIfAbsent(filename, new HashSet<>());
+            newWrites.get(filename).addAll(names);
+        }
+
+        return new SharedWithState(newReads, newWrites);
+    }
+
+    public SharedWithState remove(SharedWithCache.Access access, String filename, Set<String> names) {
+        Map<String, Set<String>> newReads = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+            newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+        Map<String, Set<String>> newWrites = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+            newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+
+        Set<String> val = access == SharedWithCache.Access.READ ? newReads.get(filename) : newWrites.get(filename);
+        if (val != null)
+            val.removeAll(names);
+
+        return new SharedWithState(newReads, newWrites);
+    }
+
+    public SharedWithState clear(String filename) {
+        Map<String, Set<String>> newReads = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+            newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+        Map<String, Set<String>> newWrites = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+            newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+
+        newReads.remove(filename);
+        newWrites.remove(filename);
+
+        return new SharedWithState(newReads, newWrites);
+    }
+
+    @JsMethod
+    public boolean isShared(String filename) {
+        return readShares.containsKey(filename) || writeShares.containsKey(filename);
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        SortedMap<String, Cborable> readState = new TreeMap<>();
+        for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+            readState.put(e.getKey(), new CborObject.CborList(e.getValue().stream().map(CborObject.CborString::new).collect(Collectors.toList())));
+        }
+        SortedMap<String, Cborable> writeState = new TreeMap<>();
+        for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+            writeState.put(e.getKey(), new CborObject.CborList(e.getValue().stream().map(CborObject.CborString::new).collect(Collectors.toList())));
+        }
+
+        state.put("r", CborObject.CborMap.build(readState));
+        state.put("w", CborObject.CborMap.build(writeState));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static SharedWithState fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for SharedWithState!");
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        CborObject.CborMap r = m.get("r", c -> (CborObject.CborMap) c);
+        Function<Cborable, String> getString = c -> ((CborObject.CborString) c).value;
+        Map<String, Set<String>> readShares = r.getMap(
+                getString,
+                c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
+
+        CborObject.CborMap w = m.get("w", c -> (CborObject.CborMap) c);
+        Map<String, Set<String>> writehares = w.getMap(
+                getString,
+                c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
+
+        return new SharedWithState(readShares, writehares);
+    }
+}

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -89,8 +89,16 @@ public class SharedWithState implements Cborable {
         }
 
         Set<String> val = access == SharedWithCache.Access.READ ? newReads.get(filename) : newWrites.get(filename);
-        if (val != null)
+        if (val != null) {
             val.removeAll(names);
+            if (val.isEmpty()) {
+                if (access == SharedWithCache.Access.READ) {
+                    newReads.remove(filename);
+                } else {
+                    newWrites.remove(filename);
+                }
+            }
+        }
 
         return new SharedWithState(newReads, newWrites);
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1321,7 +1321,19 @@ public class UserContext {
     public CompletableFuture<SharedWithState> getDirectorySharingState(Path dir) {
         return sharedWithCache.getDirSharingState(dir);
     }
-
+    @JsMethod
+    public static Path toPath(String[] parts, String filename) {
+        if (parts == null || parts.length == 0 || filename == null) {
+            throw new IllegalArgumentException("Invalid params");
+        }else if (parts.length == 1) {
+            return Paths.get(parts[0], filename);
+        } else {
+            List<String> pathFragments = Stream.of(parts).skip(1).collect(Collectors.toList());
+            pathFragments.add(filename);
+            String[] remainder = pathFragments.toArray(new String[1]);
+            return Paths.get(parts[0], remainder);
+        }
+    }
     public CompletableFuture<Boolean> shareReadAccessWith(Path path, Set<String> readersToAdd) {
         return getByPath(path.toString())
                 .thenCompose(file -> shareReadAccessWithAll(file.orElseThrow(() ->

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1427,6 +1427,9 @@ public class UserContext {
     }
 
     public CompletableFuture<Boolean> sendWriteCapToAll(Path toFile, Set<String> writersToAdd) {
+        if (writersToAdd.isEmpty())
+            return Futures.of(true);
+
         System.out.println("Resharing WRITE cap to " + toFile + " with " + writersToAdd);
         return getByPath(toFile.getParent())
                 .thenCompose(parent -> getByPath(toFile)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1200,7 +1200,6 @@ public class UserContext {
             return getByPath(path.getParent().toString())
                     .thenCompose(parentOpt -> {
                         FileWrapper parent = parentOpt.get();
-                        AbsoluteCapability originalCap = toUnshare.getPointer().capability;
                         return rotateAllKeys(toUnshare, parent, true)
                                 .thenCompose(x ->
                                         sharedWithCache.removeSharedWith(SharedWithCache.Access.WRITE,
@@ -1304,7 +1303,7 @@ public class UserContext {
             return getByPath(path.getParent().toString())
                     .thenCompose(parent -> rotateAllKeys(toUnshare, parent.get(), false)
                             .thenCompose(markedDirty -> {
-                                AbsoluteCapability originalCap = toUnshare.getPointer().capability;
+                                AbsoluteCapability originalCap = toUnshare.getPointer().capability;//todo delete
                                 return sharedWithCache.removeSharedWith(SharedWithCache.Access.READ, path, readersToRemove)
                                         .thenCompose(b -> reSendAllWriteAccessRecursive(path))
                                         .thenCompose(b -> reSendAllReadAccessRecursive(path));

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1315,6 +1315,11 @@ public class UserContext {
         return sharedWithCache.getSharedWith(p);
     }
 
+    @JsMethod
+    public CompletableFuture<Boolean> isShared(Path p) {
+        return sharedWithCache.getSharedWith(p).thenApply(s -> ! s.readAccess.isEmpty() || ! s.writeAccess.isEmpty());
+    }
+
     public CompletableFuture<Boolean> shareReadAccessWith(Path path, Set<String> readersToAdd) {
         return getByPath(path.toString())
                 .thenCompose(file -> shareReadAccessWithAll(file.orElseThrow(() ->

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1316,8 +1316,8 @@ public class UserContext {
     }
 
     @JsMethod
-    public CompletableFuture<Boolean> isShared(Path p) {
-        return sharedWithCache.getSharedWith(p).thenApply(s -> ! s.readAccess.isEmpty() || ! s.writeAccess.isEmpty());
+    public CompletableFuture<SharedWithState> getDirectorySharingState(Path dir) {
+        return sharedWithCache.getDirSharingState(dir);
     }
 
     public CompletableFuture<Boolean> shareReadAccessWith(Path path, Set<String> readersToAdd) {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1313,7 +1313,7 @@ public class UserContext {
     }
 
     @JsMethod
-    public CompletableFuture<SharedWithCache.FileSharedWithState> sharedWith(Path p, FileWrapper file) {
+    public CompletableFuture<FileSharedWithState> sharedWith(Path p, FileWrapper file) {
         return sharedWithCache.getSharedWith(p);
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1335,12 +1335,18 @@ public class UserContext {
         }
     }
     public CompletableFuture<Boolean> shareReadAccessWith(Path path, Set<String> readersToAdd) {
+        if (readersToAdd.isEmpty())
+            return Futures.of(true);
+
         return getByPath(path.toString())
                 .thenCompose(file -> shareReadAccessWithAll(file.orElseThrow(() ->
                         new IllegalStateException("Could not find path " + path.toString())), path, readersToAdd));
     }
 
     public CompletableFuture<Boolean> shareWriteAccessWith(Path fileToShare, Set<String> writersToAdd) {
+        if (writersToAdd.isEmpty())
+            return Futures.of(true);
+
         return getByPath(fileToShare.getParent().toString())
                 .thenCompose(parent -> {
                     if (! parent.isPresent())

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1428,7 +1428,7 @@ public class UserContext {
                                                         Set<String> writersToAdd) {
         if (parent.writer().equals(file.writer()))
             return Futures.errored(
-                    new IllegalStateException("A file must have different writer than it's parent to grant write access!"));
+                    new IllegalStateException("A file must have different writer than its parent to grant write access!"));
         BiFunction<FileWrapper, FileWrapper, CompletableFuture<Boolean>> sharingFunction =
                 (sharedDir, fileToShare) -> CapabilityStore.addEditSharingLinkTo(sharedDir,
                         file.writableFilePointer(), network, crypto)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1321,19 +1321,7 @@ public class UserContext {
     public CompletableFuture<SharedWithState> getDirectorySharingState(Path dir) {
         return sharedWithCache.getDirSharingState(dir);
     }
-    @JsMethod
-    public static Path toPath(String[] parts, String filename) {
-        if (parts == null || parts.length == 0 || filename == null) {
-            throw new IllegalArgumentException("Invalid params");
-        }else if (parts.length == 1) {
-            return Paths.get(parts[0], filename);
-        } else {
-            List<String> pathFragments = Stream.of(parts).skip(1).collect(Collectors.toList());
-            pathFragments.add(filename);
-            String[] remainder = pathFragments.toArray(new String[1]);
-            return Paths.get(parts[0], remainder);
-        }
-    }
+
     public CompletableFuture<Boolean> shareReadAccessWith(Path path, Set<String> readersToAdd) {
         if (readersToAdd.isEmpty())
             return Futures.of(true);

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1319,6 +1319,9 @@ public class UserContext {
 
     @JsMethod
     public CompletableFuture<SharedWithState> getDirectorySharingState(Path dir) {
+        // The global root and home folders cannot be shared
+        if (dir.getNameCount() <= 1)
+            return Futures.of(SharedWithState.empty());
         return sharedWithCache.getDirSharingState(dir);
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1335,9 +1335,6 @@ public class UserContext {
     }
 
     public CompletableFuture<Boolean> shareWriteAccessWith(Path fileToShare, Set<String> writersToAdd) {
-        if (writersToAdd.isEmpty())
-            return Futures.of(true);
-
         return getByPath(fileToShare.getParent().toString())
                 .thenCompose(parent -> {
                     if (! parent.isPresent())

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1320,7 +1320,7 @@ public class UserContext {
     @JsMethod
     public CompletableFuture<SharedWithState> getDirectorySharingState(Path dir) {
         // The global root and home folders cannot be shared
-        if (dir.getNameCount() <= 1)
+        if (dir.getNameCount() == 0)
             return Futures.of(SharedWithState.empty());
         return sharedWithCache.getDirSharingState(dir);
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1303,7 +1303,6 @@ public class UserContext {
             return getByPath(path.getParent().toString())
                     .thenCompose(parent -> rotateAllKeys(toUnshare, parent.get(), false)
                             .thenCompose(markedDirty -> {
-                                AbsoluteCapability originalCap = toUnshare.getPointer().capability;//todo delete
                                 return sharedWithCache.removeSharedWith(SharedWithCache.Access.READ, path, readersToRemove)
                                         .thenCompose(b -> reSendAllWriteAccessRecursive(path))
                                         .thenCompose(b -> reSendAllReadAccessRecursive(path));

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -491,14 +491,14 @@ public class UserContext {
                                 true,
                                 (x, friendDirectory) -> {
                                     return CapabilityStore.loadReadOnlyLinks(homeDirSupplier, friendDirectory,
-                                            this.username, network, crypto, false)
+                                            friendDirectory.getName(), network, crypto, true, false)
                                             .thenCompose(readCaps -> {
                                                 readCaps.getRetrievedCapabilities().stream().forEach(rc -> {
                                                     sharedWithCache.addSharedWith(SharedWithCache.Access.READ,
                                                         rc.path, rc.cap, friendDirectory.getName());
                                                 });
                                                 return CapabilityStore.loadWriteableLinks(homeDirSupplier, friendDirectory,
-                                                        this.username, network, crypto, false)
+                                                        friendDirectory.getName(), network, crypto, true, false)
                                                         .thenApply(writeCaps -> {
                                                             writeCaps.getRetrievedCapabilities().stream().forEach(rc -> {
                                                                 sharedWithCache.addSharedWith(SharedWithCache.Access.WRITE,
@@ -507,7 +507,7 @@ public class UserContext {
                                                             return true;
                                                         });
                                             });
-                                }, (a, b) -> a && b).thenApply(done -> done));
+                                }, (a, b) -> a && b));
     }
 
     public CompletableFuture<FileWrapper> getSharingFolder() {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1311,7 +1311,7 @@ public class UserContext {
     }
 
     @JsMethod
-    public CompletableFuture<FileSharedWithState> sharedWith(Path p, FileWrapper file) {
+    public CompletableFuture<FileSharedWithState> sharedWith(Path p) {
         return sharedWithCache.getSharedWith(p);
     }
 

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -24,7 +24,7 @@ import java.util.stream.*;
  * Each of these cache files is just a serialized CapabilitiesFromUser
  */
 public class CapabilityStore {
-    private static final String CAPABILITY_CACHE_DIR = ".capabilitycache";
+    public static final String CAPABILITY_CACHE_DIR = ".capabilitycache";
     private static final String READ_SHARING_FILE_NAME = "sharing.r";
     private static final String EDIT_SHARING_FILE_NAME = "sharing.w";
 

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1108,6 +1108,7 @@ public class FileWrapper {
     @JsMethod
     public CompletableFuture<FileWrapper> rename(String newFilename,
                                                  FileWrapper parent,
+                                                 Path ourPath,
                                                  UserContext userContext) {
         if (! isLegalName(newFilename))
             return CompletableFuture.completedFuture(parent);
@@ -1140,7 +1141,9 @@ public class FileWrapper {
                             (s, committer) -> nodeToUpdate.updateProperties(s, committer, us,
                                     entryWriter, newProps, userContext.network))
                             .thenApply(newVersion -> parent.withVersion(newVersion));
-                });
+                }).thenCompose(f -> userContext.sharedWithCache
+                        .rename(ourPath, ourPath.getParent().resolve(newFilename))
+                        .thenApply(b -> f));
     }
 
     public CompletableFuture<Boolean> setProperties(FileProperties updatedProperties,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -608,9 +608,10 @@ public class FileWrapper {
     public CompletableFuture<FileWrapper> uploadAndReturnFile(String filename,
                                                               AsyncReader fileData,
                                                               long length,
+                                                              boolean isHidden,
                                                               NetworkAccess network,
                                                               Crypto crypto) {
-        return uploadFileSection(filename, fileData, false, 0, length, Optional.empty(),
+        return uploadFileSection(filename, fileData, isHidden, 0, length, Optional.empty(),
                 true, network, crypto, x -> {}, crypto.random.randomBytes(32))
                 .thenCompose(f -> f.getChild(filename, crypto.hasher, network)
                         .thenCompose(childOpt -> childOpt.get().truncate(length, network, crypto)));

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -129,6 +129,11 @@ public class FileWrapper {
         return pointer.equals(((FileWrapper) other).getPointer());
     }
 
+    public CompletableFuture<FileWrapper> getUpdated(NetworkAccess network) {
+        return network.synchronizer.getValue(owner(), writer())
+                .thenCompose(v -> getUpdated(v, network));
+    }
+
     public CompletableFuture<FileWrapper> getUpdated(Snapshot version, NetworkAccess network) {
         if (this.version.get(writer()).equals(version.get(writer())))
             return CompletableFuture.completedFuture(this);

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -351,14 +351,24 @@ public class FileWrapper {
     }
 
     public CompletableFuture<Set<FileWrapper>> getChildren(Snapshot version, Hasher hasher, NetworkAccess network) {
+        return getChildren(version, false, hasher, network);
+    }
+
+    public CompletableFuture<Set<FileWrapper>> getChildrenWithSameWriter(Hasher hasher, NetworkAccess network) {
+        return getChildren(version, true, hasher, network);
+    }
+
+    public CompletableFuture<Set<FileWrapper>> getChildren(Snapshot version, boolean sameWriterOnly, Hasher hasher, NetworkAccess network) {
         if (capTrie.isPresent())
             return capTrie.get().getChildren("/", hasher, version.merge(this.version), network);
         if (isReadable()) {
             Optional<SigningPrivateKeyAndPublicHash> childsEntryWriter = pointer.capability.wBaseKey
                     .map(wBase -> pointer.fileAccess.getSigner(pointer.capability.rBaseKey, wBase, entryWriter));
             return pointer.fileAccess.getAllChildrenCapabilities(version, pointer.capability, hasher, network)
-                    .thenCompose(childCaps ->
-                            getFiles(owner(), childCaps, childsEntryWriter, ownername, network, version));
+                    .thenCompose(childCaps -> sameWriterOnly ?
+                            getFilesWithSameWriter(owner(), childCaps, childsEntryWriter, ownername, network, version) :
+                            getFiles(owner(), childCaps, childsEntryWriter, ownername, network, version)
+                    );
         }
         throw new IllegalStateException("Unreadable FileWrapper!");
     }
@@ -395,6 +405,23 @@ public class FileWrapper {
                                         return Futures.of(new FileWrapper(rc, Optional.empty(), entryWriter, ownername, fullVersion));
                                     return NetworkAccess.getFileFromLink(owner, rc, entryWriter, ownername, network, version);
                                 })
+                                .collect(Collectors.toSet()))));
+    }
+
+    private static CompletableFuture<Set<FileWrapper>> getFilesWithSameWriter(PublicKeyHash owner,
+                                                                              Set<AbsoluteCapability> caps,
+                                                                              Optional<SigningPrivateKeyAndPublicHash> entryWriter,
+                                                                              String ownername,
+                                                                              NetworkAccess network,
+                                                                              Snapshot version) {
+        Set<PublicKeyHash> childWriters = caps.stream()
+                .map(c -> c.writer)
+                .collect(Collectors.toSet());
+        return version.withWriters(owner, childWriters, network)
+                .thenCompose(fullVersion -> network.retrieveAllMetadata(new ArrayList<>(caps), fullVersion)
+                        .thenCompose(rcs -> Futures.combineAll(rcs.stream()
+                                .filter(rc -> ! rc.getProperties().isLink)
+                                .map(rc -> Futures.of(new FileWrapper(rc, Optional.empty(), entryWriter, ownername, fullVersion)))
                                 .collect(Collectors.toSet()))));
     }
 
@@ -576,6 +603,17 @@ public class FileWrapper {
                 .thenCompose(f -> f.getChild(filename, crypto.hasher, network)
                         .thenCompose(childOpt -> childOpt.get().truncate(length, network, crypto))
                         .thenCompose(c -> f.getUpdated(f.version.mergeAndOverwriteWith(c.version), network)));
+    }
+
+    public CompletableFuture<FileWrapper> uploadAndReturnFile(String filename,
+                                                              AsyncReader fileData,
+                                                              long length,
+                                                              NetworkAccess network,
+                                                              Crypto crypto) {
+        return uploadFileSection(filename, fileData, false, 0, length, Optional.empty(),
+                true, network, crypto, x -> {}, crypto.random.randomBytes(32))
+                .thenCompose(f -> f.getChild(filename, crypto.hasher, network)
+                        .thenCompose(childOpt -> childOpt.get().truncate(length, network, crypto)));
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1086,7 +1086,7 @@ public class FileWrapper {
     }
 
     static boolean isLegalName(String name) {
-        return !name.contains("/") && ! name.equals(".") && ! name.equals("..");
+        return !name.contains("/") && ! name.equals(".") && ! name.equals("..") && ! name.isEmpty();
     }
 
     /**

--- a/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
+++ b/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
@@ -182,7 +182,7 @@ public class LazyInputStreamCombiner implements AsyncReader {
         long seek = ((long) (hi32) << 32) | (low32 & 0xFFFFFFFFL);
 
         if (totalLength < seek)
-            throw new IllegalStateException("Cannot seek to position "+ seek);
+            throw new IllegalStateException("Cannot seek to position "+ seek + " in file of length " + totalLength);
         long globalOffset = globalIndex + index;
         if (seek > globalOffset)
             return copy().skip(seek - globalOffset);


### PR DESCRIPTION
This rewrites the shared-with cache to reside in a parallel directory tree. This then contributes 0 to login time, and O(1) to navigate to a directory and display which children are shared.