### PR TITLE
Web hosting directly from Peergos

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -357,7 +357,6 @@ public class Main extends Builder {
             Main::startGateway,
             Stream.of(
                     new Command.Arg("port", "service port", false, "9000"),
-                    new Command.Arg("peergos.identity.hash", "The hash of peergos user's public key, this is used to bootstrap the pki", true, "z59vuwzfFDp3ZA8ZpnnmHEuMtyA1q34m3Th49DYXQVJntWpxdGrRqXi"),
                     new Command.Arg("peergos-url", "Address of the Peergos server to connect to", false, "http://localhost:8000"),
                     new Command.Arg("domain-suffix", "Domain suffix to accept", false, ".public.localhost:9000"),
                     new Command.Arg("domain", "Domain name to bind to,", false, "localhost"),

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -351,6 +351,23 @@ public class Main extends Builder {
                     new Command.Arg("mountPoint", "The directory to mount the Peergos filesystem in", true, "peergos")
             ).collect(Collectors.toList())
     );
+
+    public static final Command<PublicGateway> GATEWAY = new Command<>("gateway",
+            "Serve websites directly from Peergos",
+            Main::startGateway,
+            Stream.of(
+                    new Command.Arg("port", "service port", false, "9000"),
+                    new Command.Arg("peergos.identity.hash", "The hash of peergos user's public key, this is used to bootstrap the pki", true, "z59vuwzfFDp3ZA8ZpnnmHEuMtyA1q34m3Th49DYXQVJntWpxdGrRqXi"),
+                    new Command.Arg("peergos-url", "Address of the Peergos server to connect to", false, "http://localhost:8000"),
+                    new Command.Arg("domain-suffix", "Domain suffix to accept", false, ".public.localhost:9000"),
+                    new Command.Arg("domain", "Domain name to bind to,", false, "localhost"),
+                    new Command.Arg("public-server", "Are we a public server? (allow http GETs to API)", false, "false"),
+                    new Command.Arg("collect-metrics", "Export aggregated metrics", false, "false"),
+                    new Command.Arg("metrics.address", "Listen address for serving aggregated metrics", false, "localhost"),
+                    new Command.Arg("metrics.port", "Port for serving aggregated metrics", false, "8001")
+            ).collect(Collectors.toList())
+    );
+
     public static final Command<Boolean> SHELL = new Command<>("shell",
             "An interactive command-line-interface to a Peergos server.",
             Main::startShell,
@@ -514,6 +531,29 @@ public class Main extends Builder {
         }
     }
 
+    public static PublicGateway startGateway(Args a) {
+        Crypto crypto = initCrypto();
+        String peergosUrl = a.getArg("peergos-url");
+        String domainSuffix = a.getArg("domain-suffix");
+        try {
+            URL api = new URL(peergosUrl);
+            NetworkAccess network = Builder.buildJavaNetworkAccess(api, ! peergosUrl.startsWith("http://localhost")).join();
+            PublicGateway gateway = new PublicGateway(domainSuffix, crypto, network);
+
+            String domain = a.getArg("domain");
+            int webPort = a.getInt("port");
+            InetSocketAddress userAPIAddress = new InetSocketAddress(domain, webPort);
+            InetSocketAddress localAddress = new InetSocketAddress("localhost", userAPIAddress.getPort());
+            boolean isPublicServer = a.getBoolean("public-server", false);
+            int maxConnectionQueue = a.getInt("max-connection-queue", 500);
+            int handlerThreads = a.getInt("handler-threads", 50);
+            gateway.initAndStart(localAddress, isPublicServer, maxConnectionQueue, handlerThreads);
+            return gateway;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
     public static FuseProcess startFuse(Args a) {
         String username = a.getArg("username");
         String password = a.getArg("password");
@@ -583,6 +623,7 @@ public class Main extends Builder {
                     SHELL,
                     FUSE,
                     ServerMessages.SERVER_MESSAGES,
+                    GATEWAY,
                     INSTALL_AND_RUN_IPFS,
                     PKI,
                     PKI_INIT

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -358,7 +358,7 @@ public class Main extends Builder {
             Stream.of(
                     new Command.Arg("port", "service port", false, "9000"),
                     new Command.Arg("peergos-url", "Address of the Peergos server to connect to", false, "http://localhost:8000"),
-                    new Command.Arg("domain-suffix", "Domain suffix to accept", false, ".public.localhost:9000"),
+                    new Command.Arg("domain-suffix", "Domain suffix to accept", false, ".peergos.localhost:9000"),
                     new Command.Arg("domain", "Domain name to bind to,", false, "localhost"),
                     new Command.Arg("public-server", "Are we a public server? (allow http GETs to API)", false, "false"),
                     new Command.Arg("collect-metrics", "Export aggregated metrics", false, "false"),

--- a/src/peergos/server/PublicGateway.java
+++ b/src/peergos/server/PublicGateway.java
@@ -21,6 +21,7 @@ public class PublicGateway {
     private final String domainSuffix;
     private final NetworkAccess network;
     private final Crypto crypto;
+    private volatile HttpServer localhostServer;
 
     public PublicGateway(String domainSuffix, Crypto crypto, NetworkAccess network) {
         this.domainSuffix = domainSuffix;
@@ -28,12 +29,16 @@ public class PublicGateway {
         this.network = network;
     }
 
+    public void shutdown() {
+        localhostServer.stop(0);
+    }
+
     public void initAndStart(InetSocketAddress local,
                              boolean isPublicServer,
                              int connectionBacklog,
                              int handlerPoolSize) throws IOException {
         LOG.info("Starting local Peergos gateway at: localhost:" + local.getPort());
-        HttpServer localhostServer = HttpServer.create(local, connectionBacklog);
+        localhostServer = HttpServer.create(local, connectionBacklog);
 
         GatewayHandler publicGateway = new GatewayHandler(domainSuffix, crypto, network);
         localhostServer.createContext("/", isPublicServer ? new HSTSHandler(publicGateway) : publicGateway);

--- a/src/peergos/server/PublicGateway.java
+++ b/src/peergos/server/PublicGateway.java
@@ -1,0 +1,44 @@
+package peergos.server;
+
+import com.sun.net.httpserver.*;
+import peergos.server.net.*;
+import peergos.server.util.*;
+import peergos.shared.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.concurrent.*;
+import java.util.logging.*;
+
+/** This class acts as a public gateway for serving websites from Peergos
+ *
+ *  A user alice can publish a webroot in Peergos.
+ *  This is then served at alice.public.localhost:9000 and alice.peergos.me
+ */
+public class PublicGateway {
+    private static final Logger LOG = Logging.LOG();
+
+    private final String domainSuffix;
+    private final NetworkAccess network;
+    private final Crypto crypto;
+
+    public PublicGateway(String domainSuffix, Crypto crypto, NetworkAccess network) {
+        this.domainSuffix = domainSuffix;
+        this.crypto = crypto;
+        this.network = network;
+    }
+
+    public void initAndStart(InetSocketAddress local,
+                             boolean isPublicServer,
+                             int connectionBacklog,
+                             int handlerPoolSize) throws IOException {
+        LOG.info("Starting local Peergos gateway at: localhost:" + local.getPort());
+        HttpServer localhostServer = HttpServer.create(local, connectionBacklog);
+
+        GatewayHandler publicGateway = new GatewayHandler(domainSuffix, crypto, network);
+        localhostServer.createContext("/", isPublicServer ? new HSTSHandler(publicGateway) : publicGateway);
+
+        localhostServer.setExecutor(Executors.newFixedThreadPool(handlerPoolSize));
+        localhostServer.start();
+    }
+}

--- a/src/peergos/server/net/GatewayHandler.java
+++ b/src/peergos/server/net/GatewayHandler.java
@@ -47,14 +47,12 @@ public class GatewayHandler implements HttpHandler {
             AbsoluteCapability capToWebroot = UserContext.getPublicCapability(toWebroot, network).join();
             Optional<FileWrapper> webroot = network.getFile(capToWebroot, owner).join();
             Optional<FileWrapper> assetOpt = webroot.get().getDescendentByPath(path, crypto.hasher, network).join();
-            if (assetOpt.isEmpty()) {
+            if (assetOpt.isEmpty() || assetOpt.get().isDirectory()) {
                 httpExchange.getResponseHeaders().set("Content-Type", "text/plain");
                 httpExchange.sendResponseHeaders(404, 0);
                 return;
             }
             FileWrapper file = assetOpt.get();
-            if (file.isDirectory())
-                throw new IllegalStateException("Directory listings not allowed");
             byte[] body = Serialize.readFully(file, crypto, network).join();
 
 //            if (isGzip)

--- a/src/peergos/server/net/GatewayHandler.java
+++ b/src/peergos/server/net/GatewayHandler.java
@@ -84,8 +84,6 @@ public class GatewayHandler implements HttpHandler {
             httpExchange.getResponseHeaders().set("x-frame-options", "sameorigin");
             // Enable cross site scripting protection
             httpExchange.getResponseHeaders().set("x-xss-protection", "1; mode=block");
-            // Don't let browser sniff mime types
-            httpExchange.getResponseHeaders().set("x-content-type-options", "nosniff");
             // Don't send Peergos referrer to anyone
             httpExchange.getResponseHeaders().set("referrer-policy", "no-referrer");
 

--- a/src/peergos/server/net/GatewayHandler.java
+++ b/src/peergos/server/net/GatewayHandler.java
@@ -40,8 +40,8 @@ public class GatewayHandler implements HttpHandler {
                 throw new IllegalStateException("Incorrect domain! " + domain);
             String owner = domain.substring(0, domain.length() - domainSuffix.length());
             Path toProfileEntry = Paths.get(owner).resolve(".profile").resolve("webroot");
-            AbsoluteCapability capToWebrootFiled = UserContext.getPublicCapability(toProfileEntry, network).join();
-            Optional<FileWrapper> profileField = network.getFile(capToWebrootFiled, owner).join();
+            AbsoluteCapability capToWebrootField = UserContext.getPublicCapability(toProfileEntry, network).join();
+            Optional<FileWrapper> profileField = network.getFile(capToWebrootField, owner).join();
             Path toWebroot = Paths.get(new String(Serialize.readFully(profileField.get(), crypto, network).join()));
 
             AbsoluteCapability capToWebroot = UserContext.getPublicCapability(toWebroot, network).join();

--- a/src/peergos/server/net/GatewayHandler.java
+++ b/src/peergos/server/net/GatewayHandler.java
@@ -1,0 +1,108 @@
+package peergos.server.net;
+
+import com.sun.net.httpserver.*;
+import peergos.server.util.Logging;
+import peergos.server.util.*;
+import peergos.shared.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
+
+import java.nio.file.*;
+import java.util.*;
+import java.util.logging.*;
+
+public class GatewayHandler implements HttpHandler {
+	private static final Logger LOG = Logging.LOG();
+	private static final boolean LOGGING = true;
+
+    private final String domainSuffix;
+    private final NetworkAccess network;
+    private final Crypto crypto;
+
+    public GatewayHandler(String domainSuffix, Crypto crypto, NetworkAccess network) {
+        this.domainSuffix = domainSuffix;
+        this.crypto = crypto;
+        this.network = network;
+    }
+
+    @Override
+    public void handle(HttpExchange httpExchange) {
+        long t1 = System.currentTimeMillis();
+        String path = httpExchange.getRequestURI().getPath();
+        try {
+            path = path.substring(1).replaceAll("//", "/");
+            if (path.length() == 0)
+                path = "index.html";
+
+            String domain = httpExchange.getRequestHeaders().getFirst("Host");
+            if (! domain.endsWith(domainSuffix))
+                throw new IllegalStateException("Incorrect domain! " + domain);
+            String owner = domain.substring(0, domain.length() - domainSuffix.length());
+            Path toProfileEntry = Paths.get(owner).resolve(".profile").resolve("webroot");
+            AbsoluteCapability capToWebrootFiled = UserContext.getPublicCapability(toProfileEntry, network).join();
+            Optional<FileWrapper> profileField = network.getFile(capToWebrootFiled, owner).join();
+            Path toWebroot = Paths.get(new String(Serialize.readFully(profileField.get(), crypto, network).join()));
+
+            AbsoluteCapability capToWebroot = UserContext.getPublicCapability(toWebroot, network).join();
+            Optional<FileWrapper> webroot = network.getFile(capToWebroot, owner).join();
+            Optional<FileWrapper> assetOpt = webroot.get().getDescendentByPath(path, crypto.hasher, network).join();
+            if (assetOpt.isEmpty()) {
+                httpExchange.getResponseHeaders().set("Content-Type", "text/plain");
+                httpExchange.sendResponseHeaders(404, 0);
+                return;
+            }
+            FileWrapper file = assetOpt.get();
+            if (file.isDirectory())
+                throw new IllegalStateException("Directory listings not allowed");
+            byte[] body = Serialize.readFully(file, crypto, network).join();
+
+//            if (isGzip)
+//                httpExchange.getResponseHeaders().set("Content-Encoding", "gzip");
+            if (path.endsWith(".js"))
+                httpExchange.getResponseHeaders().set("Content-Type", "text/javascript");
+            else if (path.endsWith(".html"))
+                httpExchange.getResponseHeaders().set("Content-Type", "text/html");
+            else if (path.endsWith(".css"))
+                httpExchange.getResponseHeaders().set("Content-Type", "text/css");
+            else if (path.endsWith(".json"))
+                httpExchange.getResponseHeaders().set("Content-Type", "application/json");
+            else if (path.endsWith(".png"))
+                httpExchange.getResponseHeaders().set("Content-Type", "image/png");
+            else if (path.endsWith(".woff"))
+                httpExchange.getResponseHeaders().set("Content-Type", "application/font-woff");
+            else if (path.endsWith(".svg"))
+                httpExchange.getResponseHeaders().set("Content-Type", "image/svg+xml");
+
+            if (httpExchange.getRequestMethod().equals("HEAD")) {
+                httpExchange.getResponseHeaders().set("Content-Length", "" + body.length);
+                httpExchange.sendResponseHeaders(200, -1);
+                return;
+            }
+
+            // Only allow assets to be loaded from the original host
+//            httpExchange.getResponseHeaders().set("content-security-policy", "default-src https: 'self'");
+            // Don't anyone to load Peergos site in an iframe
+            httpExchange.getResponseHeaders().set("x-frame-options", "sameorigin");
+            // Enable cross site scripting protection
+            httpExchange.getResponseHeaders().set("x-xss-protection", "1; mode=block");
+            // Don't let browser sniff mime types
+            httpExchange.getResponseHeaders().set("x-content-type-options", "nosniff");
+            // Don't send Peergos referrer to anyone
+            httpExchange.getResponseHeaders().set("referrer-policy", "no-referrer");
+
+            httpExchange.sendResponseHeaders(200, body.length);
+            httpExchange.getResponseBody().write(body);
+            httpExchange.close();
+        } catch (Exception e) {
+            LOG.severe("Error handling " +httpExchange.getRequestURI());
+            LOG.log(Level.WARNING, e.getMessage(), e);
+            HttpUtil.replyError(httpExchange, e);
+        } finally {
+            httpExchange.close();
+            long t2 = System.currentTimeMillis();
+            if (LOGGING)
+                LOG.info("Public file Handler returned " + path + " query in: " + (t2 - t1) + " mS");
+        }
+    }
+}

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -68,12 +68,12 @@ public class RamUserTests extends UserTests {
                 "-peergos-url", "http://localhost:" + args.getInt("port"),
                 "-port", "9000",
                 "-domain", "localhost",
-                "-domain-suffix", ".public.localhost:9000"
+                "-domain-suffix", ".peergos.localhost:9000"
         });
         PublicGateway publicGateway = Main.startGateway(a);
 
         // retrieve website
-        byte[] retrieved = get(new URI("http://" + username + ".public.localhost:9000").toURL());
+        byte[] retrieved = get(new URI("http://" + username + ".peergos.localhost:9000").toURL());
         Assert.assertTrue(Arrays.equals(retrieved, data));
 
         publicGateway.shutdown();

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -67,6 +67,7 @@ public class RamUserTests extends UserTests {
         Args a = Args.parse(new String[]{
                 "-peergos-url", "http://localhost:" + args.getInt("port"),
                 "-port", "9000",
+                "-domain", "localhost",
                 "-domain-suffix", ".public.localhost:9000"
         });
         PublicGateway publicGateway = Main.startGateway(a);

--- a/src/peergos/shared/user/ProfilePaths.java
+++ b/src/peergos/shared/user/ProfilePaths.java
@@ -1,6 +1,12 @@
 package peergos.shared.user;
 
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
+
 import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
 
 /** This class stores locations of the different components of a user's profile
  *
@@ -19,4 +25,37 @@ public class ProfilePaths {
     public static final Path EMAIL = ROOT.resolve("email");
     public static final Path WEBROOT = ROOT.resolve("webroot"); // The path in Peergos to this users web root
 
+    private static <V> CompletableFuture<Optional<V>> getAndParse(Path p, Function<byte[], V> parser, UserContext viewer) {
+        return viewer.getByPath(p)
+                .thenCompose(opt -> opt.map(f -> Serialize.readFully(f, viewer.crypto, viewer.network)
+                        .thenApply(parser)
+                        .thenApply(Optional::of))
+                        .orElse(Futures.of(Optional.empty())));
+    }
+
+    private static <V> CompletableFuture<Boolean> serializeAndSet(Path p, V val, Function<V, byte[]> serialize, UserContext user) {
+        byte[] raw = serialize.apply(val);
+        return user.getUserRoot()
+                .thenCompose(home -> home.getOrMkdirs(p.getParent(), user.network, true, user.crypto))
+                .thenCompose(parent -> parent.uploadOrReplaceFile(p.getFileName().toString(),
+                        AsyncReader.build(raw), raw.length, user.network, user.crypto, x -> {},
+                        user.crypto.random.randomBytes(RelativeCapability.MAP_KEY_LENGTH)))
+                .thenApply(x -> true);
+    }
+
+    public static CompletableFuture<Optional<byte[]>> getProfilePhoto(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(PHOTO_HIGH_RES), x -> x, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setProfilePhoto(UserContext user, byte[] image) {
+        return serializeAndSet(PHOTO_HIGH_RES, image, x -> x, user);
+    }
+
+    public static CompletableFuture<Optional<String>> getBio(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(BIO), String::new, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setBio(UserContext user, String bio) {
+        return serializeAndSet(BIO, bio, String::getBytes, user);
+    }
 }

--- a/src/peergos/shared/user/ProfilePaths.java
+++ b/src/peergos/shared/user/ProfilePaths.java
@@ -58,4 +58,44 @@ public class ProfilePaths {
     public static CompletableFuture<Boolean> setBio(UserContext user, String bio) {
         return serializeAndSet(BIO, bio, String::getBytes, user);
     }
+
+    public static CompletableFuture<Optional<String>> getStatus(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(STATUS), String::new, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setStatus(UserContext user, String bio) {
+        return serializeAndSet(STATUS, bio, String::getBytes, user);
+    }
+
+    public static CompletableFuture<Optional<String>> getFirstName(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(FIRSTNAME), String::new, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setFirstName(UserContext user, String firstname) {
+        return serializeAndSet(FIRSTNAME, firstname, String::getBytes, user);
+    }
+
+    public static CompletableFuture<Optional<String>> getLastName(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(LASTNAME), String::new, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setLastName(UserContext user, String lastname) {
+        return serializeAndSet(LASTNAME, lastname, String::getBytes, user);
+    }
+
+    public static CompletableFuture<Optional<String>> getPhone(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(PHONE), String::new, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setPhone(UserContext user, String phone) {
+        return serializeAndSet(PHONE, phone, String::getBytes, user);
+    }
+
+    public static CompletableFuture<Optional<String>> getEmail(String user, UserContext viewer) {
+        return getAndParse(Paths.get(user).resolve(EMAIL), String::new, viewer);
+    }
+
+    public static CompletableFuture<Boolean> setEmail(UserContext user, String email) {
+        return serializeAndSet(EMAIL, email, String::getBytes, user);
+    }
 }

--- a/src/peergos/shared/user/ProfilePaths.java
+++ b/src/peergos/shared/user/ProfilePaths.java
@@ -1,0 +1,22 @@
+package peergos.shared.user;
+
+import java.nio.file.*;
+
+/** This class stores locations of the different components of a user's profile
+ *
+ *  Each component is a separate file and can thus be shared or made public individually.
+ */
+public class ProfilePaths {
+
+    public static final Path ROOT = Paths.get(".profile");
+    private static final Path PHOTO = ROOT.resolve("photo");
+    public static final Path PHOTO_HIGH_RES = PHOTO.resolve("highres");
+    public static final Path BIO = ROOT.resolve("bio");
+    public static final Path STATUS = ROOT.resolve("status");
+    public static final Path FIRSTNAME = ROOT.resolve("firstname");
+    public static final Path LASTNAME = ROOT.resolve("lastname");
+    public static final Path PHONE = ROOT.resolve("phone");
+    public static final Path EMAIL = ROOT.resolve("email");
+    public static final Path WEBROOT = ROOT.resolve("webroot"); // The path in Peergos to this users web root
+
+}


### PR DESCRIPTION
This allows any Peergos user to publish a website securely without requiring any DNS management or TLS certificates. 

A user publishes a directory, and sets that directory as their webroot in their profile (and makes that profile property public). Then their site is served from http://$username.peergos.localhost:9000 and https://$username.peergos.me

Long term and with browser support this could become a new URL scheme peergos://$username/$path
