### PR TITLE
Make S3 GETs and HEADs use headers for auth.

### DIFF
--- a/src/peergos/server/storage/S3Request.java
+++ b/src/peergos/server/storage/S3Request.java
@@ -1,6 +1,7 @@
 package peergos.server.storage;
 
 import org.w3c.dom.*;
+import peergos.server.util.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
 import peergos.shared.util.*;
@@ -305,7 +306,7 @@ public class S3Request {
                                                    String region,
                                                    String accessKeyId,
                                                    String s3SecretKey) {
-        S3Request policy = new S3Request(verb, host, key, UNSIGNED, expiresSeconds, false, false,
+        S3Request policy = new S3Request(verb, host, key, UNSIGNED, expiresSeconds, false, true,
                 Collections.emptyMap(), Collections.emptyMap(), accessKeyId, region, now);
         return preSignRequest(policy, key, host, s3SecretKey);
     }

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -260,7 +260,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
         if (authedReads) {
             CompletableFuture<Optional<byte[]>> res = new CompletableFuture<>();
             fallback.authReads(Arrays.asList(hash))
-                    .thenCompose(preAuthedGet -> direct.get(preAuthedGet.get(0).base))
+                    .thenCompose(preAuthedGet -> direct.get(preAuthedGet.get(0).base, preAuthedGet.get(0).fields))
                     .thenApply(Optional::of)
                     .thenAccept(res::complete)
                     .exceptionally(t -> {

--- a/src/peergos/shared/user/HttpPoster.java
+++ b/src/peergos/shared/user/HttpPoster.java
@@ -13,6 +13,8 @@ public interface HttpPoster {
 
     CompletableFuture<byte[]> put(String url, byte[] payload, Map<String, String> headers);
 
+    CompletableFuture<byte[]> get(String url, Map<String, String> headers);
+
     default CompletableFuture<byte[]> get(String url) {
         // This changes to a POST with an empty body
         // The reason for this is browsers allow any website to do a get request to localhost

--- a/src/peergos/shared/user/JavaPoster.java
+++ b/src/peergos/shared/user/JavaPoster.java
@@ -124,14 +124,7 @@ public class JavaPoster implements HttpPoster {
 
     @Override
     public CompletableFuture<byte[]> get(String url) {
-        if (useGet) {
-            return publicGet(url, Collections.emptyMap());
-        } else {
-            // This changes to a POST with an empty body
-            // The reason for this is browsers allow any website to do a get request to localhost
-            // but they block POST requests. So this prevents random websites from calling APIs on localhost
-            return postUnzip(url, new byte[0]);
-        }
+        return get(url, Collections.emptyMap());
     }
 
     @Override

--- a/src/peergos/shared/user/JavaScriptPoster.java
+++ b/src/peergos/shared/user/JavaScriptPoster.java
@@ -49,9 +49,7 @@ public class JavaScriptPoster implements HttpPoster {
 
     @Override
     public CompletableFuture<byte[]> get(String url) {
-        if (isAbsolute || useGet) // Still do a get if we are served from an IPFS gateway
-            return http.get(url);
-        return postUnzip(url, new byte[0]);
+        return get(url, Collections.emptyMap());
     }
 
     @Override

--- a/src/peergos/shared/user/JavaScriptPoster.java
+++ b/src/peergos/shared/user/JavaScriptPoster.java
@@ -54,6 +54,20 @@ public class JavaScriptPoster implements HttpPoster {
         return postUnzip(url, new byte[0]);
     }
 
+    @Override
+    public CompletableFuture<byte[]> get(String url, Map<String, String> headers) {
+        if (isAbsolute || useGet) {// Still do a get if we are served from an IPFS gateway
+            String[] headersArray = new String[headers.size() * 2];
+            int index = 0;
+            for (Map.Entry<String, String> e : headers.entrySet()) {
+                headersArray[index++] = e.getKey();
+                headersArray[index++] = e.getValue();
+            }
+            return http.getWithHeaders(url, headersArray);
+        }
+        return postUnzip(url, new byte[0]);
+    }
+
     @JsMethod
     public static byte[] emptyArray() {
         return new byte[0];

--- a/src/peergos/shared/user/NativeJSHttp.java
+++ b/src/peergos/shared/user/NativeJSHttp.java
@@ -78,6 +78,8 @@ public class NativeJSHttp {
         return future;
     }-*/;
 
+    public native CompletableFuture<byte[]> getWithHeaders(String url, String[] headers);
+
     public native CompletableFuture<byte[]> postMultipart(String url, List<byte[]> payload);
 
     public native CompletableFuture<byte[]> put(String url, byte[] payload, String[] headers);


### PR DESCRIPTION
This means that browsers will cache the responses.