### PR TITLE
Implement a proof of work to rate limit sign ups

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -836,7 +836,7 @@ public class Main {
                                 .commit(peergosIdentity, pkiSigner, MaybeMultihash.empty(), mutable, dht, crypto.hasher, tid)
                                 .thenApply(version -> version.get(pkiSigner).hash), dht).join();
 
-            return new IpfsCoreNode(pkiSigner, currentPkiRoot, dht, crypto.hasher, mutable, peergosIdentity);
+            return new IpfsCoreNode(pkiSigner, a.getInt("max-daily-signups"), currentPkiRoot, dht, crypto.hasher, mutable, peergosIdentity);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -26,10 +26,10 @@ public class CorenodeEventPropagator implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
+    public CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
         return target.updateChain(username, chain, proof)
                 .thenApply(res -> {
-                    if (res) {
+                    if (res.isEmpty()) {
                         CorenodeEvent event = new CorenodeEvent(username, chain.get(chain.size() - 1).owner);
                         for (Consumer<? super CorenodeEvent> listener : listeners) {
                             listener.accept(event);

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -1,6 +1,7 @@
 package peergos.server.corenode;
 
 import peergos.shared.corenode.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 
 import java.io.*;
@@ -25,8 +26,8 @@ public class CorenodeEventPropagator implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
-        return target.updateChain(username, chain)
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
+        return target.updateChain(username, chain, proof)
                 .thenApply(res -> {
                     if (res) {
                         CorenodeEvent event = new CorenodeEvent(username, chain.get(chain.size() - 1).owner);

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -39,6 +39,7 @@ public class IpfsCoreNode implements CoreNode {
     private MaybeMultihash currentRoot;
 
     public IpfsCoreNode(SigningPrivateKeyAndPublicHash pkiSigner,
+                        int maxSignupsPerDay,
                         MaybeMultihash currentRoot,
                         ContentAddressedStorage ipfs,
                         Hasher hasher,
@@ -51,7 +52,7 @@ public class IpfsCoreNode implements CoreNode {
         this.peergosIdentity = peergosIdentity;
         this.signer = pkiSigner;
         this.update(currentRoot);
-        this.difficultyGenerator = new DifficultyGenerator(System.currentTimeMillis(), 1000);
+        this.difficultyGenerator = new DifficultyGenerator(System.currentTimeMillis(), maxSignupsPerDay);
     }
 
     public static byte[] keyHash(ByteArrayWrapper username) {

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -157,8 +157,11 @@ public class IpfsCoreNode implements CoreNode {
         byte[] hash = hasher.sha256(ArrayOps.concat(proof.prefix, new CborObject.CborList(updatedChain).serialize())).join();
         difficultyGenerator.updateTime(System.currentTimeMillis());
         int requiredDifficulty = difficultyGenerator.currentDifficulty();
-        if (! ProofOfWork.satisfiesDifficulty(requiredDifficulty, hash))
+        if (! ProofOfWork.satisfiesDifficulty(requiredDifficulty, hash)) {
+            LOG.log(Level.INFO, "Rejected request with insufficient proof of work for difficulty: " +
+                    requiredDifficulty + " and username " + username);
             return Futures.of(Optional.of(new RequiredDifficulty(requiredDifficulty)));
+        }
 
         difficultyGenerator.addEvent();
         try {

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -267,7 +267,8 @@ public class MirrorCoreNode implements CoreNode {
     public CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
         return writeTarget.updateChain(username, chain, proof)
                 .thenApply(x -> {
-                    this.update();
+                    if (x.isEmpty())
+                        this.update();
                     return x;
                 });
     }

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -264,8 +264,12 @@ public class MirrorCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
-        return writeTarget.updateChain(username, chain, proof).thenApply(x -> this.update());
+    public CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
+        return writeTarget.updateChain(username, chain, proof)
+                .thenApply(x -> {
+                    this.update();
+                    return x;
+                });
     }
 
     @Override

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -5,6 +5,7 @@ import peergos.server.util.*;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.hamt.*;
 import peergos.shared.mutable.*;
@@ -263,8 +264,8 @@ public class MirrorCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
-        return writeTarget.updateChain(username, chain).thenApply(x -> this.update());
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
+        return writeTarget.updateChain(username, chain, proof).thenApply(x -> this.update());
     }
 
     @Override

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -63,7 +63,7 @@ public class NonWriteThroughCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> updated, ProofOfWork proof) {
+    public CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username, List<UserPublicKeyLink> updated, ProofOfWork proof) {
         try {
             List<UserPublicKeyLink> modified = tempChains.get(username);
             if (modified != null)
@@ -72,7 +72,7 @@ public class NonWriteThroughCoreNode implements CoreNode {
             tempChains.put(username, mergedChain);
             UserPublicKeyLink last = mergedChain.get(mergedChain.size() - 1);
             tempOwnerToUsername.put(last.owner, username);
-            return CompletableFuture.completedFuture(true);
+            return CompletableFuture.completedFuture(Optional.empty());
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -1,6 +1,7 @@
 package peergos.server.corenode;
 
 import peergos.shared.corenode.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
 
@@ -62,7 +63,7 @@ public class NonWriteThroughCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> updated) {
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> updated, ProofOfWork proof) {
         try {
             List<UserPublicKeyLink> modified = tempChains.get(username);
             if (modified != null)

--- a/src/peergos/server/corenode/SignUpFilter.java
+++ b/src/peergos/server/corenode/SignUpFilter.java
@@ -28,7 +28,7 @@ public class SignUpFilter implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
+    public CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
         boolean forUs = chain.get(chain.size() - 1).claim.storageProviders.contains(ourNodeId);
         if (! forUs)
             return target.updateChain(username, chain, proof);

--- a/src/peergos/server/corenode/SignUpFilter.java
+++ b/src/peergos/server/corenode/SignUpFilter.java
@@ -2,6 +2,7 @@ package peergos.server.corenode;
 
 import peergos.server.storage.admin.*;
 import peergos.shared.corenode.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 
@@ -27,14 +28,14 @@ public class SignUpFilter implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
         boolean forUs = chain.get(chain.size() - 1).claim.storageProviders.contains(ourNodeId);
         if (! forUs)
-            return target.updateChain(username, chain);
+            return target.updateChain(username, chain, proof);
         return CompletableFuture.completedFuture(true)
                 .thenCompose(x -> {
                     if (judge.allowSignupOrUpdate(username))
-                        return target.updateChain(username, chain);
+                        return target.updateChain(username, chain, proof);
                     throw new IllegalStateException("This server is not currently accepting new sign ups. Please try again later");
                 });
     }

--- a/src/peergos/server/tests/DifficultyGeneratorTests.java
+++ b/src/peergos/server/tests/DifficultyGeneratorTests.java
@@ -13,12 +13,11 @@ public class DifficultyGeneratorTests {
         long currentTime = startTime;
         DifficultyGenerator gen = new DifficultyGenerator(currentTime, maxPerDay);
         int events = 100;
-        int toSleep = 0;
         for (int i = 0; i < events; i++) {
             gen.addEvent();
             int diff = gen.currentDifficulty();
             System.out.println("Difficulty " + diff);
-            toSleep = 10 << (diff - 11);
+            long toSleep = 1L << diff;
             currentTime += toSleep;
             gen.updateTime(currentTime);
         }

--- a/src/peergos/server/tests/DifficultyGeneratorTests.java
+++ b/src/peergos/server/tests/DifficultyGeneratorTests.java
@@ -18,7 +18,7 @@ public class DifficultyGeneratorTests {
             gen.addEvent();
             int diff = gen.currentDifficulty();
             System.out.println("Difficulty " + diff);
-            toSleep = 1 << (diff - 11);
+            toSleep = 10 << (diff - 11);
             currentTime += toSleep;
             gen.updateTime(currentTime);
         }

--- a/src/peergos/server/tests/DifficultyGeneratorTests.java
+++ b/src/peergos/server/tests/DifficultyGeneratorTests.java
@@ -4,6 +4,8 @@ import org.junit.*;
 import peergos.server.util.*;
 import peergos.shared.crypto.*;
 
+import java.util.*;
+
 public class DifficultyGeneratorTests {
 
     @Test
@@ -21,7 +23,7 @@ public class DifficultyGeneratorTests {
             currentTime += toSleep;
             gen.updateTime(currentTime);
         }
-        long minDuration = maxPerDay * 86400_000 / events;
+        long minDuration = maxPerDay * 86400_000L / events;
         long duration = currentTime - startTime;
         Assert.assertTrue("Won't exceed daily limit", duration > minDuration);
 
@@ -29,5 +31,33 @@ public class DifficultyGeneratorTests {
         gen.updateTime(currentTime + 86400_000L * events / maxPerDay);
         int afterDelay = gen.currentDifficulty();
         Assert.assertTrue("Reduce difficulty after period of no queries", afterDelay == ProofOfWork.MIN_DIFFICULTY);
+    }
+
+    /** Simulate different hardware which gives a different constant factor in proof of work slow down
+     *
+     */
+    @Test
+    public void differentHardware() {
+        for (int i: List.of(10_000, 1_000, 1_000_000))
+            differentHardware(i);
+    }
+
+    public void differentHardware(int hardwareSpeedup) {
+        int maxPerDay = 1000;
+        long startTime = System.currentTimeMillis();
+        long currentTime = startTime;
+        DifficultyGenerator gen = new DifficultyGenerator(currentTime, maxPerDay);
+        int events = 1000;
+        for (int i = 0; i < events; i++) {
+            gen.addEvent();
+            int diff = gen.currentDifficulty();
+            System.out.println("Difficulty " + diff);
+            long toSleep = (1L << diff) / hardwareSpeedup;
+            currentTime += toSleep;
+            gen.updateTime(currentTime);
+        }
+        long minDuration = maxPerDay * 86400_000L / events;
+        long duration = currentTime - startTime;
+        Assert.assertTrue("Won't exceed daily limit", duration > minDuration);
     }
 }

--- a/src/peergos/server/tests/DifficultyGeneratorTests.java
+++ b/src/peergos/server/tests/DifficultyGeneratorTests.java
@@ -1,0 +1,34 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.util.*;
+import peergos.shared.crypto.*;
+
+public class DifficultyGeneratorTests {
+
+    @Test
+    public void rateLimited() {
+        int maxPerDay = 1000;
+        long startTime = System.currentTimeMillis();
+        long currentTime = startTime;
+        DifficultyGenerator gen = new DifficultyGenerator(currentTime, maxPerDay);
+        int events = 100;
+        int toSleep = 0;
+        for (int i = 0; i < events; i++) {
+            gen.addEvent();
+            int diff = gen.currentDifficulty();
+            System.out.println("Difficulty " + diff);
+            toSleep = 1 << (diff - 11);
+            currentTime += toSleep;
+            gen.updateTime(currentTime);
+        }
+        long minDuration = maxPerDay * 86400_000 / events;
+        long duration = currentTime - startTime;
+        Assert.assertTrue("Won't exceed daily limit", duration > minDuration);
+
+        // Check recovery after a delay
+        gen.updateTime(currentTime + 86400_000L * events / maxPerDay);
+        int afterDelay = gen.currentDifficulty();
+        Assert.assertTrue("Reduce difficulty after period of no queries", afterDelay == ProofOfWork.MIN_DIFFICULTY);
+    }
+}

--- a/src/peergos/server/tests/ProofOfWorkTests.java
+++ b/src/peergos/server/tests/ProofOfWorkTests.java
@@ -1,0 +1,26 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.*;
+import peergos.shared.*;
+import peergos.shared.crypto.*;
+import peergos.shared.util.*;
+
+public class ProofOfWorkTests {
+    private static final Crypto crypto = Main.initCrypto();
+
+    @Test
+    public void validity() {
+        byte[] data = crypto.random.randomBytes(100);
+        // d<=21 takes < 1s, 22-24 take ~12s, 25 takes ~ 85s (all with native sha256, and single threaded)
+        // so probably 11 should be the default
+        for (int d=0; d < 25; d++) {
+            long t0 = System.currentTimeMillis();
+            ProofOfWork work = crypto.hasher.generateProofOfWork(d, data).join();
+            long t1 = System.currentTimeMillis();
+            System.out.println("Difficulty: " + d + " took " + (t1 - t0) + "ms");
+            byte[] hash = crypto.hasher.sha256(ArrayOps.concat(work.prefix, work.data)).join();
+            Assert.assertTrue(ProofOfWork.satisfiesDifficulty(d, hash));
+        }
+    }
+}

--- a/src/peergos/server/tests/ProofOfWorkTests.java
+++ b/src/peergos/server/tests/ProofOfWorkTests.java
@@ -19,7 +19,7 @@ public class ProofOfWorkTests {
             ProofOfWork work = crypto.hasher.generateProofOfWork(d, data).join();
             long t1 = System.currentTimeMillis();
             System.out.println("Difficulty: " + d + " took " + (t1 - t0) + "ms");
-            byte[] hash = crypto.hasher.sha256(ArrayOps.concat(work.prefix, work.data)).join();
+            byte[] hash = crypto.hasher.sha256(ArrayOps.concat(work.prefix, data)).join();
             Assert.assertTrue(ProofOfWork.satisfiesDifficulty(d, hash));
         }
     }

--- a/src/peergos/server/tests/RateMonitorTests.java
+++ b/src/peergos/server/tests/RateMonitorTests.java
@@ -1,0 +1,20 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.util.*;
+
+public class RateMonitorTests {
+
+    @Test
+    public void linear() {
+        RateMonitor rates = new RateMonitor(10);
+        for (int i=0; i < 1L << 20; i++) {
+            rates.addEvent();
+            rates.timeStep();
+        }
+        long[] linear = rates.getRates();
+        Assert.assertTrue("Powers of two", linear[0] == 0);
+        for (int i=1; i < 10; i++)
+            Assert.assertTrue("Powers of two", linear[i] == 1L << i - 1);
+    }
+}

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -66,6 +66,7 @@ public abstract class UserTests {
                     "-enable-gc", "true",
                     "-gc.period.millis", "60000",
                     "max-users", "10000",
+                    "max-daily-signups", "10000",
                     Main.PEERGOS_PATH, peergosDir.toString(),
                     "peergos.password", "testpassword",
                     "pki.keygen.password", "testpkipassword",

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -66,7 +66,7 @@ public abstract class UserTests {
                     "-enable-gc", "true",
                     "-gc.period.millis", "60000",
                     "max-users", "10000",
-                    "max-daily-signups", "10000",
+                    "max-daily-signups", "20000",
                     Main.PEERGOS_PATH, peergosDir.toString(),
                     "peergos.password", "testpassword",
                     "pki.keygen.password", "testpkipassword",

--- a/src/peergos/server/util/DifficultyGenerator.java
+++ b/src/peergos/server/util/DifficultyGenerator.java
@@ -1,0 +1,56 @@
+package peergos.server.util;
+
+import peergos.shared.crypto.*;
+
+public class DifficultyGenerator {
+
+    private final RateMonitor queryRate;
+    private int difficulty = ProofOfWork.MIN_DIFFICULTY;
+    private long timeOfLastUpdateMillis;
+    private final long[] maxPerBucket;
+
+    public DifficultyGenerator(long startTimeMillis, int maxPerDay) {
+        this.timeOfLastUpdateMillis = startTimeMillis;
+        // This covers a days worth of queries if the time unit is 0.1 seconds (2^20 > 864000)
+        int nBuckets = 20;
+        this.queryRate = new RateMonitor(nBuckets);
+        double maxPerTimeStep = ((double)maxPerDay) / 864000;
+        this.maxPerBucket = new long[nBuckets];
+        for (int i=0; i < nBuckets; i++)
+            maxPerBucket[i] = (long) (maxPerTimeStep * ((1L << (i + 1)) - (1L << i)));
+    }
+
+    private static long millisToTimeSteps(long millis) {
+        return millis / 100; // assumes 0.1s time step
+    }
+
+    public synchronized int currentDifficulty() {
+        return difficulty;
+    }
+
+    public synchronized void updateTime(long epochMillis) {
+        // update rate monitor
+        long timeStepsSinceLastUpdate = millisToTimeSteps(epochMillis - timeOfLastUpdateMillis);
+        if (timeStepsSinceLastUpdate > 0) {
+            queryRate.timeSteps(timeStepsSinceLastUpdate);
+            timeOfLastUpdateMillis = epochMillis;
+        }
+        updateDifficulty();
+    }
+
+    public synchronized void addEvent() {
+        queryRate.addEvent();
+    }
+
+    private synchronized void updateDifficulty() {
+        long[] rates = queryRate.getRates();
+        int newDifficulty = ProofOfWork.MIN_DIFFICULTY;
+        for (int i=0; i < rates.length; i++) {
+            long maxForIndex = maxPerBucket[i];
+            if (rates[i] > maxForIndex) {
+                newDifficulty += (i + 1);
+            }
+        }
+        difficulty = newDifficulty;
+    }
+}

--- a/src/peergos/server/util/DifficultyGenerator.java
+++ b/src/peergos/server/util/DifficultyGenerator.java
@@ -63,14 +63,14 @@ public class DifficultyGenerator {
         for (int i=0; i < rates.length; i++) {
             double maxForIndex = maxPerBucket[i];
             if (rates[i] > maxForIndex) {
-                double log = Math.log((double) rates[i] / maxForIndex);
-                newDifficulty += log * log;
+                double log = Math.log((double) rates[i] * 2 / maxForIndex);
+                newDifficulty += log;
                 includedBuckets++;
             }
         }
         if (includedBuckets == 0)
             return ProofOfWork.MIN_DIFFICULTY;
-        int result = 3 * (int) Math.sqrt(newDifficulty);
+        int result = (int) (2 * newDifficulty + ProofOfWork.DEFAULT_DIFFICULTY);
         return Math.min(Math.max(ProofOfWork.MIN_DIFFICULTY, result), ProofOfWork.MAX_DIFFICULTY);
     }
 }

--- a/src/peergos/server/util/DifficultyGenerator.java
+++ b/src/peergos/server/util/DifficultyGenerator.java
@@ -2,6 +2,13 @@ package peergos.server.util;
 
 import peergos.shared.crypto.*;
 
+/** DifficultyGenerator is used to monitor a particular event and choose a difficulty level for a proof of work to
+ *  rate limit it.
+ *
+ *  It is created with the desired maximum number of events per day to calibrate the difficulty.
+ *
+ *  The main assumption is that the proof of work scales exponentially with the difficulty.
+ */
 public class DifficultyGenerator {
 
     private final RateMonitor queryRate;

--- a/src/peergos/server/util/RateMonitor.java
+++ b/src/peergos/server/util/RateMonitor.java
@@ -1,0 +1,43 @@
+package peergos.server.util;
+
+import java.util.*;
+
+public class RateMonitor {
+
+    private long timeSteps = 0;
+    // ith element is # requests between 2^i and 2^(i+1) time steps ...
+    private final long[] buckets;
+
+    public RateMonitor(int nBuckets) {
+        this.buckets = new long[nBuckets];
+    }
+
+    public synchronized void addEvent() {
+        buckets[0]++;
+    }
+
+    private void moveBucket(int from, int to) {
+        if (to < buckets.length)
+            buckets[to] += buckets[from];
+        buckets[from] = 0;
+    }
+
+    public synchronized void timeStep() {
+        timeSteps++;
+        for (int i= buckets.length - 1; i >=0; i--) {
+            if (timeSteps % (1L << i) == 0) moveBucket(i, i + 1);
+        }
+    }
+
+    public synchronized void timeSteps(long steps) {
+        if (steps > 1L << buckets.length)
+            Arrays.fill(buckets, 0);
+        else
+            for (long i=0; i < steps; i++)
+                timeStep();
+    }
+
+    public synchronized long[] getRates() {
+        return Arrays.copyOfRange(buckets, 0, buckets.length);
+    }
+}

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -9,7 +9,6 @@ import java.util.concurrent.*;
 
 public interface CoreNode {
     int MAX_USERNAME_SIZE = 64;
-    int MAX_USERNAME_COUNT = 1024;
 
     /**
      *

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -1,7 +1,7 @@
 package peergos.shared.corenode;
 
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.social.*;
 
 import java.io.*;
 import java.util.*;
@@ -23,7 +23,7 @@ public interface CoreNode {
      * @param chain The changed links of the chain
      * @return True if successfully updated
      */
-    CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain);
+    CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof);
 
     /**
      *

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -21,9 +21,11 @@ public interface CoreNode {
      *
      * @param username
      * @param chain The changed links of the chain
-     * @return True if successfully updated
+     * @return Optional.empty() if successfully updated, otherwise the required difficulty
      */
-    CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof);
+    CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username,
+                                                                List<UserPublicKeyLink> chain,
+                                                                ProofOfWork proof);
 
     /**
      *

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -126,7 +126,7 @@ public class TofuCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
+    public CompletableFuture<Optional<RequiredDifficulty>> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
         return tofu.updateChain(username, chain, network.dhtClient)
                 .thenCompose(x -> commit())
                 .thenCompose(x -> source.updateChain(username, chain, proof));

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -2,6 +2,7 @@ package peergos.shared.corenode;
 
 import peergos.shared.*;
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
@@ -125,10 +126,10 @@ public class TofuCoreNode implements CoreNode {
     }
 
     @Override
-    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain) {
+    public CompletableFuture<Boolean> updateChain(String username, List<UserPublicKeyLink> chain, ProofOfWork proof) {
         return tofu.updateChain(username, chain, network.dhtClient)
                 .thenCompose(x -> commit())
-                .thenCompose(x -> source.updateChain(username, chain));
+                .thenCompose(x -> source.updateChain(username, chain, proof));
     }
 
     @Override

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -41,6 +41,12 @@ public class ProofOfWork implements Cborable {
         return new ProofOfWork(prefix, Multihash.Type.sha2_256);
     }
 
+    /** This tests whether the calculated hash has at least *difficulty* leading zero bits
+     *
+     * @param difficulty
+     * @param hash
+     * @return
+     */
     @JsMethod
     public static boolean satisfiesDifficulty(int difficulty, byte[] hash) {
         for (int i=0; i < difficulty; i+= 8) {

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -8,7 +8,7 @@ import java.util.*;
 
 public class ProofOfWork implements Cborable {
     public final static int PREFIX_BYTES = 8;
-    public final static int DEFAULT_DIFFICULTY = 11;
+    public final static int MIN_DIFFICULTY = 11;
 
     public final byte[] prefix;
     public final Multihash.Type type;

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -9,6 +9,7 @@ import java.util.*;
 public class ProofOfWork implements Cborable {
     public final static int PREFIX_BYTES = 8;
     public final static int MIN_DIFFICULTY = 0;
+    public final static int DEFAULT_DIFFICULTY = 11;
     public final static int MAX_DIFFICULTY = 256;
 
     public final byte[] prefix;

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -8,7 +8,8 @@ import java.util.*;
 
 public class ProofOfWork implements Cborable {
     public final static int PREFIX_BYTES = 8;
-    public final static int MIN_DIFFICULTY = 11;
+    public final static int MIN_DIFFICULTY = 0;
+    public final static int MAX_DIFFICULTY = 256;
 
     public final byte[] prefix;
     public final Multihash.Type type;

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -1,0 +1,32 @@
+package peergos.shared.crypto;
+
+import jsinterop.annotations.*;
+import peergos.shared.io.ipfs.multihash.*;
+
+public class ProofOfWork {
+    public final static int PREFIX_BYTES = 8;
+
+    public final byte[] prefix;
+    public final byte[] data;
+    public final Multihash.Type type;
+
+    public ProofOfWork(byte[] prefix, byte[] data, Multihash.Type type) {
+        this.prefix = prefix;
+        this.data = data;
+        this.type = type;
+    }
+
+    @JsMethod
+    public static boolean satisfiesDifficulty(int difficulty, byte[] hash) {
+        for (int i=0; i < difficulty; i+= 8) {
+            if (i <= difficulty - 8) {
+                if (hash[i/8] != 0)
+                    return false;
+            } else {
+                int raw = hash[i / 8] & 0xFF;
+                return (0xFF & (raw << (8 - difficulty + i))) == 0;
+            }
+        }
+        return true;
+    }
+}

--- a/src/peergos/shared/crypto/RequiredDifficulty.java
+++ b/src/peergos/shared/crypto/RequiredDifficulty.java
@@ -1,0 +1,9 @@
+package peergos.shared.crypto;
+
+public class RequiredDifficulty {
+    public final int requiredDifficulty;
+
+    public RequiredDifficulty(int requiredDifficulty) {
+        this.requiredDifficulty = requiredDifficulty;
+    }
+}

--- a/src/peergos/shared/crypto/hash/Hasher.java
+++ b/src/peergos/shared/crypto/hash/Hasher.java
@@ -1,5 +1,6 @@
 package peergos.shared.crypto.hash;
 
+import peergos.shared.crypto.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.user.*;
@@ -9,6 +10,8 @@ import java.util.concurrent.CompletableFuture;
 public interface Hasher {
 
     CompletableFuture<byte[]> hashToKeyBytes(String username, String password, SecretGenerationAlgorithm algorithm);
+
+    CompletableFuture<ProofOfWork> generateProofOfWork(int difficulty, byte[] data);
 
     CompletableFuture<byte[]> sha256(byte[] input);
 

--- a/src/peergos/shared/crypto/hash/NativeScryptJS.java
+++ b/src/peergos/shared/crypto/hash/NativeScryptJS.java
@@ -1,6 +1,7 @@
 package peergos.shared.crypto.hash;
 
 import jsinterop.annotations.*;
+import peergos.shared.crypto.*;
 import peergos.shared.user.*;
 
 import java.util.concurrent.*;
@@ -9,6 +10,8 @@ import java.util.concurrent.*;
 public class NativeScryptJS {
 
     public native CompletableFuture<byte[]> hashToKeyBytes(String username, String password, SecretGenerationAlgorithm algorithm);
+
+    public native CompletableFuture<ProofOfWork> generateProofOfWork(int difficulty, byte[] data);
 
     public native CompletableFuture<byte[]> sha256(byte[] input);
 

--- a/src/peergos/shared/crypto/hash/ScryptJS.java
+++ b/src/peergos/shared/crypto/hash/ScryptJS.java
@@ -1,5 +1,6 @@
 package peergos.shared.crypto.hash;
 
+import peergos.shared.crypto.*;
 import peergos.shared.user.*;
 
 import java.util.concurrent.CompletableFuture;
@@ -13,6 +14,10 @@ public class ScryptJS implements Hasher {
         return scriptJS.hashToKeyBytes(username, password, algorithm);
     }
 
+    @Override
+    public CompletableFuture<ProofOfWork> generateProofOfWork(int difficulty, byte[] data) {
+        return scriptJS.generateProofOfWork(difficulty, data);
+    }
 
     @Override
     public CompletableFuture<byte[]> sha256(byte[] input) {

--- a/src/peergos/shared/crypto/hash/ScryptJava.java
+++ b/src/peergos/shared/crypto/hash/ScryptJava.java
@@ -1,11 +1,15 @@
 package peergos.shared.crypto.hash;
+import java.util.*;
 import java.util.logging.*;
 
 import java.security.*;
 import java.util.concurrent.CompletableFuture;
 
+import peergos.shared.crypto.*;
+import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.scrypt.com.lambdaworks.crypto.SCrypt;
 import peergos.shared.user.*;
+import peergos.shared.util.*;
 
 public class ScryptJava implements Hasher {
 	private static final Logger LOG = Logger.getGlobal();
@@ -35,6 +39,29 @@ public class ScryptJava implements Hasher {
             return res;
         }
         throw new IllegalStateException("Unknown user generation algorithm: " + algorithm);
+    }
+
+    @Override
+    public CompletableFuture<ProofOfWork> generateProofOfWork(int difficulty, byte[] data) {
+        byte[] combined = new byte[data.length + ProofOfWork.PREFIX_BYTES];
+        System.arraycopy(data, 0, combined, ProofOfWork.PREFIX_BYTES, data.length);
+        long counter = 0;
+        while (true) {
+            byte[] hash = Hash.sha256(combined);
+            if (ProofOfWork.satisfiesDifficulty(difficulty, hash)) {
+                byte[] prefix = Arrays.copyOfRange(combined, 0, ProofOfWork.PREFIX_BYTES);
+                return Futures.of(new ProofOfWork(prefix, data, Multihash.Type.sha2_256));
+            }
+            counter++;
+            combined[0] = (byte) counter;
+            combined[1] = (byte) (counter >> 8);
+            combined[2] = (byte) (counter >> 16);
+            combined[3] = (byte) (counter >> 24);
+            combined[4] = (byte) (counter >> 32);
+            combined[5] = (byte) (counter >> 40);
+            combined[6] = (byte) (counter >> 48);
+            combined[7] = (byte) (counter >> 56);
+        }
     }
 
     @Override

--- a/src/peergos/shared/crypto/hash/ScryptJava.java
+++ b/src/peergos/shared/crypto/hash/ScryptJava.java
@@ -50,7 +50,7 @@ public class ScryptJava implements Hasher {
             byte[] hash = Hash.sha256(combined);
             if (ProofOfWork.satisfiesDifficulty(difficulty, hash)) {
                 byte[] prefix = Arrays.copyOfRange(combined, 0, ProofOfWork.PREFIX_BYTES);
-                return Futures.of(new ProofOfWork(prefix, data, Multihash.Type.sha2_256));
+                return Futures.of(new ProofOfWork(prefix, Multihash.Type.sha2_256));
             }
             counter++;
             combined[0] = (byte) counter;

--- a/src/peergos/shared/io/ipfs/multihash/Multihash.java
+++ b/src/peergos/shared/io/ipfs/multihash/Multihash.java
@@ -8,6 +8,9 @@ import peergos.shared.io.ipfs.multibase.*;
 import java.io.*;
 import java.util.*;
 
+/** Note we don't support the full range of Multihash types, because some of them are insecure
+ *
+ */
 @JsType
 public class Multihash implements Comparable<Multihash> {
     public static final int LEGACY_MAX_IDENTITY_HASH_SIZE = 4112;
@@ -16,7 +19,6 @@ public class Multihash implements Comparable<Multihash> {
     @JsType
     public enum Type {
         id(0, -1),
-        sha1(0x11, 20),
         sha2_256(0x12, 32),
         sha2_512(0x13, 64),
         sha3(0x14, 64),

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -633,7 +633,7 @@ public class UserContext {
                                                                    NetworkAccess network,
                                                                    Consumer<String> progressCallback) {
         byte[] data = new CborObject.CborList(claimChain).serialize();
-        return time(() -> hasher.generateProofOfWork(ProofOfWork.DEFAULT_DIFFICULTY, data), "Proof of work")
+        return time(() -> hasher.generateProofOfWork(ProofOfWork.MIN_DIFFICULTY, data), "Proof of work")
                 .thenCompose(proof -> network.coreNode.updateChain(username, claimChain, proof))
                 .thenCompose(diff -> {
                     if (diff.isPresent()) {


### PR DESCRIPTION
This PR implements a new proof of work mechanism to allow rate limiting pki.updateChain calls. 
This includes signing up a new user, renewing their username claim, and changing their password. 

The proof of work is essentially the same as bitcoin, find a prefix by brute force that results in a sha256 with a given number of leading zeroes. 

The most important function (and one which could easily be totally rewritten) is DifficultyGenerator.updateDifficulty()

See ProofOfWorkTests for estimates of time for calculation using native sha256 implementation.