### PR TITLE
16X speedup of general operations

### DIFF
--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -1,0 +1,129 @@
+package peergos.server.storage;
+
+import peergos.shared.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.storage.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class DelayingStorage implements ContentAddressedStorage {
+    private final ContentAddressedStorage source;
+    private final int readDelay, writeDelay;
+
+    public DelayingStorage(ContentAddressedStorage source, int readDelay, int writeDelay) {
+        this.source = source;
+        this.readDelay = readDelay;
+        this.writeDelay = writeDelay;
+    }
+
+    @Override
+    public CompletableFuture<Multihash> id() {
+        return source.id();
+    }
+
+    @Override
+    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
+        return source.startTransaction(owner);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
+        return source.closeTransaction(owner, tid);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> gc() {
+        return source.gc();
+    }
+
+    private static void sleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {}
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
+                                                  PublicKeyHash writer,
+                                                  List<byte[]> signedHashes,
+                                                  List<byte[]> blocks,
+                                                  TransactionId tid) {
+        sleep(writeDelay);
+        return source.put(owner, writer, signedHashes, blocks, tid);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> putRaw(PublicKeyHash owner,
+                                                     PublicKeyHash writer,
+                                                     List<byte[]> signatures,
+                                                     List<byte[]> blocks,
+                                                     TransactionId tid,
+                                                     ProgressConsumer<Long> progressConsumer) {
+        sleep(writeDelay);
+        return source.putRaw(owner, writer, signatures, blocks, tid, progressConsumer);
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Multihash object) {
+        try {
+            sleep(readDelay);
+            return source.getRaw(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(Multihash hash) {
+        try {
+            sleep(readDelay);
+            return source.get(hash);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursivePin(PublicKeyHash owner, Multihash h) {
+        return source.recursivePin(owner, h);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> recursiveUnpin(PublicKeyHash owner, Multihash h) {
+        return source.recursiveUnpin(owner, h);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> pinUpdate(PublicKeyHash owner, Multihash existing, Multihash updated) {
+        return source.pinUpdate(owner, existing, updated);
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> getLinks(Multihash root) {
+        try {
+            return source.getLinks(root);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
+        try {
+            return source.getSize(block);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public static NetworkAccess buildNetwork(NetworkAccess source, int readDelay, int writeDelay) {
+        ContentAddressedStorage delayingBlocks = new DelayingStorage(source.dhtClient, readDelay, writeDelay);
+        return new NetworkAccess(source.coreNode, source.social, delayingBlocks, source.mutable, source.tree,
+                source.synchronizer, source.instanceAdmin, source.spaceUsage, source.serverMessager,
+                source.hasher, source.usernames, false);
+    }
+}

--- a/src/peergos/server/tests/BlockSizeTests.java
+++ b/src/peergos/server/tests/BlockSizeTests.java
@@ -1,0 +1,43 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.*;
+import peergos.server.storage.*;
+import peergos.shared.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.symmetric.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.cryptree.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.stream.*;
+
+public class BlockSizeTests {
+    private static Crypto crypto = Main.initCrypto();
+
+    @Test
+    public void largeDirectoryCryptreeNode() {
+        SymmetricKey rBase = SymmetricKey.random();
+        SymmetricKey wBase = SymmetricKey.random();
+        SymmetricKey parent = SymmetricKey.random();
+        SymmetricKey parentParent = SymmetricKey.random();
+        FileProperties props = new FileProperties("a-directory", true, false, "", 0, 0,
+                LocalDateTime.now(), false, Optional.empty(), Optional.empty());
+        SigningPrivateKeyAndPublicHash signingPair = ChampTests.createUser(new RAMStorage(), crypto);
+
+        Optional<RelativeCapability> parentCap = Optional.of(new RelativeCapability(Optional.empty(), crypto.random.randomBytes(32), parentParent, Optional.empty()));
+        RelativeCapability nextChunk = new RelativeCapability(Optional.empty(), crypto.random.randomBytes(32), parentParent, Optional.empty());
+
+        String nameBase = IntStream.range(0, 252).mapToObj(i -> "A").collect(Collectors.joining());
+        List<NamedRelativeCapability> children = IntStream.range(0, 500)
+                .mapToObj(i -> new NamedRelativeCapability(nameBase + String.format("%03d", i), nextChunk))
+                .collect(Collectors.toList());
+        CryptreeNode.ChildrenLinks childrenLinks = new CryptreeNode.ChildrenLinks(children);
+        CryptreeNode.DirAndChildren dir = CryptreeNode.createDir(MaybeMultihash.empty(), rBase,
+                wBase, Optional.of(signingPair), props, parentCap, parent, nextChunk, childrenLinks, crypto.hasher).join();
+
+        byte[] raw = dir.dir.serialize();
+        Assert.assertTrue(raw.length < Fragment.MAX_LENGTH);
+    }
+}

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -525,7 +525,7 @@ public abstract class UserTests {
         SymmetricKey baseKey = pointer.capability.rBaseKey;
         SymmetricKey parentKey = dir.getParentKey();
         Assert.assertTrue("parent key different from base key", ! parentKey.equals(baseKey));
-        pointer.fileAccess.getDirectChildren(baseKey, network).join();
+        pointer.fileAccess.getDirectChildren(pointer.capability, dir.version, network).join();
     }
 
     @Test
@@ -682,10 +682,10 @@ public abstract class UserTests {
 
         FileWrapper home = context.getByPath(Paths.get(username).toString()).get().get();
         RetrievedCapability homePointer = home.getPointer();
-        List<RelativeCapability> children = homePointer.fileAccess.getDirectChildren(homePointer.capability.rBaseKey, network).get();
-        for (RelativeCapability child : children) {
+        List<NamedRelativeCapability> children = homePointer.fileAccess.getDirectChildren(homePointer.capability, home.version, network).get();
+        for (NamedRelativeCapability child : children) {
             Assert.assertTrue("child pointer is minimal",
-                    ! child.writer.isPresent() && child.wBaseKeyLink.isPresent());
+                    ! child.cap.writer.isPresent() && child.cap.wBaseKeyLink.isPresent());
         }
     }
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -451,9 +451,9 @@ public abstract class UserTests {
 
         //rename
         String newname = "newname.txt";
-        FileWrapper updatedRoot5 = updatedRoot4.getDescendentByPath(otherName, crypto.hasher, context.network).get().get()
-                .rename(newname, updatedRoot4, Paths.get(username, otherName), context).get();
-        checkFileContents(data3, updatedRoot5.getDescendentByPath(newname, crypto.hasher, context.network).get().get(), context);
+        FileWrapper updatedRoot5 = updatedRoot4.getDescendentByPath(otherName, crypto.hasher, context.network).join().get()
+                .rename(newname, updatedRoot4, Paths.get(username, otherName), context).join();
+        checkFileContents(data3, updatedRoot5.getDescendentByPath(newname, crypto.hasher, context.network).join().get(), context);
         // check from the root as well
         checkFileContents(data3, context.getByPath(username + "/" + newname).get().get(), context);
         // check from a fresh log in too

--- a/src/peergos/server/tests/slow/SocialBenchmark.java
+++ b/src/peergos/server/tests/slow/SocialBenchmark.java
@@ -4,6 +4,7 @@ import org.junit.*;
 import org.junit.runner.*;
 import org.junit.runners.*;
 import peergos.server.*;
+import peergos.server.storage.*;
 import peergos.server.tests.*;
 import peergos.server.util.*;
 import peergos.shared.*;
@@ -37,7 +38,10 @@ public class SocialBenchmark {
     private static Pair<UserService, NetworkAccess> buildHttpNetworkAccess(boolean useIpfs, Random r) throws Exception {
         Args args = UserTests.buildArgs().with("useIPFS", "" + useIpfs);
         UserService service = Main.PKI_INIT.main(args);
-        return new Pair<>(service, Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).get());
+        NetworkAccess net = Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).join();
+        int delayMillis = 50;
+        NetworkAccess delayed = DelayingStorage.buildNetwork(net, delayMillis, delayMillis);
+        return new Pair<>(service, delayed);
     }
 
     @Parameterized.Parameters()

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -394,7 +394,7 @@ public class NetworkAccess {
                                             return Futures.of(new FileWrapper(rc, Optional.of(link), entryWriter, ownername, fullVersion));
                                         // We have a link chain! Be sure to use the name from the first link,
                                         // and remaining properties from the final target
-                                        return getFileFromLink(owner, rc, entryWriter, ownername, network, version)
+                                        return getFileFromLink(owner, rc, entryWriter, ownername, network, fullVersion)
                                                 .thenApply(f -> new FileWrapper(f.getPointer(), Optional.of(link), entryWriter, ownername, fullVersion));
                                     }));
                 });

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -379,11 +379,11 @@ public class NetworkAccess {
                                                                  NetworkAccess network,
                                                                  Snapshot version) {
         // the link is formatted as a directory cryptree node and the target is the solitary child
-        return link.fileAccess.getDirectChildrenCapabilities(link.capability, network)
+        return link.fileAccess.getDirectChildrenCapabilities(link.capability, version, network)
                 .thenCompose(children -> {
                     if (children.size() != 1)
                         throw new IllegalStateException("Link cryptree nodes must have exactly one child link!");
-                    AbsoluteCapability cap = children.stream().findFirst().get();
+                    AbsoluteCapability cap = children.stream().findFirst().get().cap;
                     Set<PublicKeyHash> childWriters = Collections.singleton(cap.writer);
                     return version.withWriters(owner, childWriters, network)
                             .thenCompose(fullVersion -> network.retrieveAllMetadata(Collections.singletonList(cap), fullVersion)

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -47,9 +47,8 @@ public class TofuCoreNode implements CoreNode {
 
         return root.getByPath(username, crypto.hasher, network)
                 .thenApply(Optional::get)
-                .thenCompose(homeDir -> homeDir.getChildrenWithSameWriter(crypto.hasher, network)
-                        .thenCompose(children -> {
-                            Optional<FileWrapper> keystoreOpt = children.stream().filter(c -> c.getName().equals(KEY_STORE_NAME)).findFirst();
+                .thenCompose(homeDir -> homeDir.getChild(KEY_STORE_NAME, crypto.hasher, network)
+                        .thenCompose(keystoreOpt -> {
                             if (keystoreOpt.isEmpty()) {
                                 // initialize empty keystore
                                 TofuKeyStore store = new TofuKeyStore();

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -350,7 +350,7 @@ public class IncomingCapCache {
                             .thenCompose(caps -> caps.getChild(path.get(childIndex))
                                     .map(cap -> network.getFile(new EntryPoint(cap, path.get(0)), version)
                                             .thenCompose(fopt -> fopt.map(f ->
-                                                    f.getDescendentByPath(pathSuffix(path, childIndex + 1), version, hasher, network)
+                                                    f.getDescendentByPath(pathSuffix(path, childIndex + 1), version.mergeAndOverwriteWith(f.version), hasher, network)
                                                             .thenCompose(dir -> dir.map(d -> d.getChildren(hasher, network))
                                                                     .orElse(Futures.of(Collections.emptySet()))))
                                                     .orElseGet(recurse)))

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1307,7 +1307,8 @@ public class UserContext {
                 }).thenCompose(rotated ->
                                 parent.getPointer().fileAccess.updateChildLink(
                                         rotated.left, c, (WritableAbsoluteCapability) parentCap,
-                                        parentSigner, file.isLink() ? file.getLinkPointer().capability : originalCap, rotated.right,
+                                        parentSigner, file.isLink() ? file.getLinkPointer().capability : originalCap,
+                                        new NamedAbsoluteCapability(file.getName(), rotated.right),
                                         network, crypto.hasher)
                                         .thenCompose(s -> IpfsTransaction.call(owner,
                                                 tid -> FileWrapper.deleteAllChunks(

--- a/src/peergos/shared/user/fs/AbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/AbsoluteCapability.java
@@ -117,7 +117,7 @@ public class AbsoluteCapability implements Cborable {
     }
 
     @Override
-    public CborObject toCbor() {
+    public CborObject.CborMap toCbor() {
         Map<String, CborObject> cbor = new TreeMap<>();
         cbor.put("o", owner.toCbor());
         cbor.put("w", writer.toCbor());

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -233,8 +233,8 @@ public class FileWrapper {
 
     public CompletableFuture<Boolean> hasChildWithName(Snapshot version, String name, Hasher hasher, NetworkAccess network) {
         ensureUnmodified();
-        return getChildren(version, hasher, network)
-                .thenApply(children -> children.stream().anyMatch(c -> c.props.name.equals(name)));
+        return getChild(version, name, hasher, network)
+                .thenApply(Optional::isPresent);
     }
 
     /**

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1255,7 +1255,10 @@ public class FileWrapper {
                     SigningPrivateKeyAndPublicHash signer = isLink ? parent.signingPair() : signingPair();
                     return userContext.network.synchronizer.applyComplexUpdate(owner(), signer,
                             (s, committer) -> nodeToUpdate.updateProperties(s, committer, us,
-                                    entryWriter, newProps, userContext.network))
+                                    entryWriter, newProps, userContext.network)
+                                    .thenCompose(updated -> parent.updateChildLinks(updated, committer,
+                                            Arrays.asList(new Pair<>(us, us)),
+                                            userContext.network, userContext.crypto.random, userContext.crypto.hasher)))
                             .thenApply(newVersion -> parent.withVersion(newVersion));
                 }).thenCompose(f -> userContext.sharedWithCache
                         .rename(ourPath, ourPath.getParent().resolve(newFilename))

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -415,7 +415,9 @@ public class FileWrapper {
                     Optional<SigningPrivateKeyAndPublicHash> childsEntryWriter = pointer.capability.wBaseKey
                             .map(wBase -> pointer.fileAccess.getSigner(pointer.capability.rBaseKey, wBase, entryWriter));
                     if (! props.isLink)
-                        return Futures.of(Optional.of(new FileWrapper(rc, Optional.empty(), childsEntryWriter, ownername, version)));
+                        return version.withWriter(rc.capability.owner, rc.capability.writer, network)
+                                .thenApply(fullVersion -> Optional.of(new FileWrapper(rc, Optional.empty(),
+                                        childsEntryWriter, ownername, version)));
                     return version.withWriter(owner(), rc.capability.writer, network)
                             .thenCompose(fullVersion ->
                                     NetworkAccess.getFileFromLink(owner(), rc, childsEntryWriter, ownername, network, fullVersion)

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -82,6 +82,8 @@ public class FileWrapper {
                 this.props = directProps;
             }
         }
+        if (! version.contains(pointer.capability.writer))
+            throw new IllegalStateException("File version doesn't include its own writer!");
         if (isWritable() && !signingPair().publicKeyHash.equals(pointer.capability.writer))
             throw new IllegalStateException("Invalid FileWrapper! public writing keys don't match!");
     }
@@ -330,7 +332,9 @@ public class FileWrapper {
                 return Futures.of(Optional.empty());
             FileProperties parentProps = parentRFP.getProperties();
             if (! parentProps.isLink)
-                return Futures.of(Optional.of(new FileWrapper(parentRFP, Optional.empty(), Optional.empty(), ownerName, version)));
+                return version.withWriter(parentRFP.capability.owner, parentRFP.capability.writer, network)
+                        .thenApply(fullVersion -> Optional.of(new FileWrapper(parentRFP, Optional.empty(),
+                                Optional.empty(), ownerName, fullVersion)));
             return retrieveParent(parentRFP, ownerName, version, network);
         });
     }

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -222,7 +222,7 @@ public class FileWrapper {
     public CompletableFuture<Snapshot> updateChildLinks(
             Snapshot version,
             Committer committer,
-            Collection<Pair<AbsoluteCapability, AbsoluteCapability>> childCases,
+            Collection<Pair<AbsoluteCapability, NamedAbsoluteCapability>> childCases,
             NetworkAccess network,
             SafeRandom random,
             Hasher hasher) {
@@ -1257,7 +1257,7 @@ public class FileWrapper {
                             (s, committer) -> nodeToUpdate.updateProperties(s, committer, us,
                                     entryWriter, newProps, userContext.network)
                                     .thenCompose(updated -> parent.updateChildLinks(updated, committer,
-                                            Arrays.asList(new Pair<>(us, us)),
+                                            Arrays.asList(new Pair<>(us, new NamedAbsoluteCapability(newFilename, us))),
                                             userContext.network, userContext.crypto.random, userContext.crypto.hasher)))
                             .thenApply(newVersion -> parent.withVersion(newVersion));
                 }).thenCompose(f -> userContext.sharedWithCache

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -428,6 +428,8 @@ public class FileWrapper {
                                                              String name,
                                                              Hasher hasher,
                                                              NetworkAccess network) {
+        if (capTrie.isPresent())
+            return capTrie.get().getByPath("/" + name, version.merge(this.version), hasher, network);
         return pointer.fileAccess.getChild(name, pointer.capability, version, hasher, network)
                 .thenCompose(rcOpt -> {
                     if (rcOpt.isEmpty())

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1259,7 +1259,7 @@ public class FileWrapper {
                                     .thenCompose(updated -> parent.updateChildLinks(updated, committer,
                                             Arrays.asList(new Pair<>(us, new NamedAbsoluteCapability(newFilename, us))),
                                             userContext.network, userContext.crypto.random, userContext.crypto.hasher)))
-                            .thenApply(newVersion -> parent.withVersion(newVersion));
+                            .thenCompose(newVersion -> parent.getUpdated(newVersion, userContext.network));
                 }).thenCompose(f -> userContext.sharedWithCache
                         .rename(ourPath, ourPath.getParent().resolve(newFilename))
                         .thenApply(b -> f));

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -434,11 +434,13 @@ public class FileWrapper {
                         return Futures.of(Optional.empty());
                     RetrievedCapability rc = rcOpt.get();
                     FileProperties props = rc.getProperties();
+                    Optional<SigningPrivateKeyAndPublicHash> childsEntryWriter = pointer.capability.wBaseKey
+                            .map(wBase -> pointer.fileAccess.getSigner(pointer.capability.rBaseKey, wBase, entryWriter));
                     if (! props.isLink)
-                        return Futures.of(Optional.of(new FileWrapper(rc, Optional.empty(), entryWriter, ownername, version)));
+                        return Futures.of(Optional.of(new FileWrapper(rc, Optional.empty(), childsEntryWriter, ownername, version)));
                     return version.withWriter(owner(), rc.capability.writer, network)
                             .thenCompose(fullVersion ->
-                                    NetworkAccess.getFileFromLink(owner(), rc, entryWriter, ownername, network, fullVersion)
+                                    NetworkAccess.getFileFromLink(owner(), rc, childsEntryWriter, ownername, network, fullVersion)
                                             .thenApply(Optional::of));
                 });
     }

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -417,7 +417,7 @@ public class FileWrapper {
                     if (! props.isLink)
                         return version.withWriter(rc.capability.owner, rc.capability.writer, network)
                                 .thenApply(fullVersion -> Optional.of(new FileWrapper(rc, Optional.empty(),
-                                        childsEntryWriter, ownername, version)));
+                                        childsEntryWriter, ownername, fullVersion)));
                     return version.withWriter(owner(), rc.capability.writer, network)
                             .thenCompose(fullVersion ->
                                     NetworkAccess.getFileFromLink(owner(), rc, childsEntryWriter, ownername, network, fullVersion)

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -415,7 +415,7 @@ public class FileWrapper {
                     Optional<SigningPrivateKeyAndPublicHash> childsEntryWriter = pointer.capability.wBaseKey
                             .map(wBase -> pointer.fileAccess.getSigner(pointer.capability.rBaseKey, wBase, entryWriter));
                     if (! props.isLink)
-                        return version.withWriter(rc.capability.owner, rc.capability.writer, network)
+                        return version.withWriter(owner(), rc.capability.writer, network)
                                 .thenApply(fullVersion -> Optional.of(new FileWrapper(rc, Optional.empty(),
                                         childsEntryWriter, ownername, fullVersion)));
                     return version.withWriter(owner(), rc.capability.writer, network)
@@ -831,7 +831,7 @@ public class FileWrapper {
                     return network.synchronizer.applyComplexUpdate(owner(), child.signingPair(),
                             (current, committer) -> updateExistingChild(current, committer, child,
                                     fileData, startIndex, endIndex, network, crypto, monitor))
-                            .thenApply(this::withVersion);
+                            .thenApply(childVersion -> withVersion(version.mergeAndOverwriteWith(childVersion)));
                 });
     }
 

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -82,7 +82,7 @@ public class FileWrapper {
                 this.props = directProps;
             }
         }
-        if (! version.contains(pointer.capability.writer))
+        if (pointer != null && ! version.contains(pointer.capability.writer))
             throw new IllegalStateException("File version doesn't include its own writer!");
         if (isWritable() && !signingPair().publicKeyHash.equals(pointer.capability.writer))
             throw new IllegalStateException("Invalid FileWrapper! public writing keys don't match!");

--- a/src/peergos/shared/user/fs/NamedAbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/NamedAbsoluteCapability.java
@@ -1,0 +1,57 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.cbor.*;
+import peergos.shared.inode.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+public class NamedAbsoluteCapability implements Cborable {
+    public final PathElement name;
+    public final AbsoluteCapability cap;
+
+    public NamedAbsoluteCapability(PathElement name, AbsoluteCapability cap) {
+        this.name = name;
+        this.cap = cap;
+    }
+
+    public NamedAbsoluteCapability(String name, AbsoluteCapability cap) {
+        this.name = new PathElement(name);
+        this.cap = cap;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        CborObject.CborMap cbor = cap.toCbor(); // This is to ensure binary compatibility for old code with new data
+        Map<String, CborObject> values = cbor.values.entrySet().stream()
+                .collect(Collectors.toMap(e -> ((CborObject.CborString) e.getKey()).value, e -> (CborObject) e.getValue()));
+        Cborable existing = values.put("n", new CborObject.CborString(name.name));
+        if (existing != null)
+            throw new IllegalStateException("Incompatible cbor");
+        return CborObject.CborMap.build(values);
+    }
+
+    public static NamedAbsoluteCapability fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor");
+        CborObject.CborMap map = ((CborObject.CborMap) cbor);
+
+        String name = map.getString("n");
+        AbsoluteCapability cap = AbsoluteCapability.fromCbor(cbor);
+        return new NamedAbsoluteCapability(new PathElement(name), cap);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NamedAbsoluteCapability that = (NamedAbsoluteCapability) o;
+        return Objects.equals(name, that.name) &&
+                Objects.equals(cap, that.cap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, cap);
+    }
+}

--- a/src/peergos/shared/user/fs/NamedRelativeCapability.java
+++ b/src/peergos/shared/user/fs/NamedRelativeCapability.java
@@ -1,0 +1,47 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.cbor.*;
+import peergos.shared.inode.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+public class NamedRelativeCapability implements Cborable {
+    public final PathElement name;
+    public final RelativeCapability cap;
+
+    public NamedRelativeCapability(PathElement name, RelativeCapability cap) {
+        this.name = name;
+        this.cap = cap;
+    }
+
+    public NamedRelativeCapability(String name, RelativeCapability cap) {
+        this.name = new PathElement(name);
+        this.cap = cap;
+    }
+
+    public NamedAbsoluteCapability toAbsolute(AbsoluteCapability source) {
+        return new NamedAbsoluteCapability(name, cap.toAbsolute(source));
+    }
+
+    @Override
+    public CborObject toCbor() {
+        CborObject.CborMap cbor = cap.toCbor(); // This is to ensure binary compatibility for old code with new data
+        Map<String, CborObject> values = cbor.values.entrySet().stream()
+                .collect(Collectors.toMap(e -> ((CborObject.CborString) e.getKey()).value, e -> (CborObject) e.getValue()));
+        Cborable existing = values.put("n", new CborObject.CborString(name.name));
+        if (existing != null)
+            throw new IllegalStateException("Incompatible cbor");
+        return CborObject.CborMap.build(values);
+    }
+
+    public static NamedRelativeCapability fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor");
+        CborObject.CborMap map = ((CborObject.CborMap) cbor);
+
+        String name = map.getString("n");
+        RelativeCapability cap = RelativeCapability.fromCbor(cbor);
+        return new NamedRelativeCapability(new PathElement(name), cap);
+    }
+}

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -74,7 +74,7 @@ public class RelativeCapability implements Cborable {
     }
 
     @Override
-    public CborObject toCbor() {
+    public CborObject.CborMap toCbor() {
         Map<String, CborObject> cbor = new TreeMap<>();
         writer.ifPresent(w -> cbor.put("w", w.toCbor()));
         cbor.put("m", new CborObject.CborByteArray(mapKey));

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -955,7 +955,7 @@ public class CryptreeNode implements Cborable {
                     .map(c -> new NamedRelativeCapability(c.getProperties().name, ourPointer.relativise(c.capability)))
                     .collect(Collectors.toList());
 
-            List<NamedRelativeCapability> toAdd = children.stream()
+            List<NamedRelativeCapability> updatedLinks = children.stream()
                     .filter(e -> oldToNew.containsKey(e.capability.getLocation()))
                     .map(c -> {
                         NamedAbsoluteCapability newTarget = oldToNew.get(c.capability.getLocation());
@@ -968,9 +968,9 @@ public class CryptreeNode implements Cborable {
                     .filter(p -> ! existingChildLocs.contains(p.left.getLocation()))
                     .collect(Collectors.toSet());
 
-            return (! toAdd.isEmpty() ?
+            return (! updatedLinks.isEmpty() ?
                     IpfsTransaction.call(ourPointer.owner,
-                            tid -> withChildren(ourPointer.rBaseKey, new ChildrenLinks(Stream.concat(unchanged.stream(), toAdd.stream())
+                            tid -> withChildren(ourPointer.rBaseKey, new ChildrenLinks(Stream.concat(unchanged.stream(), updatedLinks.stream())
                                     .collect(Collectors.toList())), hasher)
                                     .thenCompose(d -> d.commit(base, committer, ourPointer, signer, network, tid)),
                             network.dhtClient) :

--- a/src/peergos/shared/util/Either.java
+++ b/src/peergos/shared/util/Either.java
@@ -1,6 +1,7 @@
 package peergos.shared.util;
 
 import java.util.*;
+import java.util.function.*;
 
 public class Either<A, B> {
     private final A a;
@@ -9,6 +10,12 @@ public class Either<A, B> {
     private Either(A a, B b) {
         this.a = a;
         this.b = b;
+    }
+
+    public <V> V map(Function<A, V> aMap, Function<B, V> bmap) {
+        if (isA())
+            return aMap.apply(a);
+        return bmap.apply(b);
     }
 
     public boolean isA() {


### PR DESCRIPTION
This modifies the cryptree data structure to include the names of the children of a directory with the links to them (all padded and encrypted) in a backwards compatible way. Existing directories are converted to the new format when they are modified. 

This makes dir.getChild(name) O(1) rather than O(# children in dir). This means login is O(1) and in a benchmark with 50ms blockstore latency and 80 files in the home dir login is reduced from 80s to 5s. getByPath benefits from the same speed up. It also flows through to sharing, and sending follow requests. Upload and download speed are unchanged. 

Most of the interesting changes are in CryptreeNode, ChildrenLinks, and the two new classes NamedRelativeCapability and NamedAbsoluteCapability. 