### PR TITLE
Implement server migration

### DIFF
--- a/src/peergos/server/AggregatedMetrics.java
+++ b/src/peergos/server/AggregatedMetrics.java
@@ -38,6 +38,7 @@ public class AggregatedMetrics {
     public static final Counter GET_PUBLIC_KEY  = build("core_node_get_public_key", "Total get-public-key calls.");
     public static final Counter GET_PUBLIC_KEY_CHAIN  = build("core_node_get_chain", "Total get-public-key-chain calls.");
     public static final Counter UPDATE_PUBLIC_KEY_CHAIN  = build("core_node_update_chain", "Total getupdate-public-key-chain calls.");
+    public static final Counter MIGRATE_USER  = build("core_node_migrate_user", "Total migrate-user calls.");
 
     public static final Histogram IPFS_PRE_GC_DURATION = Histogram.build()
             .name("ipfs_pre_gc")

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -256,11 +256,12 @@ public class Builder {
     }
 
     public static CoreNode buildCorenode(Args a,
-                                          DeletableContentAddressedStorage localStorage,
-                                          TransactionStore transactions,
-                                          JdbcIpnsAndSocial rawPointers,
-                                          MutablePointers localPointers,
-                                          MutablePointersProxy proxingMutable) {
+                                         DeletableContentAddressedStorage localStorage,
+                                         TransactionStore transactions,
+                                         JdbcIpnsAndSocial rawPointers,
+                                         MutablePointers localPointers,
+                                         MutablePointersProxy proxingMutable,
+                                         Hasher hasher) {
         Multihash nodeId = localStorage.id().join();
         PublicKeyHash peergosId = PublicKeyHash.fromString(a.getArg("peergos.identity.hash"));
         Multihash pkiServerId = getPkiServerId(a);
@@ -270,7 +271,7 @@ public class Builder {
                 buildPkiCorenode(new PinningMutablePointers(localPointers, localStorage), localStorage, a) :
                 new MirrorCoreNode(new HTTPCoreNode(buildP2pHttpProxy(a), pkiServerId), proxingMutable, localStorage,
                         rawPointers, transactions, peergosId,
-                        a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"));
+                        a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"), hasher);
     }
 
     public static JdbcIpnsAndSocial buildRawPointers(Args a, Supplier<Connection> dbConnectionPool) {

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -262,6 +262,7 @@ public class Builder {
                                          MutablePointers localPointers,
                                          MutablePointersProxy proxingMutable,
                                          JdbcIpnsAndSocial localSocial,
+                                         UsageStore usageStore,
                                          Hasher hasher) {
         Multihash nodeId = localStorage.id().join();
         PublicKeyHash peergosId = PublicKeyHash.fromString(a.getArg("peergos.identity.hash"));
@@ -271,7 +272,7 @@ public class Builder {
         return isPkiNode ?
                 buildPkiCorenode(new PinningMutablePointers(localPointers, localStorage), localStorage, a) :
                 new MirrorCoreNode(new HTTPCoreNode(buildP2pHttpProxy(a), pkiServerId), proxingMutable, localStorage,
-                        rawPointers, transactions, localSocial, peergosId,
+                        rawPointers, transactions, localSocial, usageStore, peergosId,
                         a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"), hasher);
     }
 

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -261,6 +261,7 @@ public class Builder {
                                          JdbcIpnsAndSocial rawPointers,
                                          MutablePointers localPointers,
                                          MutablePointersProxy proxingMutable,
+                                         JdbcIpnsAndSocial localSocial,
                                          Hasher hasher) {
         Multihash nodeId = localStorage.id().join();
         PublicKeyHash peergosId = PublicKeyHash.fromString(a.getArg("peergos.identity.hash"));
@@ -270,7 +271,7 @@ public class Builder {
         return isPkiNode ?
                 buildPkiCorenode(new PinningMutablePointers(localPointers, localStorage), localStorage, a) :
                 new MirrorCoreNode(new HTTPCoreNode(buildP2pHttpProxy(a), pkiServerId), proxingMutable, localStorage,
-                        rawPointers, transactions, peergosId,
+                        rawPointers, transactions, localSocial, peergosId,
                         a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"), hasher);
     }
 

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -668,19 +668,14 @@ public class Main extends Builder {
             Supplier<Connection> dbConnectionPool = getDBConnector(a, "transactions-sql-file");
             TransactionStore transactions = buildTransactionStore(a, dbConnectionPool);
             DeletableContentAddressedStorage localStorage = buildLocalStorage(a, transactions);
-            JdbcIpnsAndSocial rawPointers = buildRawPointers(a,
-                    getDBConnector(a, "mutable-pointers-file", dbConnectionPool));
 
             QuotaAdmin userQuotas = buildSpaceQuotas(a, localStorage, network.coreNode,
                     getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                     getDBConnector(a, "quotas-sql-file", dbConnectionPool));
 
-            Supplier<Connection> socialDatabase = getDBConnector(a, "social-sql-file", dbConnectionPool);
-            JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(socialDatabase, getSqlCommands(a));
-
             UserContext user = UserContext.signIn(username, password, network, crypto).join();
 
-            Migrate.migrateToLocal(user, transactions, localStorage, rawPointers, rawSocial, userQuotas, crypto, network);
+            Migrate.migrateToLocal(user, localStorage, userQuotas, network);
             return true;
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -439,8 +439,10 @@ public class Main extends Builder {
 
             Supplier<Connection> usageDb = getDBConnector(a, "space-usage-sql-file", dbConnectionPool);
             UsageStore usageStore = new JdbcUsageStore(usageDb, sqlCommands);
+            JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file"), sqlCommands);
 
-            CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable, hasher);
+            CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
+                    rawSocial, hasher);
 
             QuotaAdmin userQuotas = buildSpaceQuotas(a, localStorage, core,
                     getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
@@ -466,9 +468,6 @@ public class Main extends Builder {
 
             SocialNetworkProxy httpSocial = new HttpSocialNetwork(p2pHttpProxy, p2pHttpProxy);
 
-            Supplier<Connection> socialDatabase = getDBConnector(a, "social-sql-file", dbConnectionPool);
-
-            JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(socialDatabase, sqlCommands);
             SocialNetwork local = UserRepository.build(p2pDht, rawSocial);
             SocialNetwork p2pSocial = new ProxyingSocialNetwork(nodeId, core, local, httpSocial);
 

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -510,7 +510,7 @@ public class Main extends Builder {
                 new Thread(() -> {
                     while (true) {
                         try {
-                            Mirror.mirrorNode(nodeToMirrorId, localApi, rawPointers, localStorage);
+                            Mirror.mirrorNode(nodeToMirrorId, localApi, rawPointers, transactions, localStorage);
                             try {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}
@@ -528,7 +528,7 @@ public class Main extends Builder {
                 new Thread(() -> {
                     while (true) {
                         try {
-                            Mirror.mirrorUser(a.getArg("mirror.username"), localApi, rawPointers, localStorage);
+                            Mirror.mirrorUser(a.getArg("mirror.username"), localApi, rawPointers, transactions, localStorage);
                             try {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}
@@ -674,7 +674,7 @@ public class Main extends Builder {
 
             UserContext user = UserContext.signIn(username, password, network, crypto).join();
 
-            Migrate.migrateToLocal(user, localStorage, rawPointers, rawSocial, userQuotas, crypto, network);
+            Migrate.migrateToLocal(user, transactions, localStorage, rawPointers, rawSocial, userQuotas, crypto, network);
             return true;
         } catch (Exception ex) {
             throw new RuntimeException(ex);

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -443,7 +443,7 @@ public class Main extends Builder {
             HttpSpaceUsage httpSpaceUsage = new HttpSpaceUsage(p2pHttpProxy, p2pHttpProxy);
 
             CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
-                    rawSocial, hasher);
+                    rawSocial, usageStore, crypto.hasher);
 
             QuotaAdmin userQuotas = buildSpaceQuotas(a, localStorage, core,
                     getDBConnector(a, "space-requests-sql-file", dbConnectionPool),

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -510,7 +510,7 @@ public class Main extends Builder {
                 new Thread(() -> {
                     while (true) {
                         try {
-                            Mirror.mirrorNode(nodeToMirrorId, localApi, rawPointers, transactions, localStorage);
+                            Mirror.mirrorNode(nodeToMirrorId, core, p2mMutable, localStorage, rawPointers, transactions, localStorage, hasher);
                             try {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}
@@ -524,11 +524,11 @@ public class Main extends Builder {
                 }).start();
             }
             if (a.hasArg("mirror.username")) {
-                NetworkAccess localApi = Builder.buildLocalJavaNetworkAccess(webPort).join();
                 new Thread(() -> {
                     while (true) {
                         try {
-                            Mirror.mirrorUser(a.getArg("mirror.username"), localApi, rawPointers, transactions, localStorage);
+                            Mirror.mirrorUser(a.getArg("mirror.username"), core, p2mMutable, localStorage,
+                                    rawPointers, transactions, localStorage, hasher);
                             try {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -32,6 +32,7 @@ import java.io.*;
 import java.net.*;
 import java.nio.file.*;
 import java.sql.*;
+import java.time.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.Collectors;
@@ -216,7 +217,8 @@ public class Main extends Builder {
 
             // sign up peergos user
             SecretGenerationAlgorithm algorithm = SecretGenerationAlgorithm.getDefaultWithoutExtraSalt();
-            UserContext context = UserContext.signUpGeneral(pkiUsername, password, "", network, crypto, algorithm, x -> {}).get();
+            LocalDate expiry = LocalDate.now().plusMonths(2);
+            UserContext context = UserContext.signUpGeneral(pkiUsername, password, "", expiry, network, crypto, algorithm, x -> {}).get();
             Optional<PublicKeyHash> existingPkiKey = context.getNamedKey("pki").get();
             if (!existingPkiKey.isPresent() || existingPkiKey.get().equals(pkiPublicHash)) {
                 SigningPrivateKeyAndPublicHash pkiKeyPair = new SigningPrivateKeyAndPublicHash(pkiPublicHash, pkiSecret);

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -453,7 +453,7 @@ public class Main extends Builder {
 
             Supplier<Connection> usageDb = getDBConnector(a, "space-usage-sql-file", dbConnectionPool);
             UsageStore usageStore = new JdbcUsageStore(usageDb, sqlCommands);
-            JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file"), sqlCommands);
+            JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file", dbConnectionPool), sqlCommands);
             HttpSpaceUsage httpSpaceUsage = new HttpSpaceUsage(p2pHttpProxy, p2pHttpProxy);
 
             CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -436,7 +436,7 @@ public class Main extends Builder {
             MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
             MutablePointersProxy proxingMutable = new HttpMutablePointers(p2pHttpProxy, pkiServerNodeId);
 
-            CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable);
+            CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable, crypto.hasher);
 
             QuotaAdmin userQuotas = buildSpaceQuotas(a, localStorage, core,
                     getDBConnector(a, "space-requests-sql-file", dbConnectionPool),

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -510,7 +510,7 @@ public class Main extends Builder {
                 new Thread(() -> {
                     while (true) {
                         try {
-                            Mirror.mirrorNode(nodeToMirrorId, core, p2mMutable, localStorage, rawPointers, transactions, localStorage, hasher);
+                            Mirror.mirrorNode(nodeToMirrorId, core, p2mMutable, localStorage, rawPointers, transactions, hasher);
                             try {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}
@@ -528,7 +528,7 @@ public class Main extends Builder {
                     while (true) {
                         try {
                             Mirror.mirrorUser(a.getArg("mirror.username"), core, p2mMutable, localStorage,
-                                    rawPointers, transactions, localStorage, hasher);
+                                    rawPointers, transactions, hasher);
                             try {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -35,11 +35,6 @@ public class Migrate {
             if (userQuotas.getQuota(username) < localQuota)
                 throw new IllegalStateException("Not enough space quota to migrate user!");
 
-            // Mirror all the data to local
-            Mirror.mirrorUser(username, network.coreNode, network.mutable, localStorage, rawPointers, transactions,
-                    crypto.hasher);
-            Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, network.coreNode, network.mutable,
-                    localStorage, rawPointers, transactions, crypto.hasher);
 
             // Copy pending follow requests to local server
             for (BlindFollowRequest req : pending) {

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -36,10 +36,10 @@ public class Migrate {
                 throw new IllegalStateException("Not enough space quota to migrate user!");
 
             // Mirror all the data to local
-            Mirror.mirrorUser(username, network.coreNode, network.mutable, network.dhtClient, rawPointers, transactions,
-                    localStorage, crypto.hasher);
+            Mirror.mirrorUser(username, network.coreNode, network.mutable, localStorage, rawPointers, transactions,
+                    crypto.hasher);
             Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, network.coreNode, network.mutable,
-                    network.dhtClient, rawPointers, transactions, localStorage, crypto.hasher);
+                    localStorage, rawPointers, transactions, crypto.hasher);
 
             // Copy pending follow requests to local server
             for (BlindFollowRequest req : pending) {

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -1,0 +1,106 @@
+package peergos.server;
+
+import peergos.server.corenode.*;
+import peergos.server.storage.*;
+import peergos.server.storage.admin.*;
+import peergos.shared.*;
+import peergos.shared.cbor.*;
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.social.*;
+import peergos.shared.user.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.stream.*;
+
+public class Migrate {
+
+    public static boolean migrateToLocal(String username,
+                                         List<UserPublicKeyLink> updatedChain,
+                                         long localQuota,
+                                         List<BlindFollowRequest> pending,
+                                         DeletableContentAddressedStorage localStorage,
+                                         JdbcIpnsAndSocial rawPointers,
+                                         JdbcIpnsAndSocial rawSocial,
+                                         QuotaAdmin userQuotas,
+                                         Crypto crypto,
+                                         NetworkAccess network) {
+        try {
+            PublicKeyHash owner = updatedChain.get(updatedChain.size() - 1).owner;
+            // Ensure user has enough local space quota
+            if (userQuotas.getQuota(username) < localQuota)
+                throw new IllegalStateException("Not enough space quota to migrate user!");
+
+            // Mirror all the data to local
+            Mirror.mirrorUser(username, network, rawPointers, localStorage);
+            Mirror.mirrorUser(username, network, rawPointers, localStorage);
+
+            // Copy pending follow requests to local server
+            for (BlindFollowRequest req : pending) {
+                // write directly to local social database to avoid being redirected to user's current node
+                rawSocial.addFollowRequest(owner, req.serialize()).join();
+            }
+
+            // Update pki data to announce this node as user's storage node
+            // This will signal the world, including the previous storage node to redirect writes here
+            // and start accepting writes (and follow requests) on this server for this user
+            byte[] data = new CborObject.CborList(updatedChain).serialize();
+            ProofOfWork work = crypto.hasher.generateProofOfWork(ProofOfWork.MIN_DIFFICULTY, data).join();
+            Optional<RequiredDifficulty> retry = network.coreNode.updateChain(username, updatedChain, work).join();
+            if (retry.isPresent())
+                throw new IllegalStateException("Unable to update storage node in PKI during migration!");
+
+            // Enforce redirecting writes from old server to this one and commit any diff since mirroring
+            Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, network.coreNode,
+                    network.mutable, network.dhtClient, crypto.hasher).join();
+            Map<PublicKeyHash, byte[]> pointerTargets = new HashMap<>();
+            for (PublicKeyHash key : ownedKeys) {
+                Optional<byte[]> localPointer = rawPointers.getPointer(key).join();
+                if (localPointer.isPresent())
+                    pointerTargets.put(key, localPointer.get());
+            }
+
+            // todo send snapshot to previous storage node and commit diff returned
+
+            return true;
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /** Privileged version of migrate that requires the user's keys, for running locally by the user
+     *
+     * @param user
+     * @param localStorage
+     * @param rawPointers
+     * @param rawSocial
+     * @param userQuotas
+     * @param crypto
+     * @param network
+     * @return
+     */
+    public static boolean migrateToLocal(UserContext user,
+                                         DeletableContentAddressedStorage localStorage,
+                                         JdbcIpnsAndSocial rawPointers,
+                                         JdbcIpnsAndSocial rawSocial,
+                                         QuotaAdmin userQuotas,
+                                         Crypto crypto,
+                                         NetworkAccess network) {
+        List<UserPublicKeyLink> existing = network.coreNode.getChain(user.username).join();
+        UserPublicKeyLink last = existing.get(existing.size() - 1);
+        UserPublicKeyLink.Claim newClaim = UserPublicKeyLink.Claim.build(user.username, user.signer.secret,
+                LocalDate.now().plusMonths(2), Arrays.asList(localStorage.id().join()));
+        UserPublicKeyLink updatedLast = last.withClaim(newClaim);
+        List<UserPublicKeyLink> updatedChain = Stream.concat(
+                existing.stream().limit(existing.size() - 1),
+                Stream.of(updatedLast))
+                .collect(Collectors.toList());
+
+        long quota = user.getQuota().join();
+        List<BlindFollowRequest> pending = user.getFollowRequests().join();
+        return migrateToLocal(user.username, updatedChain, quota, pending, localStorage, rawPointers,
+                rawSocial, userQuotas, crypto, network);
+    }
+}

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -1,7 +1,6 @@
 package peergos.server;
 
 import peergos.server.storage.*;
-import peergos.server.storage.admin.*;
 import peergos.shared.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.asymmetric.*;

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -1,14 +1,11 @@
 package peergos.server;
 
-import peergos.server.corenode.*;
 import peergos.server.storage.*;
 import peergos.server.storage.admin.*;
 import peergos.shared.*;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.asymmetric.*;
-import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
-import peergos.shared.social.*;
 import peergos.shared.user.*;
 
 import java.time.*;
@@ -21,34 +18,14 @@ public class Migrate {
                                          List<UserPublicKeyLink> updatedChain,
                                          Multihash currentStorageNodeId,
                                          long localQuota,
-                                         List<BlindFollowRequest> pending,
-                                         TransactionStore transactions,
-                                         DeletableContentAddressedStorage localStorage,
-                                         JdbcIpnsAndSocial rawPointers,
-                                         JdbcIpnsAndSocial rawSocial,
                                          QuotaAdmin userQuotas,
-                                         Crypto crypto,
                                          NetworkAccess network) {
         try {
-            PublicKeyHash owner = updatedChain.get(updatedChain.size() - 1).owner;
             // Ensure user has enough local space quota
             if (userQuotas.getQuota(username) < localQuota)
                 throw new IllegalStateException("Not enough space quota to migrate user!");
 
-
-            // Copy pending follow requests to local server
-            for (BlindFollowRequest req : pending) {
-                // write directly to local social database to avoid being redirected to user's current node
-                rawSocial.addFollowRequest(owner, req.serialize()).join();
-            }
-
-            // Update pki data to announce this node as user's storage node
-            // This will signal the world to redirect writes here
-            // and start accepting writes (and follow requests) on this server for this user
-            // This is done via the original storage node, which then also starts redirecting writes here
-            UserSnapshot updated = network.coreNode.migrateUser(username, updatedChain, currentStorageNodeId).join();
-            // todo commit any diff
-
+            network.coreNode.migrateUser(username, updatedChain, currentStorageNodeId).join();
             return true;
         } catch (Exception ex) {
             throw new RuntimeException(ex);
@@ -59,29 +36,20 @@ public class Migrate {
      *
      * @param user
      * @param localStorage
-     * @param rawPointers
-     * @param rawSocial
      * @param userQuotas
-     * @param crypto
      * @param network
      * @return
      */
     public static boolean migrateToLocal(UserContext user,
-                                         TransactionStore transactions,
                                          DeletableContentAddressedStorage localStorage,
-                                         JdbcIpnsAndSocial rawPointers,
-                                         JdbcIpnsAndSocial rawSocial,
                                          QuotaAdmin userQuotas,
-                                         Crypto crypto,
                                          NetworkAccess network) {
         List<UserPublicKeyLink> existing = network.coreNode.getChain(user.username).join();
         List<UserPublicKeyLink> updatedChain = buildMigrationChain(existing, localStorage.id().join(), user.signer.secret);
 
         long quota = user.getQuota().join();
-        List<BlindFollowRequest> pending = user.getFollowRequests().join();
         Multihash currentStorageNodeId = existing.get(existing.size() - 1).claim.storageProviders.get(0);
-        return migrateToLocal(user.username, updatedChain, currentStorageNodeId, quota, pending,
-                transactions, localStorage, rawPointers, rawSocial, userQuotas, crypto, network);
+        return migrateToLocal(user.username, updatedChain, currentStorageNodeId, quota, userQuotas, network);
     }
 
     public static List<UserPublicKeyLink> buildMigrationChain(List<UserPublicKeyLink> existing,

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -14,42 +14,22 @@ import java.util.stream.*;
 
 public class Migrate {
 
-    public static boolean migrateToLocal(String username,
-                                         List<UserPublicKeyLink> updatedChain,
-                                         Multihash currentStorageNodeId,
-                                         long localQuota,
-                                         QuotaAdmin userQuotas,
-                                         NetworkAccess network) {
-        try {
-            // Ensure user has enough local space quota
-            if (userQuotas.getQuota(username) < localQuota)
-                throw new IllegalStateException("Not enough space quota to migrate user!");
-
-            network.coreNode.migrateUser(username, updatedChain, currentStorageNodeId).join();
-            return true;
-        } catch (Exception ex) {
-            throw new RuntimeException(ex);
-        }
-    }
-
     /** Privileged version of migrate that requires the user's keys, for running locally by the user
      *
      * @param user
      * @param localStorage
-     * @param userQuotas
      * @param network
      * @return
      */
     public static boolean migrateToLocal(UserContext user,
                                          DeletableContentAddressedStorage localStorage,
-                                         QuotaAdmin userQuotas,
                                          NetworkAccess network) {
         List<UserPublicKeyLink> existing = network.coreNode.getChain(user.username).join();
         List<UserPublicKeyLink> updatedChain = buildMigrationChain(existing, localStorage.id().join(), user.signer.secret);
 
-        long quota = user.getQuota().join();
         Multihash currentStorageNodeId = existing.get(existing.size() - 1).claim.storageProviders.get(0);
-        return migrateToLocal(user.username, updatedChain, currentStorageNodeId, quota, userQuotas, network);
+        network.coreNode.migrateUser(user.username, updatedChain, currentStorageNodeId).join();
+        return true;
     }
 
     public static List<UserPublicKeyLink> buildMigrationChain(List<UserPublicKeyLink> existing,

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -36,7 +36,7 @@ public class Migrate {
                                                               SecretSigningKey signer) {
         UserPublicKeyLink last = existing.get(existing.size() - 1);
         UserPublicKeyLink.Claim newClaim = UserPublicKeyLink.Claim.build(last.claim.username, signer,
-                LocalDate.now().plusMonths(2), Arrays.asList(newStorageId));
+                last.claim.expiry.plusDays(1), Arrays.asList(newStorageId));
         UserPublicKeyLink updatedLast = last.withClaim(newClaim);
         return Stream.concat(
                 existing.stream().limit(existing.size() - 1),

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -36,8 +36,10 @@ public class Migrate {
                 throw new IllegalStateException("Not enough space quota to migrate user!");
 
             // Mirror all the data to local
-            Mirror.mirrorUser(username, network, rawPointers, transactions, localStorage);
-            Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, network, rawPointers, transactions, localStorage);
+            Mirror.mirrorUser(username, network.coreNode, network.mutable, network.dhtClient, rawPointers, transactions,
+                    localStorage, crypto.hasher);
+            Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, network.coreNode, network.mutable,
+                    network.dhtClient, rawPointers, transactions, localStorage, crypto.hasher);
 
             // Copy pending follow requests to local server
             for (BlindFollowRequest req : pending) {

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -20,7 +20,7 @@ public class Migrate {
      * @param network
      * @return
      */
-    public static boolean migrateToLocal(UserContext user,
+    public static void migrateToLocal(UserContext user,
                                          DeletableContentAddressedStorage localStorage,
                                          NetworkAccess network) {
         List<UserPublicKeyLink> existing = network.coreNode.getChain(user.username).join();
@@ -28,7 +28,6 @@ public class Migrate {
 
         Multihash currentStorageNodeId = existing.get(existing.size() - 1).claim.storageProviders.get(0);
         network.coreNode.migrateUser(user.username, updatedChain, currentStorageNodeId).join();
-        return true;
     }
 
     public static List<UserPublicKeyLink> buildMigrationChain(List<UserPublicKeyLink> existing,

--- a/src/peergos/server/Migrate.java
+++ b/src/peergos/server/Migrate.java
@@ -13,23 +13,6 @@ import java.util.stream.*;
 
 public class Migrate {
 
-    /** Privileged version of migrate that requires the user's keys, for running locally by the user
-     *
-     * @param user
-     * @param localStorage
-     * @param network
-     * @return
-     */
-    public static void migrateToLocal(UserContext user,
-                                         DeletableContentAddressedStorage localStorage,
-                                         NetworkAccess network) {
-        List<UserPublicKeyLink> existing = network.coreNode.getChain(user.username).join();
-        List<UserPublicKeyLink> updatedChain = buildMigrationChain(existing, localStorage.id().join(), user.signer.secret);
-
-        Multihash currentStorageNodeId = existing.get(existing.size() - 1).claim.storageProviders.get(0);
-        network.coreNode.migrateUser(user.username, updatedChain, currentStorageNodeId).join();
-    }
-
     public static List<UserPublicKeyLink> buildMigrationChain(List<UserPublicKeyLink> existing,
                                                               Multihash newStorageId,
                                                               SecretSigningKey signer) {

--- a/src/peergos/server/Mirror.java
+++ b/src/peergos/server/Mirror.java
@@ -95,9 +95,19 @@ public class Mirror {
             Logging.LOG().log(Level.WARNING, "Skipping unretrievable mutable pointer for: " + writer);
             return updated;
         }
+
+        mirrorMerkleTree(owner, writer, updated.get(), storage, targetPointers, transactions);
+        return updated;
+    }
+
+    public static void mirrorMerkleTree(PublicKeyHash owner,
+                                        PublicKeyHash writer,
+                                        byte[] newPointer,
+                                        DeletableContentAddressedStorage storage,
+                                        JdbcIpnsAndSocial targetPointers,
+                                        TransactionStore transactions) {
         Optional<byte[]> existing = targetPointers.getPointer(writer).join();
         // First pin the new root, then commit updated pointer
-        byte[] newPointer = updated.get();
         MaybeMultihash existingTarget = existing.isPresent() ?
                 MutablePointers.parsePointerTarget(existing.get(), writer, storage).join() :
                 MaybeMultihash.empty();
@@ -110,6 +120,5 @@ public class Mirror {
         } finally {
             transactions.closeTransaction(owner, tid);
         }
-        return updated;
     }
 }

--- a/src/peergos/server/Mirror.java
+++ b/src/peergos/server/Mirror.java
@@ -62,11 +62,11 @@ public class Mirror {
         Optional<PublicKeyHash> identity = core.getPublicKeyHash(username).join();
         if (! identity.isPresent())
             return Collections.emptyMap();
+        PublicKeyHash owner = identity.get();
         Map<PublicKeyHash, byte[]> versions = new HashMap<>();
-        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(username, core, p2pPointers,
-                storage, hasher).join();
+        Set<PublicKeyHash> ownedKeys = WriterData.getOwnedKeysRecursive(owner, owner, p2pPointers, storage, hasher).join();
         for (PublicKeyHash ownedKey : ownedKeys) {
-            Optional<byte[]> version = mirrorMutableSubspace(identity.get(), ownedKey, p2pPointers, storage,
+            Optional<byte[]> version = mirrorMutableSubspace(owner, ownedKey, p2pPointers, storage,
                     targetPointers, transactions);
             if (version.isPresent())
                 versions.put(ownedKey, version.get());

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -2,6 +2,7 @@ package peergos.server;
 
 import peergos.server.corenode.*;
 import peergos.server.messages.*;
+import peergos.server.space.*;
 import peergos.server.sql.*;
 import peergos.server.storage.*;
 import peergos.server.storage.admin.*;

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -101,7 +101,8 @@ public class ServerMessages extends Builder {
         JdbcIpnsAndSocial rawPointers = buildRawPointers(a, getDBConnector(a, "mutable-pointers-file", dbConnectionPool));
         MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
         MutablePointersProxy proxingMutable = new HttpMutablePointers(buildP2pHttpProxy(a), getPkiServerId(a));
-        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable, Main.initCrypto().hasher);
+        JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file"), getSqlCommands(a));
+        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable, rawSocial, Main.initCrypto().hasher);
         return buildSpaceQuotas(a, localStorage, core,
                 getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                 getDBConnector(a, "quotas-sql-file", dbConnectionPool));

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -2,7 +2,6 @@ package peergos.server;
 
 import peergos.server.corenode.*;
 import peergos.server.messages.*;
-import peergos.server.space.*;
 import peergos.server.sql.*;
 import peergos.server.storage.*;
 import peergos.server.storage.admin.*;

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -100,7 +100,7 @@ public class ServerMessages extends Builder {
         JdbcIpnsAndSocial rawPointers = buildRawPointers(a, getDBConnector(a, "mutable-pointers-file", dbConnectionPool));
         MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
         MutablePointersProxy proxingMutable = new HttpMutablePointers(buildP2pHttpProxy(a), getPkiServerId(a));
-        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable);
+        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable, Main.initCrypto().hasher);
         return buildSpaceQuotas(a, localStorage, core,
                 getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                 getDBConnector(a, "quotas-sql-file", dbConnectionPool));

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -2,6 +2,7 @@ package peergos.server;
 
 import peergos.server.corenode.*;
 import peergos.server.messages.*;
+import peergos.server.space.*;
 import peergos.server.sql.*;
 import peergos.server.storage.*;
 import peergos.server.storage.admin.*;
@@ -101,7 +102,9 @@ public class ServerMessages extends Builder {
         MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
         MutablePointersProxy proxingMutable = new HttpMutablePointers(buildP2pHttpProxy(a), getPkiServerId(a));
         JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file"), getSqlCommands(a));
-        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable, rawSocial, Main.initCrypto().hasher);
+        UsageStore usageStore = new JdbcUsageStore(getDBConnector(a, "space-usage-sql-file"), getSqlCommands(a));
+        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
+                rawSocial, usageStore, Main.initCrypto().hasher);
         return buildSpaceQuotas(a, localStorage, core,
                 getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                 getDBConnector(a, "quotas-sql-file", dbConnectionPool));

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -101,8 +101,8 @@ public class ServerMessages extends Builder {
         JdbcIpnsAndSocial rawPointers = buildRawPointers(a, getDBConnector(a, "mutable-pointers-file", dbConnectionPool));
         MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
         MutablePointersProxy proxingMutable = new HttpMutablePointers(buildP2pHttpProxy(a), getPkiServerId(a));
-        JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file"), getSqlCommands(a));
-        UsageStore usageStore = new JdbcUsageStore(getDBConnector(a, "space-usage-sql-file"), getSqlCommands(a));
+        JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file", dbConnectionPool), getSqlCommands(a));
+        UsageStore usageStore = new JdbcUsageStore(getDBConnector(a, "space-usage-sql-file", dbConnectionPool), getSqlCommands(a));
         CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
                 rawSocial, usageStore, Main.initCrypto().hasher);
         return buildSpaceQuotas(a, localStorage, core,

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -35,13 +35,19 @@ public class CorenodeEventPropagator implements CoreNode {
         return target.updateChain(username, chain, proof, token)
                 .thenApply(res -> {
                     if (res.isEmpty()) {
-                        CorenodeEvent event = new CorenodeEvent(username, chain.get(chain.size() - 1).owner);
-                        for (Consumer<? super CorenodeEvent> listener : listeners) {
-                            listener.accept(event);
-                        }
+                        processEvent(chain);
                     }
                     return res;
                 });
+    }
+
+    private void processEvent(List<UserPublicKeyLink> chain) {
+        UserPublicKeyLink last = chain.get(chain.size() - 1);
+        CorenodeEvent event = new CorenodeEvent(last.claim.username, last.owner);
+        for (Consumer<? super CorenodeEvent> listener : listeners) {
+            listener.accept(event);
+        }
+
     }
 
     @Override
@@ -63,7 +69,10 @@ public class CorenodeEventPropagator implements CoreNode {
     public CompletableFuture<UserSnapshot> migrateUser(String username,
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId) {
-        return target.migrateUser(username, newChain, currentStorageId);
+        return target.migrateUser(username, newChain, currentStorageId).thenApply(res -> {
+            processEvent(newChain);
+            return res;
+        });
     }
 
     @Override

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -3,6 +3,8 @@ package peergos.server.corenode;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.user.*;
 
 import java.io.*;
 import java.util.*;
@@ -55,6 +57,13 @@ public class CorenodeEventPropagator implements CoreNode {
     @Override
     public CompletableFuture<List<String>> getUsernames(String prefix) {
         return target.getUsernames(prefix);
+    }
+
+    @Override
+    public CompletableFuture<UserSnapshot> migrateUser(String username,
+                                                       List<UserPublicKeyLink> newChain,
+                                                       Multihash currentStorageId) {
+        return target.migrateUser(username, newChain, currentStorageId);
     }
 
     @Override

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -238,6 +238,12 @@ public class IpfsCoreNode implements CoreNode {
     }
 
     @Override
-    public void close() throws IOException {}
+    public CompletableFuture<UserSnapshot> migrateUser(String username,
+                                                       List<UserPublicKeyLink> newChain,
+                                                       Multihash currentStorageId) {
+        throw new IllegalStateException("Migration from pki node unimplemented!");
+    }
 
+    @Override
+    public void close() throws IOException {}
 }

--- a/src/peergos/server/corenode/JdbcIpnsAndSocial.java
+++ b/src/peergos/server/corenode/JdbcIpnsAndSocial.java
@@ -164,6 +164,16 @@ public class JdbcIpnsAndSocial {
         return CompletableFuture.completedFuture(resp.serialize());
     }
 
+    public List<BlindFollowRequest> getAndParseFollowRequests(PublicKeyHash owner) {
+        byte[] reqs = getFollowRequests(owner).join();
+        CborObject cbor = CborObject.fromByteArray(reqs);
+        if (!(cbor instanceof CborObject.CborList))
+            throw new IllegalStateException("Invalid cbor for list of follow requests: " + cbor);
+        return ((CborObject.CborList) cbor).value.stream()
+                .map(BlindFollowRequest::fromCbor)
+                .collect(Collectors.toList());
+    }
+
     public CompletableFuture<Boolean> setPointer(PublicKeyHash writingKey, Optional<byte[]> existingCas, byte[] newCas) {
         if (existingCas.isPresent()) {
             try (Connection conn = getConnection();

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -315,16 +315,20 @@ public class MirrorCoreNode implements CoreNode {
         }
         Multihash migrationTargetNode = newChain.get(newChain.size() - 1).claim.storageProviders.get(0);
         if (migrationTargetNode.equals(ourNodeId)) {
-            // we are copying data to this node, proxy call to their current storage server
+            // We are copying data to this node
+            PublicKeyHash owner = newChain.get(newChain.size() - 1).owner;
+
             // Mirror all the data to local
             Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers, transactions, hasher);
             Map<PublicKeyHash, byte[]> mirrored = Mirror.mirrorUser(username, this, p2pMutable, ipfs,
                     localPointers, transactions, hasher);
+
+            // Proxy call to their current storage server
             UserSnapshot res = writeTarget.migrateUser(username, newChain, currentStorageId).join();
+            // pick up the new pki data locally
             update();
 
             // commit diff since our mirror above
-            PublicKeyHash owner = newChain.get(newChain.size() - 1).owner;
             for (Map.Entry<PublicKeyHash, byte[]> e : res.pointerState.entrySet()) {
                 byte[] existingVal = mirrored.get(e.getKey());
                 if (! Arrays.equals(existingVal, e.getValue())) {

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -298,9 +298,9 @@ public class MirrorCoreNode implements CoreNode {
         if (migrationTargetNode.equals(ourNodeId)) {
             // we are copying data to this node, proxy call to their current storage server
             // Mirror all the data to local
-            Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers, transactions, ipfs, hasher);
+            Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers, transactions, hasher);
             Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers,
-                    transactions, ipfs, hasher);
+                    transactions, hasher);
             UserSnapshot res = writeTarget.migrateUser(username, newChain, currentStorageId).join();
             update();
             return Futures.of(res);

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -310,10 +310,13 @@ public class MirrorCoreNode implements CoreNode {
             // we are copying data to this node, proxy call to their current storage server
             // Mirror all the data to local
             Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers, transactions, hasher);
-            Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers,
-                    transactions, hasher);
+            Map<PublicKeyHash, byte[]> userSnapshot = Mirror.mirrorUser(username, this, p2pMutable, ipfs,
+                    localPointers, transactions, hasher);
             UserSnapshot res = writeTarget.migrateUser(username, newChain, currentStorageId).join();
             update();
+
+            // TODO commit diff and follow requests
+
             return Futures.of(res);
         } else // Proxy call to their target storage server
             return writeTarget.migrateUser(username, newChain, migrationTargetNode);

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -300,6 +300,10 @@ public class MirrorCoreNode implements CoreNode {
     public CompletableFuture<UserSnapshot> migrateUser(String username,
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId) {
+        // check chain validity before proceeding further
+        List<UserPublicKeyLink> existingChain = getChain(username).join();
+        UserPublicKeyLink.merge(existingChain, newChain, ipfs).join();
+
         if (currentStorageId.equals(ourNodeId)) {
             // a user is migrating away from this server
             ProofOfWork work = ProofOfWork.empty();

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -3,7 +3,9 @@ package peergos.server.corenode;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.storage.*;
+import peergos.shared.user.*;
 
 import java.io.*;
 import java.util.*;
@@ -93,6 +95,13 @@ public class NonWriteThroughCoreNode implements CoreNode {
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public CompletableFuture<UserSnapshot> migrateUser(String username,
+                                                       List<UserPublicKeyLink> newChain,
+                                                       Multihash currentStorageId) {
+        throw new IllegalStateException("Unimplemented method!");
     }
 
     @Override

--- a/src/peergos/server/corenode/SignUpFilter.java
+++ b/src/peergos/server/corenode/SignUpFilter.java
@@ -6,6 +6,7 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.util.*;
+import peergos.shared.storage.*;
 import peergos.shared.user.*;
 
 import java.io.*;
@@ -17,11 +18,20 @@ public class SignUpFilter implements CoreNode {
     private final CoreNode target;
     private final QuotaAdmin judge;
     private final Multihash ourNodeId;
+    private final QuotaAdmin quotaStore;
+    private final HttpSpaceUsage space;
 
-    public SignUpFilter(CoreNode target, QuotaAdmin judge, Multihash ourNodeId) {
+
+    public SignUpFilter(CoreNode target,
+                        QuotaAdmin judge,
+                        Multihash ourNodeId,
+                        QuotaAdmin quotaStore,
+                        HttpSpaceUsage space) {
         this.target = target;
         this.judge = judge;
         this.ourNodeId = ourNodeId;
+        this.quotaStore = quotaStore;
+        this.space = space;
     }
 
     @Override
@@ -71,6 +81,13 @@ public class SignUpFilter implements CoreNode {
         if (forUs(newChain)) {
             if (! judge.allowSignupOrUpdate(username, ""))
                 throw new IllegalStateException("This server is not currently accepting new user migrations.");
+            PublicKeyHash owner = newChain.get(newChain.size() - 1).owner;
+
+            // check we have enough local quota to mirror all user's data
+            long currentUsage = space.getUsage(currentStorageId, owner).join();
+            long localQuota = quotaStore.getQuota(username);
+            if (localQuota < currentUsage)
+                throw new IllegalStateException("Not enough space for user to migrate user to this server!");
         }
 
         return target.migrateUser(username, newChain, currentStorageId);

--- a/src/peergos/server/corenode/SignUpFilter.java
+++ b/src/peergos/server/corenode/SignUpFilter.java
@@ -6,6 +6,7 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.util.*;
+import peergos.shared.user.*;
 
 import java.io.*;
 import java.util.*;
@@ -58,6 +59,13 @@ public class SignUpFilter implements CoreNode {
     @Override
     public CompletableFuture<List<String>> getUsernames(String prefix) {
         return target.getUsernames(prefix);
+    }
+
+    @Override
+    public CompletableFuture<UserSnapshot> migrateUser(String username,
+                                                       List<UserPublicKeyLink> newChain,
+                                                       Multihash currentStorageId) {
+        return target.migrateUser(username, newChain, currentStorageId);
     }
 
     @Override

--- a/src/peergos/server/space/JdbcUsageStore.java
+++ b/src/peergos/server/space/JdbcUsageStore.java
@@ -241,7 +241,8 @@ public class JdbcUsageStore implements UsageStore {
              PreparedStatement search = conn.prepareStatement("SELECT u.name FROM users u, writerusage wu WHERE u.id = wu.user_id AND wu.writer_id = ?;")) {
             search.setInt(1, writerId);
             ResultSet resultSet = search.executeQuery();
-            resultSet.next();
+            if (! resultSet.next())
+                throw new IllegalStateException("Unknown writer on this server!");
             return resultSet.getString(1);
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);

--- a/src/peergos/server/space/QuotaCLI.java
+++ b/src/peergos/server/space/QuotaCLI.java
@@ -19,19 +19,6 @@ import java.util.function.*;
 
 public class QuotaCLI extends Builder {
 
-    private static QuotaAdmin buildQuotaStore(Args a) {
-        Supplier<Connection> dbConnectionPool = getDBConnector(a, "transactions-sql-file");
-        TransactionStore transactions = buildTransactionStore(a, dbConnectionPool);
-        DeletableContentAddressedStorage localStorage = buildLocalStorage(a, transactions);
-        JdbcIpnsAndSocial rawPointers = buildRawPointers(a, getDBConnector(a, "mutable-pointers-file", dbConnectionPool));
-        MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
-        MutablePointersProxy proxingMutable = new HttpMutablePointers(buildP2pHttpProxy(a), getPkiServerId(a));
-        CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable);
-        return buildSpaceQuotas(a, localStorage, core,
-                getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
-                getDBConnector(a, "quotas-sql-file", dbConnectionPool));
-    }
-
     private static void printQuota(String name, long quota) {
         System.out.println(name + " " + formatQuota(quota));
     }

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -33,7 +33,8 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
      */
     default CompletableFuture<List<Multihash>> mirror(PublicKeyHash owner,
                                                       Optional<Multihash> existing,
-                                                      Optional<Multihash> updated) {
+                                                      Optional<Multihash> updated,
+                                                      TransactionId tid) {
         if (existing.isEmpty()) {
             if (updated.isEmpty())
                 return Futures.of(Collections.emptyList());

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -14,7 +14,6 @@ import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.util.*;
 
 import java.io.*;
-import java.net.*;
 import java.nio.file.*;
 import java.sql.*;
 import java.time.*;
@@ -168,6 +167,14 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         } finally {
             readTimer.observeDuration();
         }
+    }
+
+    @Override
+    public CompletableFuture<List<Multihash>> mirror(PublicKeyHash owner,
+                                                     Optional<Multihash> existing,
+                                                     Optional<Multihash> updated) {
+        // TODO
+        throw new IllegalStateException("Unimplemented!");
     }
 
     @Override

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -177,6 +177,8 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         if (updated.isEmpty())
             return Futures.of(Collections.emptyList());
         Multihash newRoot = updated.get();
+        if (existing.equals(updated))
+            return Futures.of(Collections.singletonList(newRoot));
         boolean isRaw = (newRoot instanceof Cid) && ((Cid) newRoot).codec == Cid.Codec.Raw;
         Optional<byte[]> newVal = p2pFallback.getRaw(newRoot).join();
         if (newVal.isEmpty())
@@ -188,7 +190,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
             return Futures.of(Collections.singletonList(newRoot));
 
         List<Multihash> newLinks = CborObject.fromByteArray(newBlock).links();
-        List<Multihash> existingLinks = existing.map(h -> get(existing.get()).join())
+        List<Multihash> existingLinks = existing.map(h -> get(h).join())
                 .flatMap(copt -> copt.map(CborObject::links))
                 .orElse(Collections.emptyList());
 

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -163,9 +163,9 @@ public class MultiNodeNetworkTests {
         List<UserPublicKeyLink> existing = user.network.coreNode.getChain(username).join();
         Multihash newStorageNodeId = node2.storage.id().join();
         List<UserPublicKeyLink> newChain = Migrate.buildMigrationChain(existing, newStorageNodeId, user.signer.secret);
-        node2.coreNode.migrateUser(username, newChain, node1.dhtClient.id().join()).join();
-
         UserContext userViaNewServer = ensureSignedUp(username, password, getNode(iNode2), crypto);
+        userViaNewServer.network.coreNode.migrateUser(username, newChain, node1.dhtClient.id().join()).join();
+
         List<UserPublicKeyLink> chain = userViaNewServer.network.coreNode.getChain(username).join();
         Multihash storageNode = chain.get(chain.size() - 1).claim.storageProviders.stream().findFirst().get();
         Assert.assertTrue(storageNode.equals(newStorageNodeId));

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -157,6 +157,7 @@ public class MultiNodeNetworkTests {
         String password = randomString();
         NetworkAccess node1 = getNode(iNode1);
         UserContext user = ensureSignedUp(username, password, node1, crypto);
+        long usageVia1 = user.getSpaceUsage().join();
 
         // migrate to this node
         UserService node2 = getService(iNode2);
@@ -169,6 +170,11 @@ public class MultiNodeNetworkTests {
         List<UserPublicKeyLink> chain = userViaNewServer.network.coreNode.getChain(username).join();
         Multihash storageNode = chain.get(chain.size() - 1).claim.storageProviders.stream().findFirst().get();
         Assert.assertTrue(storageNode.equals(newStorageNodeId));
+
+        // test a fresh login on the new storage node
+        UserContext postMigration = ensureSignedUp(username, password, getNode(iNode2).clear(), crypto);
+        long usageVia2 = postMigration.getSpaceUsage().join();
+        Assert.assertTrue(usageVia2 == usageVia1);
     }
 
     @Test

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -151,8 +151,8 @@ public class MultiNodeNetworkTests {
 
     @Test
     public void migrate() {
-        if (iNode1 == 0)
-            return; // Don't test migration from pki node
+        if (iNode1 == 0 || iNode2 == 0)
+            return; // Don't test migration to/from pki node
         String username = generateUsername(random);
         String password = randomString();
         NetworkAccess node1 = getNode(iNode1);

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -205,7 +205,7 @@ public class MultiNodeNetworkTests {
         try { // check a direct update call with old chain also fails
             ProofOfWork work = crypto.hasher.generateProofOfWork(ProofOfWork.DEFAULT_DIFFICULTY,
                     new CborObject.CborList(existing).serialize()).join();
-            node1.coreNode.updateChain(username, existing, work).join();
+            node1.coreNode.updateChain(username, existing, work, "").join();
             throw new RuntimeException("Shouldn't get here!");
         } catch (CompletionException e) {}
     }

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -200,14 +200,20 @@ public class MultiNodeNetworkTests {
         try {
             node1.coreNode.migrateUser(username, existing, newStorageNodeId).join();
             throw new RuntimeException("Shouldn't get here!");
-        } catch (CompletionException e) {}
+        } catch (CompletionException e) {
+            if (! e.getCause().getMessage().startsWith("Migration+claim+has+earlier+expiry+than+current+one"))
+                throw new RuntimeException(e.getCause());
+        }
 
         try { // check a direct update call with old chain also fails
             ProofOfWork work = crypto.hasher.generateProofOfWork(ProofOfWork.DEFAULT_DIFFICULTY,
                     new CborObject.CborList(existing).serialize()).join();
             node1.coreNode.updateChain(username, existing, work, "").join();
             throw new RuntimeException("Shouldn't get here!");
-        } catch (CompletionException e) {}
+        } catch (CompletionException e) {
+            if (! e.getCause().getMessage().startsWith("New%2Bclaim%2Bchain%2Bexpiry%2Bbefore%2Bexisting"))
+                throw new RuntimeException(e.getCause());
+        }
     }
 
     @Test

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -213,10 +213,9 @@ public abstract class UserTests {
     public void expiredSignin() {
         String username = generateUsername();
         String password = "password";
-        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
-
         // set username claim to an expiry in the past
-        context.renewUsernameClaim(LocalDate.now().minusDays(1)).join();
+        UserContext context = UserContext.signUpGeneral(username, password, "", LocalDate.now().minusDays(1),
+                network, crypto, SecretGenerationAlgorithm.getDefault(crypto.random), t -> {}).join();
 
         LocalDate expiry = context.getUsernameClaimExpiry().join();
         Assert.assertTrue(expiry.isBefore(LocalDate.now()));

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -233,10 +233,11 @@ public abstract class UserTests {
         String password = "password";
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         String newPassword = "G'day mate!";
-        context = context.changePassword(password, newPassword).join();
 
-        // set username claim to an expiry in the past
-        context.renewUsernameClaim(LocalDate.now().minusDays(1)).join();
+        // change password and set username claim to an expiry in the past
+        SecretGenerationAlgorithm alg = context.getKeyGenAlgorithm().join();
+        SecretGenerationAlgorithm newAlg = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random);
+        context = context.changePassword(password, newPassword, alg, newAlg, LocalDate.now().minusDays(1)).join();
 
         LocalDate expiry = context.getUsernameClaimExpiry().join();
         Assert.assertTrue(expiry.isBefore(LocalDate.now()));
@@ -348,7 +349,7 @@ public abstract class UserTests {
         UserContext userContext = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         SecretGenerationAlgorithm algo = userContext.getKeyGenAlgorithm().get();
         ScryptGenerator newAlgo = new ScryptGenerator(19, 8, 1, 96, algo.getExtraSalt());
-        userContext.changePassword(password, password, algo, newAlgo).get();
+        userContext.changePassword(password, password, algo, newAlgo, LocalDate.now().plusMonths(2)).get();
         PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
     }
 

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -2,6 +2,8 @@ package peergos.shared.corenode;
 
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.user.*;
 
 import java.io.*;
 import java.util.*;
@@ -43,6 +45,10 @@ public interface CoreNode {
      * @return All usernames starting with prefix
      */
     CompletableFuture<List<String>> getUsernames(String prefix);
+
+    CompletableFuture<UserSnapshot> migrateUser(String username,
+                                                List<UserPublicKeyLink> newChain,
+                                                Multihash currentStorageId);
 
     /** This is only implemented by caching corenodes
      *

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -149,7 +149,11 @@ public class TofuCoreNode implements CoreNode {
     public CompletableFuture<UserSnapshot> migrateUser(String username,
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId) {
-        return source.migrateUser(username, newChain, currentStorageId);
+        return source.migrateUser(username, newChain, currentStorageId)
+                .thenCompose(res -> source.getChain(username)
+                        .thenCompose(chain -> tofu.updateChain(username, chain, network.dhtClient)
+                                .thenCompose(x -> commit())
+                                .thenApply(x -> res)));
     }
 
     @Override

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -4,6 +4,7 @@ import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
@@ -142,6 +143,13 @@ public class TofuCoreNode implements CoreNode {
     @Override
     public CompletableFuture<List<String>> getUsernames(String prefix) {
         return source.getUsernames(prefix);
+    }
+
+    @Override
+    public CompletableFuture<UserSnapshot> migrateUser(String username,
+                                                       List<UserPublicKeyLink> newChain,
+                                                       Multihash currentStorageId) {
+        return source.migrateUser(username, newChain, currentStorageId);
     }
 
     @Override

--- a/src/peergos/shared/corenode/UserPublicKeyLink.java
+++ b/src/peergos/shared/corenode/UserPublicKeyLink.java
@@ -38,6 +38,10 @@ public class UserPublicKeyLink implements Cborable {
         return keyChangeProof.map(x -> Arrays.copyOfRange(x, 0, x.length));
     }
 
+    public UserPublicKeyLink withClaim(Claim claim) {
+        return new UserPublicKeyLink(owner, claim, keyChangeProof);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/peergos/shared/crypto/ProofOfWork.java
+++ b/src/peergos/shared/crypto/ProofOfWork.java
@@ -61,4 +61,8 @@ public class ProofOfWork implements Cborable {
         }
         return true;
     }
+
+    public static ProofOfWork empty() {
+        return new ProofOfWork(new byte[0], Multihash.Type.sha2_256);
+    }
 }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1567,7 +1567,7 @@ public class UserContext {
                 });
     }
 
-    private CompletableFuture<List<BlindFollowRequest>> getFollowRequests() {
+    public CompletableFuture<List<BlindFollowRequest>> getFollowRequests() {
         byte[] auth = TimeLimitedClient.signNow(signer.secret);
         return network.social.getFollowRequests(signer.publicKeyHash, auth).thenApply(reqs -> {
             CborObject cbor = CborObject.fromByteArray(reqs);

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -693,16 +693,16 @@ public class UserContext {
     public CompletableFuture<UserContext> changePassword(String oldPassword, String newPassword) {
         return getKeyGenAlgorithm().thenCompose(alg -> {
             SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random);
-            return changePassword(oldPassword, newPassword, alg, newAlgorithm);
+            // set claim expiry to two months from now
+            return changePassword(oldPassword, newPassword, alg, newAlgorithm, LocalDate.now().plusMonths(2));
         });
     }
 
     public CompletableFuture<UserContext> changePassword(String oldPassword,
                                                          String newPassword,
                                                          SecretGenerationAlgorithm existingAlgorithm,
-                                                         SecretGenerationAlgorithm newAlgorithm) {
-        // set claim expiry to two months from now
-        LocalDate expiry = LocalDate.now().plusMonths(2);
+                                                         SecretGenerationAlgorithm newAlgorithm,
+                                                         LocalDate expiry) {
         LOG.info("Changing password and setting expiry to: " + expiry);
 
         return UserUtil.generateUser(username, oldPassword, crypto.hasher, crypto.symmetricProvider, crypto.random, crypto.signer, crypto.boxer, existingAlgorithm)

--- a/src/peergos/shared/user/UserSnapshot.java
+++ b/src/peergos/shared/user/UserSnapshot.java
@@ -1,0 +1,49 @@
+package peergos.shared.user;
+
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.social.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+public class UserSnapshot implements Cborable {
+
+    public final Map<PublicKeyHash, byte[]> pointerState;
+    public final List<BlindFollowRequest> pendingFollowReqs;
+
+    public UserSnapshot(Map<PublicKeyHash, byte[]> pointerState, List<BlindFollowRequest> pendingFollowReqs) {
+        this.pointerState = pointerState;
+        this.pendingFollowReqs = pendingFollowReqs;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("f", new CborObject.CborList(pendingFollowReqs));
+        TreeMap<CborObject, Cborable> pointerMap = pointerState.entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    e -> e.getKey().toCbor(),
+                    e -> new CborObject.CborByteArray(e.getValue()),
+                    (a,b) -> a,
+                    TreeMap::new
+                ));
+        state.put("p", new CborObject.CborList(pointerMap));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static UserSnapshot fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for FileProperties! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        List<BlindFollowRequest> pendingFollowReqs = m.getList("f", BlindFollowRequest::fromCbor);
+        Map<PublicKeyHash, byte[]> pointerState = ((CborObject.CborList)m.get("p"))
+                .getMap(PublicKeyHash::fromCbor, c -> ((CborObject.CborByteArray)c).value);
+        return new UserSnapshot(pointerState, pendingFollowReqs);
+    }
+
+    public static UserSnapshot empty() {
+        return new UserSnapshot(Collections.emptyMap(), Collections.emptyList());
+    }
+}

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -350,11 +350,15 @@ public class WriterData implements Cborable {
                                 CompletableFuture<Map<PublicKeyHash, byte[]>>> composer =
                                 (a, w) -> getUserSnapshotRecursive(owner, w, a, mutable, ipfs, hasher)
                                         .thenApply(ws ->
-                                                Stream.concat(ws.entrySet().stream(), a.entrySet().stream())
+                                                Stream.concat(
+                                                        ws.entrySet().stream().filter(e -> ! a.containsKey(e.getKey())),
+                                                        a.entrySet().stream())
                                                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
                         return Futures.reduceAll(newKeys, done,
                                 composer,
-                                (a, b) -> Stream.concat(a.entrySet().stream(), b.entrySet().stream())
+                                (a, b) -> Stream.concat(
+                                        a.entrySet().stream().filter(e -> ! b.containsKey(e.getKey())),
+                                        b.entrySet().stream())
                                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
                     });
                 });


### PR DESCRIPTION
This implements server migration. It is a new call on CoreNode. 

The UX is the following you log in to your account on the server you want to migrate to, then you click migrate account to this server. This way the user never needs to see a hash. It's a single call, so if the user gets cut off it will proceed. The way the call is implemented you could actually log in to a third server, which would then proxy the request to your target server. 

The target server first mirrors your data. This can take arbitrarily long, and if the server crashes during this time, you will remain on the original server. 

The target server then proxies the migrate call to your origin server, which does the following:
Origin server:
1) update the pki with the supplied chain. This means new requests will be proxied to the target server. 
2) return the current pointer snapshot for the user, and any pending follow requests

The target server then commits any diff in the pointers and the followrequests, and updates the user's local usage. 

Authentication is handled in the same was as updating your pki chain, plus the target server checks that the local quota is > the current usage for the user. 

Before any of this the user has to ensure the target server gives them enough quota to migrate, this will depend on whether the target is a paid server or not and will require a new UI page. 