### PR TITLE
Clean up cbor maps

### DIFF
--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -110,15 +110,15 @@ public class MirrorCoreNode implements CoreNode {
             res.put("pkiKey", pkiOwnerIdentity);
             res.put("pkiTarget", pkiKeyTarget);
 
-            TreeMap<CborObject, ? extends Cborable> chainsMap = chains.entrySet()
+            TreeMap<String, ? extends Cborable> chainsMap = chains.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
-                    e -> new CborObject.CborString(e.getKey()),
+                    e -> e.getKey(),
                     e -> new CborObject.CborList(e.getValue()),
                     (a,b) -> a,
                     TreeMap::new
                 ));
-            res.put("chains", new CborObject.CborMap(chainsMap));
+            res.put("chains", CborObject.CborMap.build(chainsMap));
             TreeMap<CborObject, ? extends Cborable> reverseMap = reverseLookup.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
@@ -127,7 +127,7 @@ public class MirrorCoreNode implements CoreNode {
                     (a,b) -> a,
                     TreeMap::new
                 ));
-            res.put("reverse", new CborObject.CborMap(reverseMap));
+            res.put("reverse", new CborObject.CborList(reverseMap));
             res.put("usernames", new CborObject.CborList(usernames.stream()
                     .map(CborObject.CborString::new)
                     .collect(Collectors.toList())));
@@ -148,7 +148,7 @@ public class MirrorCoreNode implements CoreNode {
             Map<String, List<UserPublicKeyLink>> chains = ((CborObject.CborMap)map.get("chains"))
                     .getMap(fromString, chainParser);
 
-            Map<PublicKeyHash, String> reverse = ((CborObject.CborMap)map.get("reverse"))
+            Map<PublicKeyHash, String> reverse = ((CborObject.CborList)map.get("reverse"))
                     .getMap(PublicKeyHash::fromCbor, fromString);
 
             List<String> usernames = map.getList("usernames", fromString);

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -110,7 +110,7 @@ public class MirrorCoreNode implements CoreNode {
             res.put("pkiKey", pkiOwnerIdentity);
             res.put("pkiTarget", pkiKeyTarget);
 
-            TreeMap<String, ? extends Cborable> chainsMap = chains.entrySet()
+            TreeMap<String, Cborable> chainsMap = chains.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
                     e -> e.getKey(),
@@ -119,7 +119,7 @@ public class MirrorCoreNode implements CoreNode {
                     TreeMap::new
                 ));
             res.put("chains", CborObject.CborMap.build(chainsMap));
-            TreeMap<CborObject, ? extends Cborable> reverseMap = reverseLookup.entrySet()
+            TreeMap<CborObject, Cborable> reverseMap = reverseLookup.entrySet()
                 .stream()
                 .collect(Collectors.toMap(
                     e -> e.getKey().toCbor(),

--- a/src/peergos/server/space/RamUsageStore.java
+++ b/src/peergos/server/space/RamUsageStore.java
@@ -152,7 +152,7 @@ public class RamUsageStore implements UsageStore {
                     ));
 
             CborObject.CborList views = new CborObject.CborList(viewsMap);
-            CborObject.CborMap usages = CborObject.CborMap.build(usage);
+            CborObject.CborMap usages = CborObject.CborMap.build(new HashMap<>(usage));
             Map<String, Cborable> map = new HashMap<>();
             map.put("views", views);
             map.put("usages", usages);

--- a/src/peergos/server/space/RamUsageStore.java
+++ b/src/peergos/server/space/RamUsageStore.java
@@ -151,7 +151,7 @@ public class RamUsageStore implements UsageStore {
                             TreeMap::new
                     ));
 
-            CborObject.CborMap views = new CborObject.CborMap(viewsMap);
+            CborObject.CborList views = new CborObject.CborList(viewsMap);
             CborObject.CborMap usages = CborObject.CborMap.build(usage);
             Map<String, Cborable> map = new HashMap<>();
             map.put("views", views);
@@ -161,7 +161,7 @@ public class RamUsageStore implements UsageStore {
 
         public static State fromCbor(CborObject cbor) {
             CborObject.CborMap map = (CborObject.CborMap) cbor;
-            CborObject.CborMap viewsMap = (CborObject.CborMap) map.get("views");
+            CborObject.CborList viewsMap = (CborObject.CborList) map.get("views");
             CborObject.CborMap usagesMap = (CborObject.CborMap) map.get("usages");
 
             return new State(viewsMap.getMap(PublicKeyHash::fromCbor, WriterUsage::fromCbor),

--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -78,7 +78,7 @@ public class CborObjects {
 
     @Test
     public void cborMap() {
-        SortedMap<String, CborObject> map = new TreeMap<>();
+        SortedMap<String, Cborable> map = new TreeMap<>();
         map.put("KEY 1", new CborObject.CborString("A value"));
         map.put("KEY 2", new CborObject.CborByteArray("Another value".getBytes()));
         map.put("KEY 3", new CborObject.CborNull());

--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -78,20 +78,20 @@ public class CborObjects {
 
     @Test
     public void cborMap() {
-        SortedMap<CborObject, CborObject> map = new TreeMap<>();
-        map.put(new CborObject.CborString("KEY 1"), new CborObject.CborString("A value"));
-        map.put(new CborObject.CborString("KEY 2"), new CborObject.CborByteArray("Another value".getBytes()));
-        map.put(new CborObject.CborString("KEY 3"), new CborObject.CborNull());
-        map.put(new CborObject.CborString("KEY 4"), new CborObject.CborBoolean(true));
+        SortedMap<String, CborObject> map = new TreeMap<>();
+        map.put("KEY 1", new CborObject.CborString("A value"));
+        map.put("KEY 2", new CborObject.CborByteArray("Another value".getBytes()));
+        map.put("KEY 3", new CborObject.CborNull());
+        map.put("KEY 4", new CborObject.CborBoolean(true));
         Multihash hash = Multihash.fromBase58("QmPZ9gcCEpqKTo6aq61g2nXGUhM4iCL3ewB6LDXZCtioEB");
         CborObject.CborMerkleLink link = new CborObject.CborMerkleLink(hash);
-        map.put(new CborObject.CborString("Key 5"), link);
+        map.put("Key 5", link);
         List<CborObject> list = new ArrayList<>();
         list.add(new CborObject.CborBoolean(true));
         list.add(new CborObject.CborNull());
         list.add(new CborObject.CborLong(256));
-        map.put(new CborObject.CborString("KEY 6"), new CborObject.CborList(list));
-        CborObject.CborMap cborMap = new CborObject.CborMap(map);
+        map.put("KEY 6", new CborObject.CborList(list));
+        CborObject.CborMap cborMap = CborObject.CborMap.build(map);
         compatibleAndIdempotentSerialization(cborMap);
     }
 

--- a/src/peergos/server/tests/FragmentedPaddedCipherTextTests.java
+++ b/src/peergos/server/tests/FragmentedPaddedCipherTextTests.java
@@ -74,10 +74,9 @@ public class FragmentedPaddedCipherTextTests {
             return true;
         }
         if (a instanceof CborObject.CborMap) {
-            SortedMap<CborObject, ? extends Cborable> aMap = ((CborObject.CborMap) a).values;
-            SortedMap<CborObject, ? extends Cborable> bMap = ((CborObject.CborMap) b).values;
-            for (CborObject key : aMap.keySet()) {
-                if (! structurallyEqual(aMap.get(key), bMap.get(key)))
+            CborObject.CborMap aMap = (CborObject.CborMap) a;
+            for (String key : aMap.keySet()) {
+                if (! structurallyEqual(aMap.get(key), ((CborObject.CborMap)b).get(key)))
                     return false;
             }
             return true;

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -860,12 +860,12 @@ public class MultiUserTests {
         CommittedWriterData cwd2 = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
         CryptreeNode fileAccess = network.getMetadata(cwd2.props, priorPointer.withMapKey(newCap.getMapKey())).get().get();
         // check we are trying to decrypt the correct thing
-        PaddedCipherText priorPropsCipherText = (PaddedCipherText) ((CborObject.CborMap) priorFileAccess.toCbor()).get("p");
+        PaddedCipherText priorPropsCipherText = ((CborObject.CborMap) priorFileAccess.toCbor()).getObject("p", PaddedCipherText::fromCbor);
         CborObject.CborMap priorFromParent = priorPropsCipherText.decrypt(priorMetaKey, x -> (CborObject.CborMap)x);
         FileProperties priorProps = FileProperties.fromCbor(priorFromParent.get("s"));
         try {
             // Try decrypting the new metadata with the old key
-            PaddedCipherText propsCipherText = (PaddedCipherText) ((CborObject.CborMap) fileAccess.toCbor()).get("p");
+            PaddedCipherText propsCipherText = ((CborObject.CborMap) fileAccess.toCbor()).getObject("p", PaddedCipherText::fromCbor);
             CborObject.CborMap fromParent = propsCipherText.decrypt(priorMetaKey, x -> (CborObject.CborMap)x);
             FileProperties props = FileProperties.fromCbor(fromParent.get("s"));
             throw new IllegalStateException("We shouldn't be able to decrypt this after a rename! new name = " + props.name);

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -110,10 +110,11 @@ public interface CborObject extends Cborable {
     final class CborMap implements CborObject {
         public final SortedMap<CborObject,? extends Cborable> values;
 
-        public CborMap(SortedMap<CborObject,? extends Cborable> values) {
+        private CborMap(SortedMap<CborObject,? extends Cborable> values) {
             this.values = values;
         }
 
+        // Only String keys should be used in IPLD dag-cbor
         public static CborMap build(Map<String, ? extends Cborable> values) {
             SortedMap<CborObject, Cborable> transformed = values.entrySet()
                     .stream()

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -63,7 +63,7 @@ public class UserPublicKeyLink implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> values = new TreeMap<>();
+        Map<String, Cborable> values = new TreeMap<>();
         values.put("owner", owner.toCbor());
         values.put("claim", claim.toCbor());
         keyChangeProof.ifPresent(proof -> values.put("keychange", new CborObject.CborByteArray(proof)));

--- a/src/peergos/shared/crypto/OwnerProof.java
+++ b/src/peergos/shared/crypto/OwnerProof.java
@@ -29,7 +29,7 @@ public class OwnerProof implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> result = new TreeMap<>();
+        Map<String, Cborable> result = new TreeMap<>();
         result.put("o", new CborObject.CborMerkleLink(ownedKey));
         result.put("p", new CborObject.CborByteArray(signedOwner));
         return CborObject.CborMap.build(result);

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -22,7 +22,7 @@ public class ProofOfWork implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> values = new TreeMap<>();
+        Map<String, Cborable> values = new TreeMap<>();
         values.put("prefix", new CborObject.CborByteArray(prefix));
         values.put("type", new CborObject.CborLong(type.index));
         return CborObject.CborMap.build(values);

--- a/src/peergos/shared/crypto/SigningPrivateKeyAndPublicHash.java
+++ b/src/peergos/shared/crypto/SigningPrivateKeyAndPublicHash.java
@@ -20,7 +20,7 @@ public class SigningPrivateKeyAndPublicHash implements Cborable {
     @Override
     @SuppressWarnings("unusable-by-js")
     public CborObject toCbor() {
-        Map<String, CborObject> result = new TreeMap<>();
+        Map<String, Cborable> result = new TreeMap<>();
         result.put("p", publicKeyHash.toCbor());
         result.put("s", secret.toCbor());
         return CborObject.CborMap.build(result);

--- a/src/peergos/shared/social/BlindFollowRequest.java
+++ b/src/peergos/shared/social/BlindFollowRequest.java
@@ -20,7 +20,7 @@ public class BlindFollowRequest implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> result = new TreeMap<>();
+        Map<String, Cborable> result = new TreeMap<>();
         result.put("k", dummySource.toCbor());
         result.put("f", followRequest.toCbor());
         return CborObject.CborMap.build(result);

--- a/src/peergos/shared/social/FollowRequest.java
+++ b/src/peergos/shared/social/FollowRequest.java
@@ -28,7 +28,7 @@ public class FollowRequest implements Cborable {
 
     @SuppressWarnings("unusable-by-js")
     public CborObject toCbor() {
-        Map<String, CborObject> result = new TreeMap<>();
+        Map<String, Cborable> result = new TreeMap<>();
         entry.ifPresent(e -> result.put("e", e.toCbor()));
         key.ifPresent(k -> result.put("k", k.toCbor()));
         return CborObject.CborMap.build(result);

--- a/src/peergos/shared/storage/BlockStoreProperties.java
+++ b/src/peergos/shared/storage/BlockStoreProperties.java
@@ -25,7 +25,7 @@ public class BlockStoreProperties implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> props = new TreeMap<>();
+        Map<String, Cborable> props = new TreeMap<>();
         props.put("w", new CborObject.CborBoolean(directWrites));
         props.put("pr", new CborObject.CborBoolean(publicReads));
         props.put("ar", new CborObject.CborBoolean(authedReads));

--- a/src/peergos/shared/storage/PresignedUrl.java
+++ b/src/peergos/shared/storage/PresignedUrl.java
@@ -16,9 +16,9 @@ public class PresignedUrl implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> props = new TreeMap<>();
+        Map<String, Cborable> props = new TreeMap<>();
         props.put("b", new CborObject.CborString(base));
-        Map<String, CborObject> headers = new TreeMap<>();
+        Map<String, Cborable> headers = new TreeMap<>();
         for (Map.Entry<String, String> e : fields.entrySet()) {
             headers.put(e.getKey(), new CborObject.CborString(e.getValue()));
         }

--- a/src/peergos/shared/storage/QuotaControl.java
+++ b/src/peergos/shared/storage/QuotaControl.java
@@ -39,7 +39,7 @@ public interface QuotaControl {
 
         @Override
         public CborObject toCbor() {
-            Map<String, CborObject> props = new TreeMap<>();
+            Map<String, Cborable> props = new TreeMap<>();
             props.put("u", new CborObject.CborString(username));
             props.put("r", new CborObject.CborByteArray(signedRequest));
             return CborObject.CborMap.build(props);
@@ -74,7 +74,7 @@ public interface QuotaControl {
 
         @Override
         public CborObject toCbor() {
-            Map<String, CborObject> props = new TreeMap<>();
+            Map<String, Cborable> props = new TreeMap<>();
             props.put("u", new CborObject.CborString(username));
             props.put("s", new CborObject.CborLong(bytes));
             props.put("t", new CborObject.CborLong(utcMillis));

--- a/src/peergos/shared/storage/WriteAuthRequest.java
+++ b/src/peergos/shared/storage/WriteAuthRequest.java
@@ -17,7 +17,7 @@ public class WriteAuthRequest implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> props = new TreeMap<>();
+        Map<String, Cborable> props = new TreeMap<>();
         props.put("s", new CborObject.CborList(signatures.stream()
                 .map(CborObject.CborByteArray::new)
                 .collect(Collectors.toList())));

--- a/src/peergos/shared/storage/controller/InstanceAdmin.java
+++ b/src/peergos/shared/storage/controller/InstanceAdmin.java
@@ -47,7 +47,7 @@ public interface InstanceAdmin {
 
         @Override
         public CborObject toCbor() {
-            Map<String, CborObject> props = new TreeMap<>();
+            Map<String, Cborable> props = new TreeMap<>();
             props.put("v", new CborObject.CborString(version.toString()));
             return CborObject.CborMap.build(props);
         }

--- a/src/peergos/shared/user/EntryPoint.java
+++ b/src/peergos/shared/user/EntryPoint.java
@@ -50,7 +50,7 @@ public class EntryPoint implements Cborable {
     @Override
     @SuppressWarnings("unusable-by-js")
     public CborObject toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         cbor.put("c", pointer.toCbor());
         cbor.put("n", new CborObject.CborString(ownerName));
         return CborObject.CborMap.build(cbor);
@@ -61,9 +61,9 @@ public class EntryPoint implements Cborable {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor type for EntryPoint: " + cbor);
 
-        SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
-        AbsoluteCapability pointer = AbsoluteCapability.fromCbor(map.get(new CborObject.CborString("c")));
-        String ownerName = ((CborObject.CborString) map.get(new CborObject.CborString("n"))).value;
+        CborObject.CborMap map = (CborObject.CborMap) cbor;
+        AbsoluteCapability pointer = map.getObject("c", AbsoluteCapability::fromCbor);
+        String ownerName = map.getString("n");
         return new EntryPoint(pointer, ownerName);
     }
 

--- a/src/peergos/shared/user/RandomSecretType.java
+++ b/src/peergos/shared/user/RandomSecretType.java
@@ -11,7 +11,7 @@ public class RandomSecretType implements SecretGenerationAlgorithm {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> props = new TreeMap<>();
+        Map<String, Cborable> props = new TreeMap<>();
         props.put("type", new CborObject.CborLong(getType().value));
         return CborObject.CborMap.build(props);
     }

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -31,7 +31,7 @@ public class ScryptGenerator implements SecretGenerationAlgorithm {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> props = new TreeMap<>();
+        Map<String, Cborable> props = new TreeMap<>();
         props.put("type", new CborObject.CborLong(getType().value));
         props.put("m", new CborObject.CborLong(memoryCost));
         props.put("c", new CborObject.CborLong(cpuCost));

--- a/src/peergos/shared/user/SecretGenerationAlgorithm.java
+++ b/src/peergos/shared/user/SecretGenerationAlgorithm.java
@@ -56,7 +56,7 @@ public interface SecretGenerationAlgorithm extends Cborable {
     static SecretGenerationAlgorithm fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor type for SecretGenerationAlgorithm: " + cbor);
-        Type type = Type.byValue((int)((CborObject.CborLong) ((CborObject.CborMap) cbor).values.get(new CborObject.CborString("type"))).value);
+        Type type = Type.byValue((int)((CborObject.CborMap) cbor).getLong("type"));
         if (type == Type.Scrypt)
             return ScryptGenerator.fromCbor(cbor);
         if (type == Type.Random)

--- a/src/peergos/shared/user/TodoBoard.java
+++ b/src/peergos/shared/user/TodoBoard.java
@@ -45,7 +45,7 @@ public class TodoBoard implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> cborData = new TreeMap<>();
+        Map<String, Cborable> cborData = new TreeMap<>();
         cborData.put("version", new CborObject.CborString(VERSION_1));
         cborData.put("name", new CborObject.CborString(name.substring(0, Math.min(name.length(), 25))));
         cborData.put("lists", new CborObject.CborList(todoLists));

--- a/src/peergos/shared/user/TodoList.java
+++ b/src/peergos/shared/user/TodoList.java
@@ -41,7 +41,7 @@ public class TodoList implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         cbor.put("name", new CborObject.CborString(name.substring(0, Math.min(name.length(), 20))));
         cbor.put("id", new CborObject.CborString(id));
         cbor.put("items", new CborObject.CborList(todoItems));

--- a/src/peergos/shared/user/TodoListItem.java
+++ b/src/peergos/shared/user/TodoListItem.java
@@ -37,7 +37,7 @@ public class TodoListItem implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         cbor.put("i", new CborObject.CborString(Id));
         cbor.put("z", new CborObject.CborLong(created.toEpochSecond(ZoneOffset.UTC)));
         cbor.put("t", new CborObject.CborString(text.substring(0, Math.min(text.length(), 60))));
@@ -48,16 +48,13 @@ public class TodoListItem implements Cborable {
     public static TodoListItem fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor for TodoListItem: " + cbor);
-        SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
-        CborObject.CborString idStr = (CborObject.CborString)map.get(new CborObject.CborString("i"));
-
-
-        CborObject.CborMap m = (CborObject.CborMap) cbor;
-        long modifiedEpochSeconds = m.getLong("z");
+        CborObject.CborMap map = (CborObject.CborMap) cbor;
+        String id = map.getString("i");
+        long modifiedEpochSeconds = map.getLong("z");
         LocalDateTime modified = LocalDateTime.ofEpochSecond(modifiedEpochSeconds, 0, ZoneOffset.UTC);
-        CborObject.CborString textStr = (CborObject.CborString)map.get(new CborObject.CborString("t"));
-        CborObject.CborBoolean checkedStr = (CborObject.CborBoolean)map.get(new CborObject.CborString("c"));
-        return new TodoListItem(idStr.value, modified, textStr.value, checkedStr.value);
+        String text = map.getString("t");
+        boolean checked = map.getBoolean("c");
+        return new TodoListItem(id, modified, text, checked);
     }
 
     @Override

--- a/src/peergos/shared/user/TofuKeyStore.java
+++ b/src/peergos/shared/user/TofuKeyStore.java
@@ -92,14 +92,14 @@ public class TofuKeyStore implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        SortedMap<CborObject, CborObject> state = new TreeMap<>();
-        Consumer<Map<String, List<UserPublicKeyLink>>> serialise = map -> map.forEach((name, chain) -> state.put(new CborObject.CborString(name),
+        SortedMap<String, CborObject> state = new TreeMap<>();
+        Consumer<Map<String, List<UserPublicKeyLink>>> serialise = map -> map.forEach((name, chain) -> state.put(name,
                 new CborObject.CborList(chain.stream()
                         .map(link -> link.toCbor())
                         .collect(Collectors.toList()))));
         serialise.accept(chains);
         serialise.accept(expired);
-        return new CborObject.CborMap(state);
+        return CborObject.CborMap.build(state);
     }
 
     public static TofuKeyStore fromCbor(CborObject cbor) {

--- a/src/peergos/shared/user/UserStaticData.java
+++ b/src/peergos/shared/user/UserStaticData.java
@@ -64,11 +64,11 @@ public class UserStaticData implements Cborable {
         public static EntryPoints fromCbor(Cborable cbor) {
             if (! (cbor instanceof CborObject.CborMap))
                 throw new IllegalStateException("Incorrect cbor type for EntryPoints: " + cbor);
-            CborObject.CborLong version = (CborObject.CborLong)((CborObject.CborMap) cbor).values.get(new CborObject.CborString("v"));
-            if (version.value != VERSION)
-                throw new IllegalStateException("Unknown UserStaticData version: " + version.value);
-            return new EntryPoints(version.value,
-                    ((CborObject.CborList) ((CborObject.CborMap) cbor).values.get(new CborObject.CborString("e")))
+            long version = ((CborObject.CborMap) cbor).getLong("v");
+            if (version != VERSION)
+                throw new IllegalStateException("Unknown UserStaticData version: " + version);
+            return new EntryPoints(version,
+                    ((CborObject.CborMap) cbor).getList("e")
                             .value.stream()
                             .map(EntryPoint::fromCbor)
                             .collect(Collectors.toList()));

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -293,9 +293,7 @@ public class WriterData implements Cborable {
         followRequestReceiver.ifPresent(boxer -> result.put("inbound", new CborObject.CborMerkleLink(boxer)));
         ownedKeys.ifPresent(root -> result.put("owned", new CborObject.CborMerkleLink(root)));
         if (! namedOwnedKeys.isEmpty())
-            result.put("named", new CborObject.CborMap(new TreeMap<>(namedOwnedKeys.entrySet()
-                    .stream()
-                    .collect(Collectors.toMap(e -> new CborObject.CborString(e.getKey()), e -> e.getValue())))));
+            result.put("named", CborObject.CborMap.build(namedOwnedKeys));
         staticData.ifPresent(sd -> result.put("static", sd.toCbor()));
         tree.ifPresent(tree -> result.put("tree", new CborObject.CborMerkleLink(tree)));
         return CborObject.CborMap.build(result);

--- a/src/peergos/shared/user/fs/AbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/AbsoluteCapability.java
@@ -118,7 +118,7 @@ public class AbsoluteCapability implements Cborable {
 
     @Override
     public CborObject.CborMap toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         cbor.put("o", owner.toCbor());
         cbor.put("w", writer.toCbor());
         cbor.put("m", new CborObject.CborByteArray(mapKey));

--- a/src/peergos/shared/user/fs/CapabilitiesFromUser.java
+++ b/src/peergos/shared/user/fs/CapabilitiesFromUser.java
@@ -30,7 +30,7 @@ public class CapabilitiesFromUser implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         cbor.put("bytes", new CborObject.CborLong(bytesRead));
         cbor.put("caps", new CborObject.CborList(retrievedCapabilities));
         return CborObject.CborMap.build(cbor);

--- a/src/peergos/shared/user/fs/CapabilityWithPath.java
+++ b/src/peergos/shared/user/fs/CapabilityWithPath.java
@@ -17,7 +17,7 @@ public class CapabilityWithPath implements Cborable {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         cbor.put("p", new CborObject.CborString(path));
         cbor.put("c", cap.toCbor());
         return CborObject.CborMap.build(cbor);
@@ -26,10 +26,10 @@ public class CapabilityWithPath implements Cborable {
     public static CapabilityWithPath fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor for CapabilityWithPath: " + cbor);
-        SortedMap<CborObject, ? extends Cborable> map = ((CborObject.CborMap) cbor).values;
-        CborObject.CborString path = (CborObject.CborString)map.get(new CborObject.CborString("p"));
-        AbsoluteCapability fp = AbsoluteCapability.fromCbor(map.get(new CborObject.CborString("c")));
-        return new CapabilityWithPath(path.value, fp);
+        CborObject.CborMap map = (CborObject.CborMap) cbor;
+        String path = map.getString("p");
+        AbsoluteCapability fp = map.getObject("c", AbsoluteCapability::fromCbor);
+        return new CapabilityWithPath(path, fp);
     }
 
     @Override

--- a/src/peergos/shared/user/fs/ErasureFragmenter.java
+++ b/src/peergos/shared/user/fs/ErasureFragmenter.java
@@ -37,7 +37,7 @@ public class ErasureFragmenter implements Fragmenter {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> res = new HashMap<>();
+        Map<String, Cborable> res = new HashMap<>();
         res.put("t", new CborObject.CborLong(Type.ERASURE_CODING.val));
         res.put("o", new CborObject.CborLong(nOriginalFragments));
         res.put("a", new CborObject.CborLong(nAllowedFailures));

--- a/src/peergos/shared/user/fs/Fragmenter.java
+++ b/src/peergos/shared/user/fs/Fragmenter.java
@@ -32,14 +32,13 @@ public interface Fragmenter extends Cborable {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Incorrect cbor for Fragmenter: " + cbor);
 
-        SortedMap<CborObject, ? extends Cborable> values = ((CborObject.CborMap) cbor).values;
-
-        long t = ((CborObject.CborLong) values.get(new CborObject.CborString("t"))).value;
+        CborObject.CborMap map = (CborObject.CborMap) cbor;
+        long t = map.getLong("t");
         Type type = Type.ofVal((int) t);
         if (type == Type.SIMPLE)
             return new SplitFragmenter();
-        int originalFragments = (int)((CborObject.CborLong) values.get(new CborObject.CborString("o"))).value;
-        int allowedFailures = (int)((CborObject.CborLong) values.get(new CborObject.CborString("a"))).value;
+        int originalFragments = (int)(map.getLong("o"));
+        int allowedFailures = (int)(map.getLong("a"));
         return new ErasureFragmenter(originalFragments, allowedFailures);
     }
 

--- a/src/peergos/shared/user/fs/NamedAbsoluteCapability.java
+++ b/src/peergos/shared/user/fs/NamedAbsoluteCapability.java
@@ -4,7 +4,6 @@ import peergos.shared.cbor.*;
 import peergos.shared.inode.*;
 
 import java.util.*;
-import java.util.stream.*;
 
 public class NamedAbsoluteCapability implements Cborable {
     public final PathElement name;
@@ -23,12 +22,10 @@ public class NamedAbsoluteCapability implements Cborable {
     @Override
     public CborObject toCbor() {
         CborObject.CborMap cbor = cap.toCbor(); // This is to ensure binary compatibility for old code with new data
-        Map<String, CborObject> values = cbor.values.entrySet().stream()
-                .collect(Collectors.toMap(e -> ((CborObject.CborString) e.getKey()).value, e -> (CborObject) e.getValue()));
-        Cborable existing = values.put("n", new CborObject.CborString(name.name));
-        if (existing != null)
+        if (cbor.containsKey("n"))
             throw new IllegalStateException("Incompatible cbor");
-        return CborObject.CborMap.build(values);
+        cbor.put("n", new CborObject.CborString(name.name));
+        return cbor;
     }
 
     public static NamedAbsoluteCapability fromCbor(Cborable cbor) {

--- a/src/peergos/shared/user/fs/NamedRelativeCapability.java
+++ b/src/peergos/shared/user/fs/NamedRelativeCapability.java
@@ -3,9 +3,6 @@ package peergos.shared.user.fs;
 import peergos.shared.cbor.*;
 import peergos.shared.inode.*;
 
-import java.util.*;
-import java.util.stream.*;
-
 public class NamedRelativeCapability implements Cborable {
     public final PathElement name;
     public final RelativeCapability cap;
@@ -27,12 +24,10 @@ public class NamedRelativeCapability implements Cborable {
     @Override
     public CborObject toCbor() {
         CborObject.CborMap cbor = cap.toCbor(); // This is to ensure binary compatibility for old code with new data
-        Map<String, CborObject> values = cbor.values.entrySet().stream()
-                .collect(Collectors.toMap(e -> ((CborObject.CborString) e.getKey()).value, e -> (CborObject) e.getValue()));
-        Cborable existing = values.put("n", new CborObject.CborString(name.name));
-        if (existing != null)
+        if (cbor.containsKey("n"))
             throw new IllegalStateException("Incompatible cbor");
-        return CborObject.CborMap.build(values);
+        cbor.put("n", new CborObject.CborString(name.name));
+        return cbor;
     }
 
     public static NamedRelativeCapability fromCbor(Cborable cbor) {

--- a/src/peergos/shared/user/fs/RelativeCapability.java
+++ b/src/peergos/shared/user/fs/RelativeCapability.java
@@ -75,7 +75,7 @@ public class RelativeCapability implements Cborable {
 
     @Override
     public CborObject.CborMap toCbor() {
-        Map<String, CborObject> cbor = new TreeMap<>();
+        Map<String, Cborable> cbor = new TreeMap<>();
         writer.ifPresent(w -> cbor.put("w", w.toCbor()));
         cbor.put("m", new CborObject.CborByteArray(mapKey));
         cbor.put("k", rBaseKey.toCbor());

--- a/src/peergos/shared/user/fs/SplitFragmenter.java
+++ b/src/peergos/shared/user/fs/SplitFragmenter.java
@@ -40,7 +40,7 @@ public class SplitFragmenter implements Fragmenter {
 
     @Override
     public CborObject toCbor() {
-        Map<String, CborObject> res = new HashMap<>();
+        Map<String, Cborable> res = new HashMap<>();
         res.put("t", new CborObject.CborLong(Fragmenter.Type.SIMPLE.val));
         return CborObject.CborMap.build(res);
     }

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -223,7 +223,7 @@ public class CryptreeNode implements Cborable {
             if (cborList.isEmpty())
                 return empty();
             CborObject.CborMap firstMap = (CborObject.CborMap) cborList.get(0);
-            if (firstMap.values.containsKey(new CborObject.CborString("n")))
+            if (firstMap.containsKey("n"))
                 return new ChildrenLinks(Either.b(cborList
                         .stream()
                         .map(NamedRelativeCapability::fromCbor)


### PR DESCRIPTION
This PR enforces a that IPLD dag-cbor maps always have String keys 

At the same time I cleaned up the cbor map api and privatised its members, removing most of the boiler plate from serialization code.

The only two changes in actual serialized bytes are the cached state files of RamUsageStore and MirrorCoreNode, which can simply be deleted. 