### PR TITLE
Remove unnecessary props update when there is no thumbnail

### DIFF
--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1021,6 +1021,8 @@ public class FileWrapper {
                                                                    Optional<byte[]> streamSecret) {
         return generateThumbnail(network, fileData, (int) Math.min(fileSize, Integer.MAX_VALUE), fileName, mimeType)
                 .thenCompose(thumbData -> {
+                    if (thumbData.isEmpty())
+                        return Futures.of(base);
                     FileProperties fileProps = new FileProperties(fileName, false, props.isLink, mimeType, fileSize,
                             updatedDateTime, isHidden, thumbData, streamSecret);
 


### PR DESCRIPTION
This should make uploading small files 33% faster (2 champ puts instead of 3)