### PR TITLE
Optimise GC in S3 setting

### DIFF
--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -22,6 +22,12 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
 
     void delete(Multihash hash);
 
+    default void bulkDelete(List<Multihash> blocks) {
+        for (Multihash block : blocks) {
+            delete(block);
+        }
+    }
+
     List<Multihash> getOpenTransactionBlocks();
 
     /** Ensure that local copies of all blocks in merkle tree referenced are present locally

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -141,7 +141,7 @@ public class GarbageCollector {
                 int size = getWithBackoff(() -> storage.getSize(hash).join().get());
                 deletedBlocks++;
                 deletedSize += size;
-                storage.delete(hash);
+                getWithBackoff(() -> {storage.delete(hash); return true;});
             } catch (Exception e) {
                 LOG.info("GC Unable to read " + hash + " during delete phase, ignoring block and continuing.");
             }

--- a/src/peergos/server/util/HttpUtil.java
+++ b/src/peergos/server/util/HttpUtil.java
@@ -80,22 +80,26 @@ public class HttpUtil {
         }
     }
 
-    public static Map<String, List<String>> head(PresignedUrl head) throws Exception {
-        HttpURLConnection conn = (HttpURLConnection) new URI(head.base).toURL().openConnection();
-        conn.setRequestMethod("HEAD");
-        for (Map.Entry<String, String> e : head.fields.entrySet()) {
-            conn.setRequestProperty(e.getKey(), e.getValue());
-        }
-
+    public static Map<String, List<String>> head(PresignedUrl head) throws IOException {
         try {
-            int resp = conn.getResponseCode();
-            if (resp == 200)
-                return conn.getHeaderFields();
-            throw new IllegalStateException("HTTP " + resp + " " + head.base);
-        } catch (IOException e) {
-            InputStream err = conn.getErrorStream();
-            byte[] errBody = Serialize.readFully(err);
-            throw new IllegalStateException(new String(errBody));
+            HttpURLConnection conn = (HttpURLConnection) new URI(head.base).toURL().openConnection();
+            conn.setRequestMethod("HEAD");
+            for (Map.Entry<String, String> e : head.fields.entrySet()) {
+                conn.setRequestProperty(e.getKey(), e.getValue());
+            }
+
+            try {
+                int resp = conn.getResponseCode();
+                if (resp == 200)
+                    return conn.getHeaderFields();
+                throw new IllegalStateException("HTTP " + resp + " " + head.base);
+            } catch (IOException e) {
+                InputStream err = conn.getErrorStream();
+                byte[] errBody = Serialize.readFully(err);
+                throw new IOException(new String(errBody));
+            }
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Remove log spam when getSize calls are rate limited.

Retry delete calls with backoff.

Use bulk delete calls. 