### PR TITLE
Allow signup via CLI

### DIFF
--- a/src/peergos/server/cli/CLI.java
+++ b/src/peergos/server/cli/CLI.java
@@ -584,7 +584,8 @@ public class CLI implements Runnable {
 
         boolean isRegistered = networkAccess.isUsernameRegistered(username).join();
         if (! isRegistered) {
-            writer.println("To create account, enter password");
+            writer.println("To create account, enter password,");
+            writer.println("we recommend a random alphanumeric password longer than 12 characters");
             String password = reader.readLine(PROMPT, PASSWORD_MASK);
             writer.println("Re-enter password");
             String password2 = reader.readLine(PROMPT, PASSWORD_MASK);


### PR DESCRIPTION
This is important for people self-hosting, but without a public https interface. 

I.e. they always access it via another peergos instance, e.g. on localhost. 