### PR TITLE
Increase max fragment size from 128 KiB to 512 KiB.

### DIFF
--- a/src/peergos/shared/user/fs/Fragment.java
+++ b/src/peergos/shared/user/fs/Fragment.java
@@ -1,10 +1,10 @@
 package peergos.shared.user.fs;
 
-/** A Fragment is a part of an EncryptedChunk which is stored directly in IPFS in raw format
+/** A Fragment is a part of an EncryptedChunk which is stored directly in IPFS in a raw format block
  *
  */
 public class Fragment {
-    public static final int MAX_LENGTH = 1024*128;
+    public static final int MAX_LENGTH = 512*1024; // max size allowed by bitswap protocol is 1 MiB
 
     public final byte[] data;
 


### PR DESCRIPTION
This is still allowed in bitswap (which allows up to 1 MiB) and
it should make uploads and downloads much faster (less latency sensitive).
It also means that when download chunks in parallel we need 4x fewer 
download threads.

The original motivation for 128 KiB was to play well with erasure encoding
(5 MiB -> 40 * 128 KiB ==erasure encode=> 60 * 128 KiB),
but we no longer do that and it should be done at a lower level regardless.

This will reduce the number of network requests to retrieve a block by 4X
and thus greatly improve bandwidth for latency sensitive instances.

It also reduces the pressure on the blockstore by having ~ 4x fewer blocks.
Some blockstores like S3 can impose limits on the total number of blocks
and also on the number of requests per second.