### PR TITLE
Implement private sender side Groups

### DIFF
--- a/src/peergos/client/JsUtil.java
+++ b/src/peergos/client/JsUtil.java
@@ -3,6 +3,7 @@ package peergos.client;
 import jsinterop.annotations.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /** Utility methods to handle conversion between types necessary for Javascript interop
  *
@@ -13,4 +14,10 @@ public class JsUtil {
     public static <T> List<T> asList(T[] array) {
         return Arrays.asList(array);
     }
+
+    @JsMethod
+    public static <T> Set<T> asSet(T[] array) {
+        return Arrays.asList(array).stream().collect(Collectors.toSet());
+    }
+
 }

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -146,7 +146,7 @@ public class MirrorCoreNode implements CoreNode {
             Function<? super Cborable, List<UserPublicKeyLink>> chainParser =
                     c -> ((CborObject.CborList) c).map(UserPublicKeyLink::fromCbor);
             Map<String, List<UserPublicKeyLink>> chains = ((CborObject.CborMap)map.get("chains"))
-                    .getMap(fromString, chainParser);
+                    .toMap(fromString, chainParser);
 
             Map<PublicKeyHash, String> reverse = ((CborObject.CborList)map.get("reverse"))
                     .getMap(PublicKeyHash::fromCbor, fromString);

--- a/src/peergos/server/space/RamUsageStore.java
+++ b/src/peergos/server/space/RamUsageStore.java
@@ -4,8 +4,6 @@ import peergos.server.util.*;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
-import peergos.shared.mutable.*;
-import peergos.shared.storage.*;
 
 import java.io.*;
 import java.nio.file.*;
@@ -165,7 +163,7 @@ public class RamUsageStore implements UsageStore {
             CborObject.CborMap usagesMap = (CborObject.CborMap) map.get("usages");
 
             return new State(viewsMap.getMap(PublicKeyHash::fromCbor, WriterUsage::fromCbor),
-                    usagesMap.getMap(e -> ((CborObject.CborString) e).value, UserUsage::fromCbor));
+                    usagesMap.toMap(e -> ((CborObject.CborString) e).value, UserUsage::fromCbor));
         }
 
         public Map<String, UserUsage> getUsage() {

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1127,6 +1127,29 @@ public class MultiUserTests {
     }
 
     @Test
+    public void denyThenSubsequentFollowRequest() throws Exception {
+        UserContext a = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
+        UserContext b = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
+        UserContext c = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
+        b.sendFollowRequest(a.username, SymmetricKey.random()).get();
+        assertTrue(! b.getSocialState().join().getFollowing().contains(a.username));
+        assertTrue(! b.getSocialState().join().getFollowers().contains(a.username));
+
+        List<FollowRequestWithCipherText> aRequests = a.processFollowRequests().get();
+        assertTrue("Receive a follow request", aRequests.size() > 0);
+        a.sendReplyFollowRequest(aRequests.get(0), false, false).get();
+        List<FollowRequestWithCipherText> bFollowRequests = b.processFollowRequests().get();
+        b.sendFollowRequest(a.username, SymmetricKey.random()).get();
+
+        b.sendFollowRequest(c.username, SymmetricKey.random()).get();
+        SocialState state = b.getSocialState().join();
+        assertTrue(state.pendingIncoming.size() == 0);
+        aRequests = b.processFollowRequests().get();
+        state = b.getSocialState().join();
+        assertTrue(state.pendingIncoming.size() == 0);
+    }
+
+    @Test
     public void concurrentMutualFollowRequests() throws Exception {
         UserContext a = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
         UserContext b = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -189,6 +189,16 @@ public class MultiUserTests {
     }
 
     @Test
+    public void groupSharing() {
+        PeergosNetworkUtils.groupSharing(network, random);
+    }
+
+    @Test
+    public void groupSharingToFollowers() {
+        PeergosNetworkUtils.groupSharingToFollowers(network, random);
+    }
+
+    @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
         TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
                 (u1, u2, filename) ->

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -211,7 +211,7 @@ public class MultiUserTests {
 
         TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
                 (u1, dirToShare, usersToRemove) ->
-                        u1.unShareReadAccessGroupAware(u1.getByPath(dirToShare).join().get(), usersToRemove);
+                        u1.unShareReadAccess(u1.getByPath(dirToShare).join().get(), usersToRemove);
 
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
                 (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().readAccess.size();
@@ -226,7 +226,7 @@ public class MultiUserTests {
                         u1.shareWriteAccessWithAll(dirToShare, usersToAdd);
         TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
                 (u1, dirToShare, usersToRemove) ->
-                        u1.unShareWriteAccessGroupAware(u1.getByPath(dirToShare).join().get(), usersToRemove);
+                        u1.unShareWriteAccess(u1.getByPath(dirToShare).join().get(), usersToRemove);
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
                 (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().writeAccess.size();
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -207,10 +207,10 @@ public class MultiUserTests {
     public void groupAwareSharingReadAccess() {
         TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
                 (u1, dirToShare, usersToAdd) ->
-                        u1.shareReadAccessWithAll(u1.getByPath(dirToShare).join().get(), dirToShare, usersToAdd);
+                        u1.shareReadAccessWith(dirToShare, usersToAdd);
 
-        TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
-                (u1, dirToShare, usersToRemove) -> u1.unShareReadAccess(dirToShare, usersToRemove);
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> unshareFunction =
+                (u1, dirToShare, usersToRemove) -> u1.unShareReadAccessWith(dirToShare, usersToRemove);
 
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
                 (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().readAccess.size();
@@ -222,10 +222,10 @@ public class MultiUserTests {
     public void groupAwareSharingWriteAccess() {
         TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
                 (u1, dirToShare, usersToAdd) ->
-                        u1.shareWriteAccessWithAll(dirToShare, usersToAdd);
-        TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
+                        u1.shareWriteAccessWith(dirToShare, usersToAdd);
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> unshareFunction =
                 (u1, dirToShare, usersToRemove) ->
-                        u1.unShareWriteAccess(u1.getByPath(dirToShare).join().get(), usersToRemove);
+                        u1.unShareWriteAccessWith(dirToShare, usersToRemove);
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
                 (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().writeAccess.size();
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1039,6 +1039,9 @@ public class MultiUserTests {
         assertTrue("Friend root present after accepted follow request", u1Tou2.isPresent());
         assertTrue("Friend root not present after non reciprocated follow request", !u2Tou1.isPresent());
 
+        Set<String> followers = u1.getFollowerNames().join();
+        assertTrue(followers.contains(u2.username));
+
         // Now test them trying to become full friends after u1 unfollowing u2
         u1.unfollow(u2.username).join();
         u1.sendInitialFollowRequest(u2.username).join();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -306,10 +306,10 @@ public class MultiUserTests {
                 reader, fileData.length, u1.network, crypto, x -> {}, u1.crypto.random.randomBytes(32)).join();
         Path filePath = Paths.get(u1.username, "subdir", "file.txt");
         FileWrapper file = u1.getByPath(filePath).join().get();
-        u1.shareWriteAccessWith(filePath, Stream.of(u2.username).collect(Collectors.toSet())).join();
-        u1.shareWriteAccessWith(filePath, Stream.of(u3.username).collect(Collectors.toSet())).join();
-        u1.shareReadAccessWith(filePath, Stream.of(u4.username).collect(Collectors.toSet())).join();
-        u1.unShareReadAccess(filePath, Stream.of(u4.username).collect(Collectors.toSet())).join();
+        u1.shareWriteAccessWith(filePath, Collections.singleton(u2.username)).join();
+        u1.shareWriteAccessWith(filePath, Collections.singleton(u3.username)).join();
+        u1.shareReadAccessWith(filePath, Collections.singleton(u4.username)).join();
+        u1.unShareReadAccess(filePath, u4.username).join();
 
         // check u1 can log in
         UserContext freshContext = PeergosNetworkUtils.ensureSignedUp(u1.username, "a", network.clear(), crypto);

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -210,8 +210,7 @@ public class MultiUserTests {
                         u1.shareReadAccessWithAll(u1.getByPath(dirToShare).join().get(), dirToShare, usersToAdd);
 
         TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
-                (u1, dirToShare, usersToRemove) ->
-                        u1.unShareReadAccess(u1.getByPath(dirToShare).join().get(), usersToRemove);
+                (u1, dirToShare, usersToRemove) -> u1.unShareReadAccess(dirToShare, usersToRemove);
 
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
                 (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().readAccess.size();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -204,6 +204,36 @@ public class MultiUserTests {
     }
 
     @Test
+    public void groupAwareSharingReadAccess() {
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
+                (u1, dirToShare, usersToAdd) ->
+                        u1.shareReadAccessWithAll(u1.getByPath(dirToShare).join().get(), dirToShare, usersToAdd);
+
+        TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
+                (u1, dirToShare, usersToRemove) ->
+                        u1.unShareReadAccessGroupAware(u1.getByPath(dirToShare).join().get(), usersToRemove);
+
+        TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
+                (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().readAccess.size();
+
+        PeergosNetworkUtils.groupAwareSharing(network, random, shareFunction, unshareFunction, resultFunc);
+    }
+
+    @Test
+    public void groupAwareSharingWriteAccess() {
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
+                (u1, dirToShare, usersToAdd) ->
+                        u1.shareWriteAccessWithAll(dirToShare, usersToAdd);
+        TriFunction<UserContext, Path, String[], CompletableFuture<Boolean>> unshareFunction =
+                (u1, dirToShare, usersToRemove) ->
+                        u1.unShareWriteAccessGroupAware(u1.getByPath(dirToShare).join().get(), usersToRemove);
+        TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
+                (u1, dirToShare, fileSharedWithState) -> u1.sharedWith(dirToShare).join().writeAccess.size();
+
+        PeergosNetworkUtils.groupAwareSharing(network, random, shareFunction, unshareFunction, resultFunc);
+    }
+
+    @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
         TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
                 (u1, u2, filename) ->

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -976,7 +976,7 @@ public class MultiUserTests {
 
         Set<FileWrapper> children = u2ToU1.get().getChildren(crypto.hasher, u2.network).get();
 
-        assertTrue("Browse to friend root", children.isEmpty());
+        assertTrue("Browse to friend root", children.size() == 1);
 
         SocialState u1Social = PeergosNetworkUtils.ensureSignedUp(username1, password1, network.clear(), crypto)
                 .getSocialState().get();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1128,9 +1128,9 @@ public class MultiUserTests {
 
     @Test
     public void denyThenSubsequentFollowRequest() throws Exception {
-        UserContext a = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
-        UserContext b = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
-        UserContext c = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
+        UserContext a = PeergosNetworkUtils.ensureSignedUp("a-" + random(), random(), network, crypto);
+        UserContext b = PeergosNetworkUtils.ensureSignedUp("b-" + random(), random(), network, crypto);
+        UserContext c = PeergosNetworkUtils.ensureSignedUp("c-" + random(), random(), network, crypto);
         b.sendFollowRequest(a.username, SymmetricKey.random()).get();
         assertTrue(! b.getSocialState().join().getFollowing().contains(a.username));
         assertTrue(! b.getSocialState().join().getFollowers().contains(a.username));
@@ -1139,14 +1139,15 @@ public class MultiUserTests {
         assertTrue("Receive a follow request", aRequests.size() > 0);
         a.sendReplyFollowRequest(aRequests.get(0), false, false).get();
         List<FollowRequestWithCipherText> bFollowRequests = b.processFollowRequests().get();
+        assertTrue(bFollowRequests.isEmpty());
         b.sendFollowRequest(a.username, SymmetricKey.random()).get();
 
         b.sendFollowRequest(c.username, SymmetricKey.random()).get();
-        SocialState state = b.getSocialState().join();
-        assertTrue(state.pendingIncoming.size() == 0);
+        SocialState bState = b.getSocialState().join();
+        assertTrue(bState.pendingIncoming.size() == 0);
         aRequests = b.processFollowRequests().get();
-        state = b.getSocialState().join();
-        assertTrue(state.pendingIncoming.size() == 0);
+        bState = b.getSocialState().join();
+        assertTrue(bState.pendingIncoming.size() == 0);
     }
 
     @Test

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -199,6 +199,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void groupReadIndividualWrite() {
+        PeergosNetworkUtils.groupReadIndividualWrite(network, random);
+    }
+
+    @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
         TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
                 (u1, u2, filename) ->

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -366,7 +366,7 @@ public class PeergosNetworkUtils {
 
         FileWrapper friend = sharee.getByPath(Paths.get(sharer.username)).join().get();
         Set<FileWrapper> friendChildren = friend.getChildren(crypto.hasher, sharee.network).join();
-        Assert.assertEquals(friendChildren.size(), 1);
+        Assert.assertEquals(friendChildren.size(), 2);
     }
 
     public static void sharedwithPermutations(NetworkAccess sharerNode, Random rnd) throws Exception {
@@ -1006,7 +1006,7 @@ public class PeergosNetworkUtils {
         // check 'a' can't see the shared directory
         FileWrapper unsharedLocation = a.getByPath(sharer.username).join().get();
         Set<FileWrapper> children = unsharedLocation.getChildren(crypto.hasher, sharer.network).join();
-        Assert.assertTrue("a can't see unshared folder", children.isEmpty());
+        Assert.assertTrue("a can't see unshared folder", children.stream().filter(c -> c.getName().equals(folderName)).findFirst().isEmpty());
     }
 
     public static void grantAndRevokeWriteThenReadAccessToFolder(NetworkAccess network, Random random) throws IOException {
@@ -1059,7 +1059,7 @@ public class PeergosNetworkUtils {
         // check 'a' can't see the shared directory
         unsharedLocation = a.getByPath(sharer.username).join().get();
         children = unsharedLocation.getChildren(crypto.hasher, sharer.network).join();
-        Assert.assertTrue("a can't see unshared folder", children.isEmpty());
+        Assert.assertTrue("a can't see unshared folder", children.stream().filter(c -> c.getName().equals(folderName)).findFirst().isEmpty());
     }
 
     

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -337,7 +337,7 @@ public class PeergosNetworkUtils {
         sharer.shareWriteAccessWith(dirPath, Collections.singleton(sharee.username)).join();
 
         // no revoke write access to dir
-        sharer.unShareWriteAccess(dirPath, Collections.singleton(sharee.username)).join();
+        sharer.unShareWriteAccess(dirPath, sharee.username).join();
 
         // check sharee can't read the dir
         Optional<FileWrapper> sharedDir = sharee.getByPath(dirPath).join();
@@ -404,11 +404,11 @@ public class PeergosNetworkUtils {
         result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 1);
 
-        sharer.unShareReadAccess(p, Set.of(sharee.username)).join();
+        sharer.unShareReadAccess(p, sharee.username).join();
         result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 1);
 
-        sharer.unShareWriteAccess(p, Set.of(sharee2.username)).join();
+        sharer.unShareWriteAccess(p, sharee2.username).join();
         result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 
@@ -422,7 +422,7 @@ public class PeergosNetworkUtils {
         result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 1);
 
-        sharer.unShareWriteAccess(p, Set.of(sharee2.username)).join();
+        sharer.unShareWriteAccess(p, sharee2.username).join();
         result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 1 && result.writeAccess.size() == 0);
 
@@ -509,7 +509,7 @@ public class PeergosNetworkUtils {
         file.rename(renamedFolderName, u1Root, p, sharer).join();
         p = Paths.get(sharerUsername, renamedFolderName);
 
-        sharer.unShareReadAccess(p, Set.of(sharee.username)).join();
+        sharer.unShareReadAccess(p, sharee.username).join();
         result = sharer.sharedWith(p).join();
         Assert.assertTrue(result.readAccess.size() == 0 && result.writeAccess.size() == 0);
 

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1043,7 +1043,7 @@ public class PeergosNetworkUtils {
         // check 'a' can't see the shared directory
         FileWrapper unsharedLocation = a.getByPath(sharer.username).join().get();
         Set<FileWrapper> children = unsharedLocation.getChildren(crypto.hasher, sharer.network).join();
-        Assert.assertTrue("a can't see unshared folder", children.isEmpty());
+        Assert.assertTrue("a can't see unshared folder", children.stream().filter(c -> c.getName().equals(folderName)).findFirst().isEmpty());
 
 
         sharer.shareReadAccessWithAll(sharer.getByPath(dirPath).join().get(), dirPath
@@ -1379,7 +1379,7 @@ public class PeergosNetworkUtils {
 
         SocialFeed feed = a.getSocialFeed().join();
         List<SharedItem> items = feed.getShared(0, 1000, a.crypto, a.network).join();
-        Assert.assertTrue(items.size() == 2);
+        Assert.assertTrue(items.size() == 3 + 2);
 
         //Add another file and share
         String dir3 = "three";
@@ -1390,8 +1390,7 @@ public class PeergosNetworkUtils {
 
         feed = a.getSocialFeed().join().update().join();
         items = feed.getShared(0, 1000, a.crypto, a.network).join();
-        Assert.assertTrue(items.size() == 3);
-
+        Assert.assertTrue(items.size() == 3 + 3);
     }
 
     public static void groupSharing(NetworkAccess network, Random random) {
@@ -1436,7 +1435,7 @@ public class PeergosNetworkUtils {
         Assert.assertTrue(dir2.isEmpty());
 
         // new friends
-        List<UserContext> newFriends = getUserContextsForNode(network.clear(), random, 1, Arrays.asList(password, password));
+        List<UserContext> newFriends = getUserContextsForNode(network, random, 1, Arrays.asList(password, password));
         UserContext newFriend = newFriends.get(0);
 
         // friend sharer with others
@@ -1452,7 +1451,7 @@ public class PeergosNetworkUtils {
         String password = "notagoodone";
         UserContext sharer = PeergosNetworkUtils.ensureSignedUp(generateUsername(random), password, network, crypto);
 
-        List<UserContext> shareeUsers = getUserContextsForNode(network.clear(), random, 2, Arrays.asList(password, password));
+        List<UserContext> shareeUsers = getUserContextsForNode(network, random, 2, Arrays.asList(password, password));
         UserContext friend = shareeUsers.get(0);
 
         // make others follow sharer

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1203,7 +1203,7 @@ public class PeergosNetworkUtils {
 
         // check 'a' can see the shared file in their social feed
         SocialFeed feed = a.getSocialFeed().join();
-        int feedSize = 3;
+        int feedSize = 2;
         List<SharedItem> items = feed.getShared(feedSize, feedSize + 1, a.crypto, a.network).join();
         Assert.assertTrue(items.size() > 0);
         SharedItem item = items.get(0);
@@ -1293,7 +1293,7 @@ public class PeergosNetworkUtils {
 
         SocialFeed feed = sharee.getSocialFeed().join();
         List<SharedItem> items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 3 + 2);
+        Assert.assertTrue(items.size() == 2 + 2);
 
         sharee.getUserRoot().join().mkdir("mine", sharee.network, false, sharer.crypto).join();
     }
@@ -1320,21 +1320,22 @@ public class PeergosNetworkUtils {
         sharer.shareReadAccessWith(dirToShare2, Set.of(sharee.username)).join();
 
         SocialFeed feed = sharee.getSocialFeed().join();
+        int initialFeedSize = 2;
         List<SharedItem> items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 3 + 2);
+        Assert.assertTrue(items.size() == initialFeedSize + 2);
 
         sharee = PeergosNetworkUtils.ensureSignedUp(sharee.username, password, network, crypto);
         sharee.getUserRoot().join().mkdir("mine", sharer.network, false, sharer.crypto).join();
 
         feed = sharee.getSocialFeed().join();
         items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 3 + 2);
+        Assert.assertTrue(items.size() == initialFeedSize + 2);
 
         //When attempting this in the web-ui the below call results in a failure when loading timeline entry
         //Cannot seek to position 680 in file of length 340
         feed = sharee.getSocialFeed().join();
         items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 3 + 2);
+        Assert.assertTrue(items.size() == initialFeedSize + 2);
     }
 
     public static void socialFeedEmpty(NetworkAccess network, Random random) {
@@ -1371,8 +1372,9 @@ public class PeergosNetworkUtils {
         sharer.shareReadAccessWith(dirToShare2, Set.of(a.username)).join();
 
         SocialFeed feed = a.getSocialFeed().join();
+        int initialFeedSize = 2;
         List<SharedItem> items = feed.getShared(0, 1000, a.crypto, a.network).join();
-        Assert.assertTrue(items.size() == 3 + 2);
+        Assert.assertTrue(items.size() == initialFeedSize + 2);
 
         //Add another file and share
         String dir3 = "three";
@@ -1383,7 +1385,7 @@ public class PeergosNetworkUtils {
 
         feed = a.getSocialFeed().join().update().join();
         items = feed.getShared(0, 1000, a.crypto, a.network).join();
-        Assert.assertTrue(items.size() == 3 + 3);
+        Assert.assertTrue(items.size() == initialFeedSize + 3);
     }
 
     public static void groupSharing(NetworkAccess network, Random random) {

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1210,7 +1210,8 @@ public class PeergosNetworkUtils {
 
         // check 'a' can see the shared file in their social feed
         SocialFeed feed = a.getSocialFeed().join();
-        List<SharedItem> items = feed.getShared(0, 1, a.crypto, a.network).join();
+        int feedSize = 3;
+        List<SharedItem> items = feed.getShared(feedSize, feedSize + 1, a.crypto, a.network).join();
         Assert.assertTrue(items.size() > 0);
         SharedItem item = items.get(0);
         Assert.assertTrue(item.owner.equals(sharer.username));
@@ -1222,7 +1223,7 @@ public class PeergosNetworkUtils {
         // Test the feed after a fresh login
         UserContext freshA = PeergosNetworkUtils.ensureSignedUp(a.username, password, network, crypto);
         SocialFeed freshFeed = freshA.getSocialFeed().join();
-        List<SharedItem> freshItems = freshFeed.getShared(0, 1, a.crypto, a.network).join();
+        List<SharedItem> freshItems = freshFeed.getShared(feedSize, feedSize + 1, a.crypto, a.network).join();
         Assert.assertTrue(freshItems.size() > 0);
         SharedItem freshItem = freshItems.get(0);
         Assert.assertTrue(freshItem.equals(item));
@@ -1232,7 +1233,7 @@ public class PeergosNetworkUtils {
         uploadAndShare(fileData, file2, sharer, a.username);
 
         SocialFeed updatedFeed = freshFeed.update().join();
-        List<SharedItem> items2 = updatedFeed.getShared(1, 2, a.crypto, a.network).join();
+        List<SharedItem> items2 = updatedFeed.getShared(feedSize + 1, feedSize + 2, a.crypto, a.network).join();
         Assert.assertTrue(items2.size() > 0);
         SharedItem item2 = items2.get(0);
         Assert.assertTrue(item2.owner.equals(sharer.username));
@@ -1259,7 +1260,7 @@ public class PeergosNetworkUtils {
 
         // now check feed
         SocialFeed updatedFeed3 = freshFeed.update().join();
-        List<SharedItem> items3 = updatedFeed3.getShared(2, 3, a.crypto, a.network).join();
+        List<SharedItem> items3 = updatedFeed3.getShared(feedSize + 2, feedSize + 3, a.crypto, a.network).join();
         Assert.assertTrue(items3.size() > 0);
         SharedItem item3 = items3.get(0);
         Assert.assertTrue(item3.owner.equals(sharer.username));
@@ -1299,7 +1300,7 @@ public class PeergosNetworkUtils {
 
         SocialFeed feed = sharee.getSocialFeed().join();
         List<SharedItem> items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 2);
+        Assert.assertTrue(items.size() == 3 + 2);
 
         sharee.getUserRoot().join().mkdir("mine", sharee.network, false, sharer.crypto).join();
     }
@@ -1327,20 +1328,20 @@ public class PeergosNetworkUtils {
 
         SocialFeed feed = sharee.getSocialFeed().join();
         List<SharedItem> items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 2);
+        Assert.assertTrue(items.size() == 3 + 2);
 
         sharee = PeergosNetworkUtils.ensureSignedUp(sharee.username, password, network, crypto);
         sharee.getUserRoot().join().mkdir("mine", sharer.network, false, sharer.crypto).join();
 
         feed = sharee.getSocialFeed().join();
         items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 2);
+        Assert.assertTrue(items.size() == 3 + 2);
 
         //When attempting this in the web-ui the below call results in a failure when loading timeline entry
         //Cannot seek to position 680 in file of length 340
         feed = sharee.getSocialFeed().join();
         items = feed.getShared(0, 1000, sharee.crypto, sharee.network).join();
-        Assert.assertTrue(items.size() == 2);
+        Assert.assertTrue(items.size() == 3 + 2);
     }
 
     public static void socialFeedEmpty(NetworkAccess network, Random random) {

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -314,7 +314,7 @@ public class RamUserTests extends UserTests {
 
         user1.shareWriteAccessWith(Paths.get(username1, folder1), Collections.singleton(username2)).join();
 
-        user1.unShareWriteAccess(Paths.get(username1, folder1), Collections.singleton(username2)).join();
+        user1.unShareWriteAccess(Paths.get(username1, folder1), username2).join();
         // check user1 can still log in
         UserContext freshUser1 = PeergosNetworkUtils.ensureSignedUp(username1, password, network, crypto);
     }

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -252,12 +252,16 @@ public interface CborObject extends Cborable {
             return fromCbor.apply(get(key));
         }
 
-        public <K,V> Map<K,V> getMap(Function<? super Cborable, K> toKey, Function<? super Cborable, V> toValue) {
+        public <K,V> Map<K,V> toMap(Function<? super Cborable, K> toKey, Function<? super Cborable, V> toValue) {
             return values.entrySet().stream()
                 .collect(Collectors.toMap(
                     e -> toKey.apply(e.getKey()),
                     e -> toValue.apply(e.getValue())
                 ));
+        }
+
+        public <K,V> Map<K,V> getMap(String key, Function<? super Cborable, K> toKey, Function<? super Cborable, V> toValue) {
+            return ((CborMap)get(key)).toMap(toKey, toValue);
         }
     }
 

--- a/src/peergos/shared/cbor/Cborable.java
+++ b/src/peergos/shared/cbor/Cborable.java
@@ -1,10 +1,16 @@
 package peergos.shared.cbor;
 
+import java.util.function.*;
+
 public interface Cborable {
 
     CborObject toCbor();
 
     default byte[] serialize() {
         return toCbor().toByteArray();
+    }
+
+    static <T> Function<byte[], T> parser(Function<Cborable, T> parser) {
+        return arr -> parser.apply(CborObject.fromByteArray(arr));
     }
 }

--- a/src/peergos/shared/social/FollowRequest.java
+++ b/src/peergos/shared/social/FollowRequest.java
@@ -44,4 +44,9 @@ public class FollowRequest implements Cborable {
                 .map(SymmetricKey::fromCbor);
         return new FollowRequest(entryPoint, key);
     }
+
+    @Override
+    public String toString() {
+        return entry + " - " + key.isPresent();
+    }
 }

--- a/src/peergos/shared/storage/PresignedUrl.java
+++ b/src/peergos/shared/storage/PresignedUrl.java
@@ -30,7 +30,7 @@ public class PresignedUrl implements Cborable {
         CborObject.CborMap map = (CborObject.CborMap) cbor;
         String base = map.getString("b");
         Map<String, String> headers = ((CborObject.CborMap)map.get("h"))
-                .getMap(k -> ((CborObject.CborString)k).value, k -> ((CborObject.CborString)k).value);
+                .toMap(k -> ((CborObject.CborString)k).value, k -> ((CborObject.CborString)k).value);
         return new PresignedUrl(base, headers);
     }
 }

--- a/src/peergos/shared/user/AcquaintanceSourcedTrieNode.java
+++ b/src/peergos/shared/user/AcquaintanceSourcedTrieNode.java
@@ -1,0 +1,119 @@
+package peergos.shared.user;
+
+import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
+
+import java.nio.file.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.*;
+
+public class AcquaintanceSourcedTrieNode implements TrieNode {
+
+    private final String ownerName;
+    private final IncomingCapCache cache;
+    private final Crypto crypto;
+
+    public AcquaintanceSourcedTrieNode(String ownerName,
+                                       IncomingCapCache cache,
+                                       Crypto crypto) {
+        this.ownerName = ownerName;
+        this.cache = cache;
+        this.crypto = crypto;
+    }
+
+    public static CompletableFuture<Optional<AcquaintanceSourcedTrieNode>> build(String ownerName,
+                                                                                 IncomingCapCache cache,
+                                                                                 Crypto crypto) {
+        return Futures.of(Optional.of(new AcquaintanceSourcedTrieNode(ownerName, cache, crypto)));
+    }
+
+    private FileWrapper convert(FileWrapper file, String path) {
+        return file.withTrieNode(new ExternalTrieNode(path, this));
+    }
+
+    @Override
+    public synchronized CompletableFuture<Optional<FileWrapper>> getByPath(String path,
+                                                                           Hasher hasher,
+                                                                           NetworkAccess network) {
+        FileProperties.ensureValidPath(path);
+        Path file = Paths.get(ownerName + path);
+        return cache.getByPath(file, cache.getVersion(), hasher, network)
+                .thenApply(opt -> opt.map(f -> convert(f, path)));
+    }
+
+    @Override
+    public synchronized CompletableFuture<Optional<FileWrapper>> getByPath(String path,
+                                                                           Snapshot version,
+                                                                           Hasher hasher,
+                                                                           NetworkAccess network) {
+        FileProperties.ensureValidPath(path);
+        Path file = Paths.get(ownerName + path);
+        return cache.getByPath(file, version, hasher, network)
+                .thenApply(opt -> opt.map(f -> convert(f, path)));
+    }
+
+    @Override
+    public synchronized CompletableFuture<Set<FileWrapper>> getChildren(String path,
+                                                                        Hasher hasher,
+                                                                        NetworkAccess network) {
+        FileProperties.ensureValidPath(path);
+        Path dir = Paths.get(ownerName + path);
+        return cache.getChildren(dir, cache.getVersion(), hasher, network)
+                .thenApply(children -> children.stream()
+                        .map(f -> convert(f, path + "/" + f.getName()))
+                        .collect(Collectors.toSet()));
+    }
+
+    @Override
+    public synchronized CompletableFuture<Set<FileWrapper>> getChildren(String path,
+                                                                        Hasher hasher,
+                                                                        Snapshot version,
+                                                                        NetworkAccess network) {
+        FileProperties.ensureValidPath(path);
+        Path dir = Paths.get(ownerName + path);
+        return cache.getChildren(dir, version, hasher, network)
+                .thenApply(children -> children.stream()
+                        .map(f -> convert(f, path + "/" + f.getName()))
+                        .collect(Collectors.toSet()));
+    }
+
+    @Override
+    public synchronized Set<String> getChildNames() {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
+    public synchronized TrieNode put(String path, EntryPoint e) {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
+    public synchronized TrieNode putNode(String path, TrieNode t) {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
+    public synchronized TrieNode removeEntry(String path) {
+        if (TrieNode.canonicalise(path).isEmpty())
+            return TrieNodeImpl.empty();
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
+    public Collection<TrieNode> getChildNodes() {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
+    public TrieNode getChildNode(String name) {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
+    public boolean isEmpty() {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+}

--- a/src/peergos/shared/user/CapsDiff.java
+++ b/src/peergos/shared/user/CapsDiff.java
@@ -50,7 +50,9 @@ public class CapsDiff {
     }
 
     public boolean isEmpty() {
-        return newCaps.readCaps.getBytesRead() == 0 && newCaps.writeCaps.getBytesRead() == 0;
+        return newCaps.readCaps.getBytesRead() == 0 &&
+                newCaps.writeCaps.getBytesRead() == 0 &&
+                groupDiffs.values().stream().allMatch(CapsDiff::isEmpty);
     }
 
     public long updatedReadBytes() {

--- a/src/peergos/shared/user/CapsDiff.java
+++ b/src/peergos/shared/user/CapsDiff.java
@@ -1,13 +1,52 @@
 package peergos.shared.user;
 
+import peergos.shared.user.fs.*;
+
+import java.util.*;
+import java.util.stream.*;
+
 public class CapsDiff {
     public final long priorReadByteOffset, priorWriteByteOffset;
-    public final FriendSourcedTrieNode.ReadAndWriteCaps newCaps;
+    public final ReadAndWriteCaps newCaps;
+    public final Map<String, CapsDiff> groupDiffs;
 
-    public CapsDiff(long priorReadByteOffset, long priorWriteByteOffset, FriendSourcedTrieNode.ReadAndWriteCaps newCaps) {
+    public CapsDiff(long priorReadByteOffset,
+                    long priorWriteByteOffset,
+                    ReadAndWriteCaps newCaps,
+                    Map<String, CapsDiff> groupDiffs) {
         this.priorReadByteOffset = priorReadByteOffset;
         this.priorWriteByteOffset = priorWriteByteOffset;
         this.newCaps = newCaps;
+        this.groupDiffs = groupDiffs;
+    }
+
+    public int readCapCount() {
+        return newCaps.readCaps.getRetrievedCapabilities().size();
+    }
+
+    public int writeCapCount() {
+        return newCaps.writeCaps.getRetrievedCapabilities().size();
+    }
+
+    public CapsDiff flatten() {
+        Map<String, CapsDiff> flattenedGroups = groupDiffs.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().flatten()));
+        return new CapsDiff(updatedReadBytes(), updatedWriteBytes(), ReadAndWriteCaps.empty(), flattenedGroups);
+    }
+
+    public List<CapabilityWithPath> getNewCaps() {
+        Stream<CapabilityWithPath> direct = Stream.concat(
+                newCaps.readCaps.getRetrievedCapabilities().stream(),
+                newCaps.writeCaps.getRetrievedCapabilities().stream());
+        return Stream.concat(direct, groupDiffs.values().stream().flatMap(d -> d.getNewCaps().stream()))
+                .collect(Collectors.toList());
+    }
+
+    public CapsDiff mergeGroups(CapsDiff other) {
+        HashMap<String, CapsDiff> combined = new HashMap<>(groupDiffs);
+        combined.putAll(other.groupDiffs);
+        return new CapsDiff(priorReadByteOffset, priorWriteByteOffset, newCaps,
+                combined);
     }
 
     public boolean isEmpty() {
@@ -24,5 +63,23 @@ public class CapsDiff {
 
     public long priorBytes() {
         return priorReadByteOffset + priorWriteByteOffset;
+    }
+
+    public static CapsDiff empty() {
+        return new CapsDiff(0, 0, ReadAndWriteCaps.empty(), Collections.emptyMap());
+    }
+
+    public static class ReadAndWriteCaps {
+        public final CapabilitiesFromUser readCaps, writeCaps;
+
+        public ReadAndWriteCaps(CapabilitiesFromUser readCaps, CapabilitiesFromUser writeCaps) {
+            this.readCaps = readCaps;
+            this.writeCaps = writeCaps;
+        }
+
+        public static ReadAndWriteCaps empty() {
+            CapabilitiesFromUser empty = new CapabilitiesFromUser(0, Collections.emptyList());
+            return new ReadAndWriteCaps(empty, empty);
+        }
     }
 }

--- a/src/peergos/shared/user/EntryPoint.java
+++ b/src/peergos/shared/user/EntryPoint.java
@@ -90,4 +90,9 @@ public class EntryPoint implements Cborable {
         byte[] raw = key.decrypt(Arrays.copyOfRange(input, 24, input.length), nonce);
         return fromCbor(CborObject.fromByteArray(raw));
     }
+
+    @Override
+    public String toString() {
+        return ownerName;
+    }
 }

--- a/src/peergos/shared/user/ExternalTrieNode.java
+++ b/src/peergos/shared/user/ExternalTrieNode.java
@@ -7,11 +7,11 @@ import peergos.shared.user.fs.*;
 import java.util.*;
 import java.util.concurrent.*;
 
-public class FriendDirTrieNode implements TrieNode {
+public class ExternalTrieNode implements TrieNode {
     private final String dirPath; // without owner
-    private final FriendSourcedTrieNode root;
+    private final TrieNode root;
 
-    public FriendDirTrieNode(String dirPath, FriendSourcedTrieNode root) {
+    public ExternalTrieNode(String dirPath, TrieNode root) {
         this.dirPath = dirPath;
         this.root = root;
     }

--- a/src/peergos/shared/user/FriendDirTrieNode.java
+++ b/src/peergos/shared/user/FriendDirTrieNode.java
@@ -62,6 +62,11 @@ public class FriendDirTrieNode implements TrieNode {
     }
 
     @Override
+    public TrieNode getChildNode(String name) {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
+    }
+
+    @Override
     public boolean isEmpty() {
         throw new IllegalStateException("Invalid operation");
     }

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -76,7 +76,7 @@ public class FriendSourcedTrieNode implements TrieNode {
     }
 
     private FileWrapper convert(FileWrapper file, String path) {
-        return file.withTrieNode(new FriendDirTrieNode(path, this));
+        return file.withTrieNode(new ExternalTrieNode(path, this));
     }
 
     private CompletableFuture<Boolean> updateIncludingGroups(NetworkAccess network) {

--- a/src/peergos/shared/user/FriendSourcedTrieNode.java
+++ b/src/peergos/shared/user/FriendSourcedTrieNode.java
@@ -2,6 +2,7 @@ package peergos.shared.user;
 
 import peergos.shared.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.social.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
@@ -16,6 +17,7 @@ public class FriendSourcedTrieNode implements TrieNode {
     private final IncomingCapCache cache;
     private final EntryPoint sharedDir;
     private final Crypto crypto;
+    private final List<EntryPoint> groups;
 
     public FriendSourcedTrieNode(IncomingCapCache cache,
                                  String ownerName,
@@ -25,6 +27,12 @@ public class FriendSourcedTrieNode implements TrieNode {
         this.ownerName = ownerName;
         this.sharedDir = sharedDir;
         this.crypto = crypto;
+        this.groups = new ArrayList<>();
+    }
+
+    public synchronized void addGroup(EntryPoint group) {
+        if (! groups.contains(group))
+            groups.add(group);
     }
 
     public static CompletableFuture<Optional<FriendSourcedTrieNode>> build(IncomingCapCache cache,
@@ -42,13 +50,12 @@ public class FriendSourcedTrieNode implements TrieNode {
      */
     public synchronized CompletableFuture<CapsDiff> ensureUptodate(Crypto crypto,
                                                                    NetworkAccess network) {
-        return cache.ensureFriendUptodate(ownerName, sharedDir, network);
+        return cache.ensureFriendUptodate(ownerName, sharedDir, groups, network);
     }
 
-    public synchronized CompletableFuture<CapsDiff> getCaps(long readByteOffset,
-                                                            long writeByteOffset,
+    public synchronized CompletableFuture<CapsDiff> getCaps(ProcessedCaps current,
                                                             NetworkAccess network) {
-        return cache.getCapsFrom(ownerName, sharedDir, readByteOffset, writeByteOffset, network);
+        return cache.getCapsFrom(ownerName, sharedDir, groups, current, network);
     }
 
     private CompletableFuture<Optional<FileWrapper>> getFriendRoot(NetworkAccess network) {
@@ -72,6 +79,22 @@ public class FriendSourcedTrieNode implements TrieNode {
         return file.withTrieNode(new FriendDirTrieNode(path, this));
     }
 
+    private CompletableFuture<Boolean> updateIncludingGroups(NetworkAccess network) {
+        return ensureUptodate(crypto, network)
+                .thenCompose(x -> {
+                    List<CapabilityWithPath> newGroups = x.getNewCaps().stream()
+                            .filter(c -> c.path.startsWith("/" + ownerName + "/" + UserContext.SHARED_DIR_NAME))
+                            .collect(Collectors.toList());
+                    for (CapabilityWithPath groupCap : newGroups) {
+                        addGroup(new EntryPoint(groupCap.cap, ownerName));
+                    }
+                    if (newGroups.isEmpty())
+                        return Futures.of(true);
+                    return ensureUptodate(crypto, network)
+                            .thenApply(y -> true);
+                });
+    }
+
     @Override
     public synchronized CompletableFuture<Optional<FileWrapper>> getByPath(String path,
                                                                            Hasher hasher,
@@ -81,8 +104,8 @@ public class FriendSourcedTrieNode implements TrieNode {
             return getFriendRoot(network)
                     .thenApply(opt -> opt.map(f -> f.withTrieNode(this)));
         Path file = Paths.get(ownerName + path);
-        return ensureUptodate(crypto, network)
-                .thenCompose(x -> cache.getByPath(file, cache.getVersion(), hasher, network))
+        return updateIncludingGroups(network)
+                .thenCompose(y -> cache.getByPath(file, cache.getVersion(), hasher, network))
                 .thenApply(opt -> opt.map(f -> convert(f, path)));
     }
 
@@ -106,7 +129,7 @@ public class FriendSourcedTrieNode implements TrieNode {
                                                                         NetworkAccess network) {
         FileProperties.ensureValidPath(path);
         Path dir = Paths.get(ownerName + path);
-        return ensureUptodate(crypto, network)
+        return updateIncludingGroups(network)
                 .thenCompose(x -> cache.getChildren(dir, cache.getVersion(), hasher, network))
                 .thenApply(children -> children.stream()
                         .map(f -> convert(f, path + "/" + f.getName()))
@@ -154,21 +177,12 @@ public class FriendSourcedTrieNode implements TrieNode {
     }
 
     @Override
-    public boolean isEmpty() {
+    public TrieNode getChildNode(String name) {
         throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
     }
 
-    public static class ReadAndWriteCaps {
-        public final CapabilitiesFromUser readCaps, writeCaps;
-
-        public ReadAndWriteCaps(CapabilitiesFromUser readCaps, CapabilitiesFromUser writeCaps) {
-            this.readCaps = readCaps;
-            this.writeCaps = writeCaps;
-        }
-
-        public static ReadAndWriteCaps empty() {
-            CapabilitiesFromUser empty = CapabilitiesFromUser.empty();
-            return new ReadAndWriteCaps(empty, empty);
-        }
+    @Override
+    public boolean isEmpty() {
+        throw new IllegalStateException("Not valid operation on FriendSourcedTrieNode.");
     }
 }

--- a/src/peergos/shared/user/Groups.java
+++ b/src/peergos/shared/user/Groups.java
@@ -1,0 +1,52 @@
+package peergos.shared.user;
+
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.random.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+import java.util.function.*;
+
+public class Groups implements Cborable {
+    public final Map<String, String> uidToGroupName;
+
+    public Groups(Map<String, String> uidToGroupName) {
+        this.uidToGroupName = uidToGroupName;
+    }
+
+    public static Groups generate(SafeRandom r) {
+        Map<String, String> uidToNames = new TreeMap<>();
+        uidToNames.put(generateUid(r), SocialState.FRIENDS_GROUP_NAME);
+        uidToNames.put(generateUid(r), SocialState.FOLLOWERS_GROUP_NAME);
+        return new Groups(uidToNames);
+    }
+
+    /* Generate a uid that cannot clash with a username, but which is a valid filename
+     */
+    public static String generateUid(SafeRandom r) {
+        return "." + ArrayOps.bytesToHex(r.randomBytes(32));
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        SortedMap<String, Cborable> uidToNames = new TreeMap<>();
+        for (Map.Entry<String, String> e : uidToGroupName.entrySet()) {
+            uidToNames.put(e.getKey(), new CborObject.CborString(e.getValue()));
+        }
+
+        state.put("n", CborObject.CborMap.build(uidToNames));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static Groups fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for Groups!");
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        CborObject.CborMap r = m.get("n", c -> (CborObject.CborMap) c);
+        Function<Cborable, String> getString = c -> ((CborObject.CborString) c).value;
+        Map<String, String> uidToNames = r.toMap(getString, getString);
+
+        return new Groups(uidToNames);
+    }
+}

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -111,7 +111,7 @@ public class IncomingCapCache {
                             Stream.of(updatedChild))
                             .collect(Collectors.toList())));
                 }
-                if (current.sharers.equals(Arrays.asList(sharer))) {
+                if (current.sharers.equals(Arrays.asList(sharer)) && ! current.cap.isWritable()) {
                     ChildElement updatedChild = new ChildElement(name, cap, current.sharers);
                     return Futures.of(new CapsInDirectory(Stream.concat(remainder.stream(),
                             Stream.of(updatedChild))

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -281,8 +281,8 @@ public class IncomingCapCache {
                                 .thenApply(CapsInDirectory::fromCbor)
                                 .thenCompose(caps -> Futures.findFirst(caps.children,
                                         c -> network.retrieveEntryPoint(new EntryPoint(c.cap, ownerName))))
-                                .thenCompose(fileOpt -> fileOpt.map(f -> f.retrieveParent(network))
-                                        .orElseGet(recurse));
+                                .thenCompose(fileOpt -> Futures.asyncExceptionally(() -> fileOpt.map(f -> f.retrieveParent(network))
+                                        .orElseGet(recurse), t -> recurse.get()));
                     return recurse.get();
                 });
     }

--- a/src/peergos/shared/user/PendingSocialState.java
+++ b/src/peergos/shared/user/PendingSocialState.java
@@ -1,0 +1,48 @@
+package peergos.shared.user;
+
+import peergos.shared.cbor.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+public class PendingSocialState implements Cborable {
+
+    public final Set<String> pendingOutgoingFollowRequests;
+
+    public PendingSocialState(Set<String> pendingOutgoingFollowRequests) {
+        this.pendingOutgoingFollowRequests = pendingOutgoingFollowRequests;
+    }
+
+    public PendingSocialState withPending(String username) {
+        HashSet<String> updated = new HashSet<>(pendingOutgoingFollowRequests);
+        updated.add(username);
+        return new PendingSocialState(updated);
+    }
+
+    public PendingSocialState withoutPending(String username) {
+        HashSet<String> updated = new HashSet<>(pendingOutgoingFollowRequests);
+        updated.remove(username);
+        return new PendingSocialState(updated);
+    }
+
+    public static PendingSocialState empty() {
+        return new PendingSocialState(Collections.emptySet());
+    }
+
+    @Override
+    public CborObject toCbor() {
+        Map<String, Cborable> cbor = new TreeMap<>();
+        cbor.put("pendingOutgoing", new CborObject.CborList(pendingOutgoingFollowRequests.stream()
+                .map(CborObject.CborString::new)
+                .collect(Collectors.toList())));
+        return CborObject.CborMap.build(cbor);
+    }
+
+    public static PendingSocialState fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for PendingSocialState!");
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        List<String> pendingOutgoing = m.getList("pendingOutgoing", c -> ((CborObject.CborString)c).value);
+        return new PendingSocialState(new HashSet<>(pendingOutgoing));
+    }
+}

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -151,12 +151,12 @@ public class SharedWithState implements Cborable {
         CborObject.CborMap m = (CborObject.CborMap) cbor;
         CborObject.CborMap r = m.get("r", c -> (CborObject.CborMap) c);
         Function<Cborable, String> getString = c -> ((CborObject.CborString) c).value;
-        Map<String, Set<String>> readShares = r.getMap(
+        Map<String, Set<String>> readShares = r.toMap(
                 getString,
                 c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
 
         CborObject.CborMap w = m.get("w", c -> (CborObject.CborMap) c);
-        Map<String, Set<String>> writehares = w.getMap(
+        Map<String, Set<String>> writehares = w.toMap(
                 getString,
                 c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
 

--- a/src/peergos/shared/user/SocialState.java
+++ b/src/peergos/shared/user/SocialState.java
@@ -9,18 +9,22 @@ import java.util.stream.*;
 
 @JsType
 public class SocialState {
+    public static final String FRIENDS_GROUP_NAME = "friends";
+    public static final String FOLLOWERS_GROUP_NAME = "followers";
 
     public final List<FollowRequestWithCipherText> pendingIncoming;
     public final Map<String, FileWrapper> followerRoots;
     public final Set<FileWrapper> followingRoots;
     public final Map<String, FileWrapper> pendingOutgoingFollowRequests;
     public final Map<String, FriendAnnotation> friendAnnotations;
+    public final Map<String, String> uidToGroupName, groupNameToUid;
 
     public SocialState(List<FollowRequestWithCipherText> pendingIncoming,
                        Set<String> actualFollowers,
                        Map<String, FileWrapper> followerRoots,
                        Set<FileWrapper> followingRoots,
-                       Map<String, FriendAnnotation> friendAnnotations) {
+                       Map<String, FriendAnnotation> friendAnnotations,
+                       Map<String, String> uidToGroupName) {
         this.pendingIncoming = pendingIncoming;
         this.pendingOutgoingFollowRequests = followerRoots.entrySet()
                 .stream()
@@ -35,5 +39,17 @@ public class SocialState {
         sortedByName.addAll(followingRoots);
         this.followingRoots = sortedByName;
         this.friendAnnotations = friendAnnotations;
+        this.uidToGroupName = uidToGroupName;
+        this.groupNameToUid = uidToGroupName.entrySet()
+                .stream()
+                .collect(Collectors.toMap(e -> e.getValue(), e -> e.getKey()));
+    }
+
+    public String getFriendsGroupUid() {
+        return groupNameToUid.get(FRIENDS_GROUP_NAME);
+    }
+
+    public String getFollowersGroupUid() {
+        return groupNameToUid.get(FOLLOWERS_GROUP_NAME);
     }
 }

--- a/src/peergos/shared/user/SocialState.java
+++ b/src/peergos/shared/user/SocialState.java
@@ -54,7 +54,7 @@ public class SocialState {
     }
 
     public Set<String> getFriends() {
-        HashSet<String> res = new HashSet<>(getFriends());
+        HashSet<String> res = new HashSet<>(getFollowing());
         res.retainAll(getFollowers());
         return res;
     }

--- a/src/peergos/shared/user/SocialState.java
+++ b/src/peergos/shared/user/SocialState.java
@@ -16,7 +16,6 @@ public class SocialState {
     public final Set<String> pendingOutgoing;
     public final Map<String, FileWrapper> followerRoots;
     public final Set<FileWrapper> followingRoots;
-    public final Map<String, FileWrapper> pendingOutgoingFollowRequests;
     public final Map<String, FriendAnnotation> friendAnnotations;
     public final Map<String, String> uidToGroupName, groupNameToUid;
 
@@ -29,10 +28,6 @@ public class SocialState {
                        Map<String, String> uidToGroupName) {
         this.pendingIncoming = pendingIncoming;
         this.pendingOutgoing = pendingOutgoing;
-        this.pendingOutgoingFollowRequests = followerRoots.entrySet()
-                .stream()
-                .filter(e -> ! actualFollowers.contains(e.getKey()))
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
         Map<String, FileWrapper> actualFollowerRoots = followerRoots.entrySet()
                 .stream()
                 .filter(e -> actualFollowers.contains(e.getKey()))

--- a/src/peergos/shared/user/SocialState.java
+++ b/src/peergos/shared/user/SocialState.java
@@ -45,6 +45,20 @@ public class SocialState {
                 .collect(Collectors.toMap(e -> e.getValue(), e -> e.getKey()));
     }
 
+    public Set<String> getFollowers() {
+        return followerRoots.keySet();
+    }
+
+    public Set<String> getFollowing() {
+        return followingRoots.stream().map(f -> f.getFileProperties().name).collect(Collectors.toSet());
+    }
+
+    public Set<String> getFriends() {
+        HashSet<String> res = new HashSet<>(getFriends());
+        res.retainAll(getFollowers());
+        return res;
+    }
+
     public String getFriendsGroupUid() {
         return groupNameToUid.get(FRIENDS_GROUP_NAME);
     }

--- a/src/peergos/shared/user/SocialState.java
+++ b/src/peergos/shared/user/SocialState.java
@@ -13,6 +13,7 @@ public class SocialState {
     public static final String FOLLOWERS_GROUP_NAME = "followers";
 
     public final List<FollowRequestWithCipherText> pendingIncoming;
+    public final Set<String> pendingOutgoing;
     public final Map<String, FileWrapper> followerRoots;
     public final Set<FileWrapper> followingRoots;
     public final Map<String, FileWrapper> pendingOutgoingFollowRequests;
@@ -20,12 +21,14 @@ public class SocialState {
     public final Map<String, String> uidToGroupName, groupNameToUid;
 
     public SocialState(List<FollowRequestWithCipherText> pendingIncoming,
+                       Set<String> pendingOutgoing,
                        Set<String> actualFollowers,
                        Map<String, FileWrapper> followerRoots,
                        Set<FileWrapper> followingRoots,
                        Map<String, FriendAnnotation> friendAnnotations,
                        Map<String, String> uidToGroupName) {
         this.pendingIncoming = pendingIncoming;
+        this.pendingOutgoing = pendingOutgoing;
         this.pendingOutgoingFollowRequests = followerRoots.entrySet()
                 .stream()
                 .filter(e -> ! actualFollowers.contains(e.getKey()))

--- a/src/peergos/shared/user/TrieNode.java
+++ b/src/peergos/shared/user/TrieNode.java
@@ -31,6 +31,8 @@ public interface TrieNode {
 
     Collection<TrieNode> getChildNodes();
 
+    TrieNode getChildNode(String name);
+
     boolean isEmpty();
 
     static String canonicalise(String path) {

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -243,6 +243,11 @@ public class TrieNodeImpl implements TrieNode {
         return children.values();
     }
 
+    @Override
+    public TrieNode getChildNode(String name) {
+        return children.get(name);
+    }
+
     public static TrieNodeImpl empty() {
         return new TrieNodeImpl(Collections.emptyMap(), Optional.empty());
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -130,11 +130,69 @@ public class UserContext {
         );
     }
 
+    /*
+        Taking into account currently shared users/groups and users/groups selected for unsharing, build a list that is group aware
+     */
+    private Set<String> gatherAllUsernamesToUnshare(SocialState social,
+                                                List<String> currentSharedWithUsernames, List<String> usernamesToUnshare) {
+
+        List<String> followerNames = social.followerRoots.keySet().stream().collect(Collectors.toList());
+        List<String> followeeNames = social.followingRoots.stream().map(f -> f.getFileProperties().name).collect(Collectors.toList());
+        List<String> friendNames = followerNames.stream().filter(x -> followeeNames.contains(x)).collect(Collectors.toList());
+
+        String friendGroupUid = social.getFriendsGroupUid();
+        String followersGroupUid = social.getFollowersGroupUid();
+
+        List<String> usersToUnshare = new ArrayList<>(usernamesToUnshare);
+        if (usernamesToUnshare.indexOf(friendGroupUid) > -1) {
+            for (String name : currentSharedWithUsernames) {
+                if (usersToUnshare.indexOf(name) == -1 && friendNames.indexOf(name) > -1) {
+                    usersToUnshare.add(name);
+                }
+            }
+        }
+        if (usernamesToUnshare.indexOf(followersGroupUid) > -1) {
+            for (String name: currentSharedWithUsernames) {
+                if (usersToUnshare.indexOf(name) == -1 && followerNames.indexOf(name) > -1) {
+                    usersToUnshare.add(name);
+                }
+            }
+            if (currentSharedWithUsernames.indexOf(friendGroupUid) > -1) {
+                usersToUnshare.add(friendGroupUid);
+            }
+        }
+        return new HashSet<>(usersToUnshare);
+    }
+
+    @JsMethod
+    public CompletableFuture<Boolean> unShareReadAccessGroupAware(FileWrapper file, String[] readers) {
+        return file.getPath(network).thenCompose(pathString ->
+            getSocialState().thenCompose(social -> sharedWith(Paths.get(pathString))
+                .thenCompose(fileSharingState -> {
+                    List<String> currentReadAccess = new ArrayList<>(fileSharingState.readAccess);
+                    Set<String> readersToUnShare = gatherAllUsernamesToUnshare(social, currentReadAccess, Arrays.asList(readers));
+                    return unShareReadAccess(Paths.get(pathString), readersToUnShare);
+                }))
+        );
+    }
+
     @JsMethod
     public CompletableFuture<Boolean> unShareWriteAccess(FileWrapper file, String[] writers) {
         Set<String> writersToUnShare = new HashSet<>(Arrays.asList(writers));
         return file.getPath(network).thenCompose(pathString ->
                 unShareWriteAccess(Paths.get(pathString), writersToUnShare)
+        );
+    }
+
+    @JsMethod
+    public CompletableFuture<Boolean> unShareWriteAccessGroupAware(FileWrapper file, String[] writers) {
+        return file.getPath(network).thenCompose(pathString ->
+                getSocialState().thenCompose(social -> sharedWith(Paths.get(pathString))
+                    .thenCompose(fileSharingState -> {
+                        List<String> currentWriteAccess = new ArrayList<>(fileSharingState.writeAccess);
+                        Set<String> writersToUnShare = gatherAllUsernamesToUnshare(social, currentWriteAccess, Arrays.asList(writers));
+                        return unShareWriteAccess(Paths.get(pathString), writersToUnShare);
+                    }))
         );
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1433,7 +1433,6 @@ public class UserContext {
                                                     Set<String> usernamesToUnshare) {
 
         Set<String> followers = social.getFollowers();
-        Set<String> following = social.getFollowing();
         Set<String> friends = social.getFriends();
 
         String friendGroupUid = social.getFriendsGroupUid();
@@ -1441,18 +1440,14 @@ public class UserContext {
 
         Set<String> usersToUnshare = new HashSet<>(usernamesToUnshare);
         if (usernamesToUnshare.contains(friendGroupUid)) {
-            for (String name : currentSharedWithUsernames) {
-                if (! usersToUnshare.contains(name) && friends.contains(name)) {
-                    usersToUnshare.add(name);
-                }
-            }
+            HashSet<String> toAdd = new HashSet<>(currentSharedWithUsernames);
+            toAdd.retainAll(friends);
+            usersToUnshare.addAll(toAdd);
         }
         if (usernamesToUnshare.contains(followersGroupUid)) {
-            for (String name: currentSharedWithUsernames) {
-                if (! usersToUnshare.contains(name) && followers.contains(name)) {
-                    usersToUnshare.add(name);
-                }
-            }
+            HashSet<String> toAdd = new HashSet<>(currentSharedWithUsernames);
+            toAdd.retainAll(followers);
+            usersToUnshare.addAll(toAdd);
             if (currentSharedWithUsernames.contains(friendGroupUid)) {
                 usersToUnshare.add(friendGroupUid);
             }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1093,7 +1093,7 @@ public class UserContext {
         return processFollowRequests()
                 .thenCompose(pending -> getFollowerRoots().thenCompose(
                         followerRoots -> getFriendRoots().thenCompose(
-                                followingRoots -> getFollowers().thenCompose(
+                                followingRoots -> getFollowerNames().thenCompose(
                                         followers -> getFriendAnnotations().thenCompose(
                                                 annotations -> getGroupNameMappings().thenApply(
                                                         groups -> new SocialState(pending, followers, followerRoots, followingRoots, annotations, groups.uidToGroupName)))))));

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1743,8 +1743,8 @@ public class UserContext {
                         String theirName = freq.entry.get().ownerName;
                         FileWrapper ourDirForThem = followerRoots.get(theirName);
                         byte[] ourKeyForThem = ourDirForThem.getKey().serialize();
-                        byte[] keyFromResponse = freq.key.map(k -> k.serialize()).orElse(null);
-                        if (keyFromResponse == null || !Arrays.equals(keyFromResponse, ourKeyForThem)) {
+                        Optional<byte[]> keyFromResponse = freq.key.map(Cborable::serialize);
+                        if (keyFromResponse.isEmpty()) {
                             // They didn't reciprocate (follow us)
                             CompletableFuture<FileWrapper> removeDir = ourDirForThem.remove(sharing,
                                     Paths.get(username, SHARED_DIR_NAME, theirName), this);

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1760,7 +1760,8 @@ public class UserContext {
                             CompletableFuture<FileWrapper> removeDir = ourDirForThem.remove(sharing,
                                     Paths.get(username, SHARED_DIR_NAME, theirName), this);
 
-                            return removeDir.thenCompose(b -> addToStatic.apply(trie, p));
+                            return removeDir.thenCompose(x -> removeFromPendingOutgoing(freq.entry.get().ownerName))
+                                    .thenCompose(b -> addToStatic.apply(trie, p));
                         } else if (freq.entry.get().pointer.isNull()) {
                             // They reciprocated, but didn't accept (they follow us, but we can't follow them)
                             // add entry point to static data to signify their acceptance

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1745,7 +1745,8 @@ public class UserContext {
                                         .thenApply(b -> newRoot);
                             });
                         }
-                        return CompletableFuture.completedFuture(root);
+                        return network.social.removeFollowRequest(signer.publicKeyHash, signer.secret.signMessage(p.cipher.serialize()))
+                                .thenApply(b -> root);
                     };
 
                     BiFunction<TrieNode, FollowRequestWithCipherText, CompletableFuture<TrieNode>> mozart = (trie, p) -> {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1767,7 +1767,8 @@ public class UserContext {
         if (path.equals("/"))
             return CompletableFuture.completedFuture(Optional.of(FileWrapper.createRoot(entrie)));
         FileProperties.ensureValidPath(path);
-        return entrie.getByPath(path.startsWith("/") ? path : "/" + path, crypto.hasher, network);
+        String absolutePath = path.startsWith("/") ? path : "/" + path;
+        return entrie.getByPath(absolutePath, crypto.hasher, network);
     }
 
     public CompletableFuture<FileWrapper> getUserRoot() {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1247,9 +1247,9 @@ public class UserContext {
                                                     // note that we have a pending request sent to them
                                                     PendingSocialState updated = pending.withPending(targetUsername);
                                                     byte[] raw = updated.toCbor().serialize();
-                                                    return getUserRoot().thenCompose(home -> home.uploadOrReplaceFile(
-                                                            SOCIAL_STATE_FILENAME, AsyncReader.build(raw), raw.length,
-                                                            network, crypto, x -> {}, crypto.random.randomBytes(32)))
+                                                    return getUserRoot().thenCompose(home -> home.uploadFileSection(
+                                                            SOCIAL_STATE_FILENAME, AsyncReader.build(raw), true, 0, raw.length, Optional.empty(),
+                                                            true, network, crypto, x -> {}, crypto.random.randomBytes(32)))
                                                             .thenApply(x -> b);
                                                 }));
                             });

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1223,7 +1223,7 @@ public class UserContext {
         return unShareWriteAccess(path, Collections.singleton(writerToRemove));
     }
 
-    public CompletableFuture<Boolean> unShareWriteAccess(Path path, Set<String> writersToRemove) {
+    private CompletableFuture<Boolean> unShareWriteAccess(Path path, Set<String> writersToRemove) {
         // 1. Authorise new writer pair as an owned key to parent's writer
         // 2. Rotate all keys (except data keys which are marked as dirty)
         // 3. Update link from parent to point ot new rotated child
@@ -1332,7 +1332,7 @@ public class UserContext {
         );
     }
 
-    public CompletableFuture<Boolean> unShareReadAccess(Path path, Set<String> readersToRemove) {
+    private CompletableFuture<Boolean> unShareReadAccess(Path path, Set<String> readersToRemove) {
         String pathString = path.toString();
         String absolutePathString = pathString.startsWith("/") ? pathString : "/" + pathString;
         return getByPath(absolutePathString).thenCompose(opt -> {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -984,6 +984,7 @@ public class UserContext {
         return getSharingFolder()
                 .thenCompose(sharing -> sharing.getChildren(crypto.hasher, network))
                 .thenApply(children -> children.stream()
+                        .filter(c -> ! c.getName().startsWith(".") && ! c.getName().startsWith(GROUPS_FILENAME))
                         .collect(Collectors.toMap(e -> e.getFileProperties().name, e -> e)));
     }
 

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -312,7 +312,7 @@ public class WriterData implements Cborable {
         Optional<Multihash> owned = m.getOptional("owned", val -> ((CborObject.CborMerkleLink)val).target);
 
         Map<String, OwnerProof> named = m.getOptional("named", c -> (CborObject.CborMap)c)
-                .map(map -> map.getMap(k -> ((CborObject.CborString)k).value, OwnerProof::fromCbor))
+                .map(map -> map.toMap(k -> ((CborObject.CborString)k).value, OwnerProof::fromCbor))
                 .orElseGet(() -> Collections.emptyMap());
 
         Optional<UserStaticData> staticData = m.getOptional("static", UserStaticData::fromCbor);

--- a/src/peergos/shared/util/FileUtils.java
+++ b/src/peergos/shared/util/FileUtils.java
@@ -1,0 +1,42 @@
+package peergos.shared.util;
+
+import peergos.shared.cbor.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+
+import java.nio.file.*;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+public class FileUtils {
+
+    /** Get and parse an object from a file, or create and save an object if file doesn't exist
+     *
+     * @param context
+     * @param file
+     * @param generator
+     * @param parser
+     * @param <T>
+     * @return
+     */
+    public static <T extends Cborable> CompletableFuture<T> getOrCreateObject(UserContext context,
+                                                                              Path file,
+                                                                              Supplier<T> generator,
+                                                                              Function<T, CompletableFuture<Boolean>> initializer,
+                                                                              Function<byte[], T> parser) {
+        return context.getByPath(file).thenCompose(opt -> {
+            if (opt.isPresent())
+                return opt.get().getInputStream(context.network, context.crypto, x -> {})
+                        .thenCompose(in -> Serialize.readFully(in, opt.get().getSize()))
+                        .thenApply(parser);
+            T val = generator.get();
+            byte[] raw = val.serialize();
+            String filename = file.getFileName().toString();
+            AsyncReader reader = AsyncReader.build(raw);
+            return initializer.apply(val).thenCompose(x -> context.getByPath(file.getParent()))
+                    .thenCompose(dopt -> dopt.get()
+                            .uploadAndReturnFile(filename, reader, raw.length, false, context.network, context.crypto))
+                    .thenApply(x -> val);
+        });
+    }
+}

--- a/src/peergos/shared/util/Serialize.java
+++ b/src/peergos/shared/util/Serialize.java
@@ -2,11 +2,13 @@ package peergos.shared.util;
 
 import jsinterop.annotations.*;
 import peergos.shared.*;
+import peergos.shared.cbor.*;
 import peergos.shared.user.fs.*;
 
 import java.io.*;
 import java.util.Arrays;
 import java.util.concurrent.*;
+import java.util.function.*;
 
 public class Serialize
 {
@@ -108,6 +110,12 @@ public class Serialize
     public static CompletableFuture<byte[]> readFully(AsyncReader in, long size) {
         byte[] res = new byte[(int)size];
         return in.readIntoArray(res, 0, (int) size).thenApply(i -> res);
+    }
+
+    public static <T> CompletableFuture<T> parse(AsyncReader in, long size, Function<Cborable, T> parser) {
+        byte[] res = new byte[(int)size];
+        return in.readIntoArray(res, 0, (int) size)
+                .thenApply(i -> Cborable.parser(parser).apply(res));
     }
 
     public static CompletableFuture<Boolean> readFullArray(AsyncReader in, byte[] result) {


### PR DESCRIPTION
This gives an O(1) way to share something with an arbitrarily large group of people.
You can define your own groups.

Members of a group cannot see:
 1) other members in the group
 2) how many members there are
 3) the name of the group

 The most important groups are two predefined ones for friends and followers

When a user is removed from a group we need to rotate keys for everything ever shared with that group. This is clearly expensive, but also a rare operation in normal usage. 