### PR TITLE
Sign in without boxer

### DIFF
--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -136,6 +136,7 @@ public abstract class UserTests {
         String extraSalt = ArrayOps.bytesToHex(crypto.random.randomBytes(32));
         List<ScryptGenerator> params = Arrays.asList(
                 new ScryptGenerator(17, 8, 1, 96, extraSalt),
+                new ScryptGenerator(17, 8, 1, 64, extraSalt),
                 new ScryptGenerator(18, 8, 1, 96, extraSalt),
                 new ScryptGenerator(19, 8, 1, 96, extraSalt),
                 new ScryptGenerator(17, 9, 1, 96, extraSalt)
@@ -156,7 +157,7 @@ public abstract class UserTests {
 
         SafeRandomJava random = new SafeRandomJava();
         UserUtil.generateUser(username, password, new ScryptJava(), new Salsa20Poly1305Java(),
-                random, new Ed25519Java(), new Curve25519Java(), SecretGenerationAlgorithm.getDefault(random)).thenAccept(userWithRoot -> {
+                random, new Ed25519Java(), new Curve25519Java(), SecretGenerationAlgorithm.getLegacy(random)).thenAccept(userWithRoot -> {
 		    PublicSigningKey expected = PublicSigningKey.fromString("7HvEWP6yd1UD8rOorfFrieJ8S7yC8+l3VisV9kXNiHmI7Eav7+3GTRSVBRCymItrzebUUoCi39M6rdgeOU9sXXFD");
 		    if (! expected.equals(userWithRoot.getUser().publicSigningKey))
 		        throw new IllegalStateException("Generated user different from the Javascript! \n"+userWithRoot.getUser().publicSigningKey + " != \n"+expected);

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -295,10 +295,13 @@ public abstract class UserTests {
         String username = generateUsername();
         String password = "password";
         UserContext userContext = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        PublicBoxingKey initialBoxer = userContext.getPublicKeys(username).join().get().right;
         String newPassword = "newPassword";
         userContext.changePassword(password, newPassword).get();
         MultiUserTests.checkUserValidity(network, username);
 
+        PublicBoxingKey newBoxer = userContext.getPublicKeys(username).join().get().right;
+        Assert.assertTrue(newBoxer.equals(initialBoxer));
         UserContext changedPassword = PeergosNetworkUtils.ensureSignedUp(username, newPassword, network, crypto);
 
         // change it again

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -312,6 +312,25 @@ public abstract class UserTests {
     }
 
     @Test
+    public void legacyLogin() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext userContext = UserContext.signUpGeneral(username, password, "", LocalDate.now().plusMonths(2),
+                network, crypto, SecretGenerationAlgorithm.getLegacy(crypto.random), x -> {}).join();
+        PublicBoxingKey initialBoxer = userContext.getPublicKeys(username).join().get().right;
+
+        UserContext login = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+
+        String newPassword = "newPassword";
+        userContext.changePassword(password, newPassword).get();
+        MultiUserTests.checkUserValidity(network, username);
+
+        UserContext changedPassword = PeergosNetworkUtils.ensureSignedUp(username, newPassword, network, crypto);
+        PublicBoxingKey newBoxer = changedPassword.getPublicKeys(username).join().get().right;
+        Assert.assertTrue(newBoxer.equals(initialBoxer));
+    }
+
+    @Test
     public void ownerUpdateAfterPasswordChange() throws Exception {
         String username = generateUsername();
         String password = "password";

--- a/src/peergos/shared/crypto/BoxingKeyPair.java
+++ b/src/peergos/shared/crypto/BoxingKeyPair.java
@@ -24,7 +24,7 @@ public class BoxingKeyPair implements Cborable
                 secretBoxingKey.toCbor()));
     }
 
-    public static BoxingKeyPair fromCbor(CborObject cbor) {
+    public static BoxingKeyPair fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborList))
             throw new IllegalStateException("Incorrect cbor for SigningKeyPair: " + cbor);
 

--- a/src/peergos/shared/user/RandomSecretType.java
+++ b/src/peergos/shared/user/RandomSecretType.java
@@ -21,6 +21,11 @@ public class RandomSecretType implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public boolean includesBoxerGeneration() {
+        return false;
+    }
+
+    @Override
     public Type getType() {
         return Type.Random;
     }

--- a/src/peergos/shared/user/RandomSecretType.java
+++ b/src/peergos/shared/user/RandomSecretType.java
@@ -26,6 +26,11 @@ public class RandomSecretType implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public SecretGenerationAlgorithm withoutBoxer() {
+        return this;
+    }
+
+    @Override
     public Type getType() {
         return Type.Random;
     }

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -30,6 +30,11 @@ public class ScryptGenerator implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public SecretGenerationAlgorithm withoutBoxer() {
+        return new ScryptGenerator(memoryCost, cpuCost, parallelism, 64, extraSalt);
+    }
+
+    @Override
     public String getExtraSalt() {
         return extraSalt;
     }

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -25,6 +25,11 @@ public class ScryptGenerator implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public boolean includesBoxerGeneration() {
+        return outputBytes == 96;
+    }
+
+    @Override
     public String getExtraSalt() {
         return extraSalt;
     }

--- a/src/peergos/shared/user/SecretGenerationAlgorithm.java
+++ b/src/peergos/shared/user/SecretGenerationAlgorithm.java
@@ -33,7 +33,13 @@ public interface SecretGenerationAlgorithm extends Cborable {
 
     String getExtraSalt();
 
+    boolean includesBoxerGeneration();
+
     static SecretGenerationAlgorithm getDefault(SafeRandom rnd) {
+        return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 64, generateSalt(rnd));
+    }
+
+    static SecretGenerationAlgorithm getLegacy(SafeRandom rnd) {
         return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 96, generateSalt(rnd));
     }
 

--- a/src/peergos/shared/user/SecretGenerationAlgorithm.java
+++ b/src/peergos/shared/user/SecretGenerationAlgorithm.java
@@ -35,6 +35,8 @@ public interface SecretGenerationAlgorithm extends Cborable {
 
     boolean includesBoxerGeneration();
 
+    SecretGenerationAlgorithm withoutBoxer();
+
     static SecretGenerationAlgorithm getDefault(SafeRandom rnd) {
         return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 64, generateSalt(rnd));
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -698,7 +698,8 @@ public class UserContext {
     @JsMethod
     public CompletableFuture<UserContext> changePassword(String oldPassword, String newPassword) {
         return getKeyGenAlgorithm().thenCompose(alg -> {
-            SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random);
+            // Use a new salt, and if this is a legacy account with generated boxer, remove it from generation
+            SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random).withoutBoxer();
             // set claim expiry to two months from now
             return changePassword(oldPassword, newPassword, alg, newAlgorithm, LocalDate.now().plusMonths(2));
         });
@@ -745,7 +746,7 @@ public class UserContext {
                                                 wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient, network.hasher))
                                                 .thenCompose(version -> version.get(signer).props.changeKeys(signer,
                                                         newSigner,
-                                                        newBoxingKeypair.publicBoxingKey,
+                                                        newBoxingKeypair,
                                                         existingUser.getRoot(),
                                                         updatedUser.getRoot(),
                                                         newAlgorithm,

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -720,6 +720,8 @@ public class UserContext {
                             .thenCompose(updatedUser -> {
                                 PublicSigningKey newPublicSigningKey = updatedUser.getUser().publicSigningKey;
                                 PublicKeyHash existingOwner = ContentAddressedStorage.hashKey(existingUser.getUser().publicSigningKey);
+
+                                BoxingKeyPair newBoxingKeypair = newAlgorithm.includesBoxerGeneration() ? updatedUser.getBoxingPair() : boxer;
                                 return IpfsTransaction.call(existingOwner,
                                         tid -> network.dhtClient.putSigningKey(
                                                 existingUser.getUser().secretSigningKey.signMessage(newPublicSigningKey.serialize()),
@@ -743,7 +745,7 @@ public class UserContext {
                                                 wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient, network.hasher))
                                                 .thenCompose(version -> version.get(signer).props.changeKeys(signer,
                                                         newSigner,
-                                                        updatedUser.getBoxingPair().publicBoxingKey,
+                                                        newBoxingKeypair.publicBoxingKey,
                                                         existingUser.getRoot(),
                                                         updatedUser.getRoot(),
                                                         newAlgorithm,

--- a/src/peergos/shared/user/UserStaticData.java
+++ b/src/peergos/shared/user/UserStaticData.java
@@ -41,7 +41,7 @@ public class UserStaticData implements Cborable {
 
         private final long version;
         public final List<EntryPoint> entries;
-        public final Optional<BoxingKeyPair> boxer;
+        public final Optional<BoxingKeyPair> boxer; // this is only absent on legacy accounts
 
         public EntryPoints(long version, List<EntryPoint> entries, Optional<BoxingKeyPair> boxer) {
             this.version = version;

--- a/src/peergos/shared/user/UserUtil.java
+++ b/src/peergos/shared/user/UserUtil.java
@@ -25,8 +25,10 @@ public class UserUtil {
         CompletableFuture<byte[]> fut = hasher.hashToKeyBytes(username + algorithm.getExtraSalt(), password, algorithm);
         return fut.thenApply(keyBytes -> {
             byte[] signBytesSeed = Arrays.copyOfRange(keyBytes, 0, 32);
-            byte[] secretBoxBytes = Arrays.copyOfRange(keyBytes, 32, 64);
-            byte[] rootKeyBytes = Arrays.copyOfRange(keyBytes, 64, 96);
+            boolean hasBoxer = algorithm.includesBoxerGeneration();
+            byte[] secretBoxBytes = hasBoxer ? Arrays.copyOfRange(keyBytes, 32, 64) : random.randomBytes(32);
+
+            byte[] rootKeyBytes = Arrays.copyOfRange(keyBytes, hasBoxer ? 64 : 32, hasBoxer ? 96 : 64);
 	
             byte[] secretSignBytes = Arrays.copyOf(signBytesSeed, 64);
             byte[] publicSignBytes = new byte[32];

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -187,6 +187,7 @@ public class WriterData implements Cborable {
                                                                           SigningPrivateKeyAndPublicHash writer,
                                                                           Optional<PublicKeyHash> followRequestReceiver,
                                                                           SymmetricKey rootKey,
+                                                                          Optional<BoxingKeyPair> boxer,
                                                                           SecretGenerationAlgorithm algorithm,
                                                                           ContentAddressedStorage ipfs,
                                                                           Hasher hasher,
@@ -198,7 +199,7 @@ public class WriterData implements Cborable {
                         followRequestReceiver,
                         Optional.of(ownedRoot),
                         Collections.emptyMap(),
-                        Optional.of(new UserStaticData(rootKey)),
+                        Optional.of(new UserStaticData(Collections.emptyList(), rootKey, boxer)),
                         Optional.empty()));
     }
 
@@ -219,7 +220,7 @@ public class WriterData implements Cborable {
         return network.synchronizer.applyUpdate(oldSigner.publicKeyHash, signer,
                 (wd, tid) -> {
                     Optional<UserStaticData> newEntryPoints = staticData
-                            .map(sd -> new UserStaticData(sd.getEntryPoints(currentKey), newKey));
+                            .map(sd -> new UserStaticData(sd.getData(currentKey).entries, newKey, sd.getData(currentKey).boxer));
                     return network.hasher.sha256(followRequestReceiver.serialize())
                             .thenCompose(boxerHash -> network.dhtClient.putBoxingKey(oldSigner.publicKeyHash,
                             oldSigner.secret.signMessage(boxerHash),


### PR DESCRIPTION
This upgrades sign in to not generate a boxing key pair. 

Key requirements:
1) New sign ups are in the new scheme
2) Legacy accounts can still login
3) Changing your password will upgrade a legacy account, and keep the same boxing keypair