### PR TITLE
link fix

### DIFF
--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1816,6 +1816,9 @@ public class UserContext {
 
     @JsMethod
     public CompletableFuture<List<ServerConversation>> getServerConversations() {
+        if (this.username == null) {
+            return Futures.of(Collections.emptyList());
+        }
         return network.serverMessager.getMessages(username, signer.secret).thenApply(ServerConversation::combine);
     }
 


### PR DESCRIPTION
handle case where a user navigates to a secret link. 
There are no server msgs in this case, so return empty list.