### PR TITLE
Don't use the direct S3 blockstore during signup.

### DIFF
--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -21,6 +21,11 @@ public class DelayingStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<Multihash> id() {
         return source.id();
     }

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -42,6 +42,11 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<Multihash> id() {
         return CompletableFuture.completedFuture(new Multihash(Multihash.Type.sha2_256, RAMStorage.hash("FileStorage".getBytes())));
     }

--- a/src/peergos/server/storage/IpfsDHT.java
+++ b/src/peergos/server/storage/IpfsDHT.java
@@ -35,6 +35,11 @@ public class IpfsDHT implements ContentAddressedStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<Multihash> id() {
         CompletableFuture<Multihash> res = new CompletableFuture<>();
         try {

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -19,6 +19,11 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<Multihash> id() {
         return source.id();
     }

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -21,6 +21,11 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     private final Set<Multihash> pinnedRoots = new HashSet<>();
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<Multihash> id() {
         return CompletableFuture.completedFuture(new Multihash(Multihash.Type.sha2_256, new byte[32]));
     }

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -72,6 +72,11 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         this.p2pFallback = p2pFallback;
     }
 
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
     private static String hashToKey(Multihash hash) {
         return DirectS3BlockStore.hashToKey(hash);
     }

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -22,6 +22,11 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
         return Futures.of(transactions.startTransaction(owner));
     }

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -22,6 +22,12 @@ public class RetryStorageTests {
         public FailingStorage(int retryLimit) {
             this.retryLimit = retryLimit;
         }
+
+        @Override
+        public ContentAddressedStorage directToOrigin() {
+            return this;
+        }
+
         @Override
         public CompletableFuture<Multihash> id() {
             if(counter++ % retryLimit != 0) {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -82,7 +82,10 @@ public class NetworkAccess {
     }
 
     public NetworkAccess withoutS3BlockStore() {
-        return new NetworkAccess(coreNode, social, dhtClient.directToOrigin(), mutable, tree, synchronizer, instanceAdmin,
+        ContentAddressedStorage directDht = dhtClient.directToOrigin();
+        WriteSynchronizer synchronizer = new WriteSynchronizer(mutable, directDht, hasher);
+        MutableTree tree = new MutableTreeImpl(mutable, directDht, hasher, synchronizer);
+        return new NetworkAccess(coreNode, social, directDht, mutable, tree, synchronizer, instanceAdmin,
                 spaceUsage, serverMessager, hasher, usernames, isJavascript);
     }
 

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -81,6 +81,11 @@ public class NetworkAccess {
                 spaceUsage, serverMessager, hasher, usernames, isJavascript);
     }
 
+    public NetworkAccess withoutS3BlockStore() {
+        return new NetworkAccess(coreNode, social, dhtClient.directToOrigin(), mutable, tree, synchronizer, instanceAdmin,
+                spaceUsage, serverMessager, hasher, usernames, isJavascript);
+    }
+
     @JsMethod
     public CompletableFuture<Boolean> isUsernameRegistered(String username) {
         if (usernames.contains(username))

--- a/src/peergos/shared/storage/CachingStorage.java
+++ b/src/peergos/shared/storage/CachingStorage.java
@@ -13,15 +13,21 @@ public class CachingStorage extends DelegatingStorage {
     private final LRUCache<Multihash, byte[]> cache;
     private final LRUCache<Multihash, CompletableFuture<Optional<CborObject>>> pending;
     private final LRUCache<Multihash, CompletableFuture<Optional<byte[]>>> pendingRaw;
-    private final int maxValueSize;
+    private final int maxValueSize, cacheSize;
 
     public CachingStorage(ContentAddressedStorage target, int cacheSize, int maxValueSize) {
         super(target);
         this.target = target;
         this.cache = new LRUCache<>(cacheSize);
         this.maxValueSize = maxValueSize;
+        this.cacheSize = cacheSize;
         this.pending = new LRUCache<>(100);
         this.pendingRaw = new LRUCache<>(100);
+    }
+
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return new CachingStorage(target.directToOrigin(), cacheSize, maxValueSize);
     }
 
     @Override

--- a/src/peergos/shared/storage/CommittableStorage.java
+++ b/src/peergos/shared/storage/CommittableStorage.java
@@ -39,6 +39,11 @@ public class CommittableStorage extends DelegatingStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return new CommittableStorage(target.directToOrigin());
+    }
+
+    @Override
     public CompletableFuture<Multihash> put(PublicKeyHash owner,
                                             PublicKeyHash writer,
                                             byte[] signature,

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -29,6 +29,10 @@ public interface ContentAddressedStorage {
         return Futures.of(BlockStoreProperties.empty());
     }
 
+    /**
+     *
+     * @return an instance of the same type that doesn't do any cross domain requests
+     */
     ContentAddressedStorage directToOrigin();
 
     default CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -29,6 +29,8 @@ public interface ContentAddressedStorage {
         return Futures.of(BlockStoreProperties.empty());
     }
 
+    ContentAddressedStorage directToOrigin();
+
     default CompletableFuture<List<PresignedUrl>> authReads(List<Multihash> blocks) {
         return Futures.errored(new IllegalStateException("Unimplemented call!"));
     }
@@ -344,6 +346,11 @@ public interface ContentAddressedStorage {
             this.isPeergosServer = isPeergosServer;
         }
 
+        @Override
+        public ContentAddressedStorage directToOrigin() {
+            return this;
+        }
+
         private static Multihash getObjectHash(Object rawJson) {
             Map json = (Map)rawJson;
             String hash = (String)json.get("Hash");
@@ -603,6 +610,11 @@ public interface ContentAddressedStorage {
             this.p2p = p2p;
             this.ourNodeId = ourNodeId;
             this.core = core;
+        }
+
+        @Override
+        public ContentAddressedStorage directToOrigin() {
+            return new Proxying(local.directToOrigin(), p2p, ourNodeId, core);
         }
 
         @Override

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -40,6 +40,11 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
         this.core = core;
     }
 
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return fallback;
+    }
+
     public static String hashToKey(Multihash hash) {
         // To be compatible with IPFS we use the same scheme here, the cid bytes encoded as uppercase base32
         String padded = new Base32().encodeAsString(hash.toBytes());

--- a/src/peergos/shared/storage/HashVerifyingStorage.java
+++ b/src/peergos/shared/storage/HashVerifyingStorage.java
@@ -45,6 +45,11 @@ public class HashVerifyingStorage extends DelegatingStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return new HashVerifyingStorage(source.directToOrigin(), hasher);
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signedHashes,

--- a/src/peergos/shared/storage/PeergosBackedStorage.java
+++ b/src/peergos/shared/storage/PeergosBackedStorage.java
@@ -31,6 +31,11 @@ public class PeergosBackedStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<Multihash> id() {
         return CompletableFuture.completedFuture(new Multihash(Multihash.Type.sha2_256, new byte[32]));
     }

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -28,6 +28,11 @@ public class RetryStorage implements ContentAddressedStorage {
         this.maxAttempts = maxAttempts;
     }
 
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return new RetryStorage(target.directToOrigin(), maxAttempts);
+    }
+
     private <V> void retryAfter(Supplier<CompletableFuture<V>> method, int milliseconds) {
         executor.schedule(method::get, milliseconds, TimeUnit.MILLISECONDS);
     }

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -32,6 +32,11 @@ public class WriteFilter extends DelegatingStorage {
     }
 
     @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
     public CompletableFuture<List<Multihash>> put(PublicKeyHash owner,
                                                   PublicKeyHash writer,
                                                   List<byte[]> signedHashes,

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -230,10 +230,11 @@ public class UserContext {
 
     public static CompletableFuture<UserContext> signUpGeneral(String username,
                                                                String password,
-                                                               NetworkAccess network,
+                                                               NetworkAccess initialNetwork,
                                                                Crypto crypto,
                                                                SecretGenerationAlgorithm algorithm,
                                                                Consumer<String> progressCallback) {
+        NetworkAccess network = initialNetwork.withoutS3BlockStore();
         progressCallback.accept("Generating keys");
         return UserUtil.generateUser(username, password, crypto.hasher, crypto.symmetricProvider, crypto.random, crypto.signer, crypto.boxer, algorithm)
                 .thenCompose(userWithRoot -> {
@@ -283,7 +284,7 @@ public class UserContext {
                                                 TRANSACTIONS_DIR_NAME, network, crypto))
                                         .thenCompose(globalRoot -> createSpecialDirectory(globalRoot, username,
                                                 CapabilityStore.CAPABILITY_CACHE_DIR, network, crypto))
-                                        .thenCompose(y -> signIn(username, userWithRoot, network, crypto, progressCallback));
+                                        .thenCompose(y -> signIn(username, userWithRoot, initialNetwork, crypto, progressCallback));
                             }));
                 }).exceptionally(Futures::logAndThrow);
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -163,13 +163,16 @@ public class UserContext {
             progressCallback.accept("Generating keys");
             return UserUtil.generateUser(username, password, crypto.hasher, crypto.symmetricProvider,
                     crypto.random, crypto.signer, crypto.boxer, algorithm)
-                    .thenCompose(userWithRoot ->
-                            login(username, userWithRoot, pair, network, crypto, progressCallback));
+                    .thenCompose(userWithRoot -> {
+                        progressCallback.accept("Logging in");
+                        return login(username, userWithRoot, pair, network, crypto, progressCallback);
+                    });
         }).exceptionally(Futures::logAndThrow);
     }
 
     public static CompletableFuture<UserContext> signIn(String username, UserWithRoot userWithRoot, NetworkAccess network
             , Crypto crypto, Consumer<String> progressCallback) {
+        progressCallback.accept("Logging in");
         return getWriterDataCbor(network, username)
                 .thenCompose(pair -> login(username, userWithRoot, pair, network, crypto, progressCallback))
                 .exceptionally(Futures::logAndThrow);
@@ -182,7 +185,6 @@ public class UserContext {
                                                         Crypto crypto,
                                                         Consumer<String> progressCallback) {
         try {
-            progressCallback.accept("Logging in");
             WriterData userData = WriterData.fromCbor(pair.right);
             return createOurFileTreeOnly(username, userWithRoot.getRoot(), userData, network, crypto)
                     .thenCompose(root -> TofuCoreNode.load(username, root, network, crypto)


### PR DESCRIPTION
Otherwise users which block 3rd party domains will end up with an unrecoverable signup.

The important changes are in UserContext and NetworkAccess. 

Container implementations of ContentAddressedStorage should make a new version of themselves with a recursive call on their target. 