### PR TITLE
Rewrite Chat implementation

### DIFF
--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -87,14 +87,10 @@ public class PeergosFileSystemImpl implements FileSystem {
         Set<String> userSet = Stream.of(user).collect(Collectors.toSet());
         switch (permission) {
             case READ:
-                if(! userContext.shareReadAccessWith(path, userSet).join()){
-                    throw new Error("unable to grant read access");
-                }
+                userContext.shareReadAccessWith(path, userSet).join();
                 return;
             case WRITE:
-                if(! userContext.shareWriteAccessWith(path, userSet).join()){
-                    throw new Error("unable to grant write access");
-                }
+                userContext.shareWriteAccessWith(path, userSet).join();
                 return;
         }
         throw new IllegalStateException();

--- a/src/peergos/server/social/NonWriteThroughSocialNetwork.java
+++ b/src/peergos/server/social/NonWriteThroughSocialNetwork.java
@@ -38,7 +38,7 @@ public class NonWriteThroughSocialNetwork implements SocialNetwork {
     @Override
     public CompletableFuture<byte[]> getFollowRequests(PublicKeyHash owner, byte[] signedTime) {
         try {
-            byte[] reqs = source.getFollowRequests(owner, signedTime).get();
+            byte[] reqs = source.getFollowRequests(owner, signedTime).join();
             CborObject cbor = CborObject.fromByteArray(reqs);
             List<byte[]> notDeleted = new ArrayList<>();
             List<ByteArrayWrapper> removed = removedFollowRequests.get(owner);
@@ -67,7 +67,7 @@ public class NonWriteThroughSocialNetwork implements SocialNetwork {
     @Override
     public CompletableFuture<Boolean> removeFollowRequest(PublicKeyHash owner, byte[] signedEncryptedPermission) {
         try {
-            PublicSigningKey signer = ipfs.getSigningKey(owner).get().get();
+            PublicSigningKey signer = ipfs.getSigningKey(owner).join().get();
             byte[] unsigned = signer.unsignMessage(signedEncryptedPermission);
 
             newFollowRequests.putIfAbsent(owner, new ArrayList<>());

--- a/src/peergos/server/tests/InodeFilesystemTests.java
+++ b/src/peergos/server/tests/InodeFilesystemTests.java
@@ -179,11 +179,11 @@ public class InodeFilesystemTests {
         SigningKeyPair random = SigningKeyPair.random(crypto.random, crypto.signer);
         try {
             PublicKeyHash ownerHash = ContentAddressedStorage.hashKey(random.publicSigningKey);
-            TransactionId tid = storage.startTransaction(ownerHash).get();
+            TransactionId tid = storage.startTransaction(ownerHash).join();
             PublicKeyHash publicHash = storage.putSigningKey(
                     random.secretSigningKey.signMessage(random.publicSigningKey.serialize()),
                     ownerHash,
-                    random.publicSigningKey, tid).get();
+                    random.publicSigningKey, tid).join();
             return new SigningPrivateKeyAndPublicHash(publicHash, random.secretSigningKey);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/peergos/server/tests/IpfsUserTests.java
+++ b/src/peergos/server/tests/IpfsUserTests.java
@@ -30,7 +30,7 @@ public class IpfsUserTests extends UserTests {
         UserService service = Main.PKI_INIT.main(args);
         return Arrays.asList(new Object[][] {
                 {
-                        Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).get(),
+                        Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).join(),
                         service
                 }
         });

--- a/src/peergos/server/tests/MessagingTests.java
+++ b/src/peergos/server/tests/MessagingTests.java
@@ -10,6 +10,7 @@ import peergos.shared.display.*;
 import peergos.shared.messaging.*;
 import peergos.shared.messaging.messages.*;
 import peergos.shared.storage.*;
+import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -31,166 +32,176 @@ public class MessagingTests {
         List<PrivateChatState> chatIdentities = generateChatIdentities(2);
         List<RamMessageStore> stores = IntStream.range(0, 2).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
 
-        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
+        Chat chat1 = Chat.createNew("uid", "user1", identities.get(0).publicKeyHash);
         OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_1);
 
-        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-        Chat chat2 = chat1.copy(user2);
-        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
+        ChatUpdate u1_2 = u1_1.state.inviteMember("user2", identities.get(1).publicKeyHash,
+                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_2);
+        Member user2 = u1_2.state.getMember("user2");
+        Chat chat2 = u1_2.state.copy(user2);
+//        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
         stores.get(1).mirror(stores.get(0));
         OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
+        ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_1);
 
-        MessageEnvelope msg1 = chat1.addMessage(text("Welcome!"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
-        chat2.merge("chat-uid", chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
+        ChatUpdate u1_3 = u1_2.state.sendMessage(text("Welcome!"), chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_3);
+        MessageEnvelope msg1 = u1_3.newMessages.get(u1_3.newMessages.size() - 1).msg;
+        ChatUpdate u2_2 = u2_1.state.merge("chat-uid", chat1.host, stores.get(0), ipfs).join();
+        stores.get(1).apply(u2_2);
         Assert.assertTrue(stores.get(1).messages.get(3).msg.equals(msg1));
 
         ReplyTo reply = ReplyTo.build(msg1, text("This is cool!"), hasher).join();
-        MessageEnvelope msg2 = chat2.addMessage(reply, chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
+        ChatUpdate u2_3 = u2_2.state.sendMessage(reply, chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_3);
+        MessageEnvelope msg2 = u2_3.newMessages.get(u2_3.newMessages.size() - 1).msg;;
 
-        chat1.merge("chat-uid", chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
+        ChatUpdate u1_4 = u1_3.state.merge("chat-uid", chat2.host, stores.get(1), ipfs).join();
+        stores.get(0).apply(u1_4);
         Assert.assertTrue(stores.get(0).messages.get(4).msg.equals(msg2));
     }
 
-    @Test
-    public void multipleInvites() {
-        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
-        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
-        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
-
-        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
-        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
-
-        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-        Chat chat2 = chat1.copy(user2);
-        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
-        stores.get(1).mirror(stores.get(0));
-        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
-
-        Member user3 = chat1.inviteMember("user3", identities.get(2).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-        Chat chat3 = chat1.copy(user3);
-        chat3.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
-        stores.get(2).mirror(stores.get(0));
-        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(0), NO_OP, hasher).join();
-
-        Assert.assertTrue(! user2.id.equals(user3.id));
-    }
-
-    @Test
-    public void messagePropagation() {
-        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
-        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
-        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
-
-        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
-        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
-
-        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-        Chat chat2 = chat1.copy(user2);
-        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
-        stores.get(1).mirror(stores.get(0));
-        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
-
-        Member user3 = chat2.inviteMember("user3", identities.get(2).publicKeyHash,
-                chatIdentities.get(1).chatIdentity, stores.get(1), NO_OP, hasher).join();
-        Chat chat3 = chat2.copy(user3);
-        chat3.host().messagesMergedUpto = chat2.host().messagesMergedUpto;
-        stores.get(2).mirror(stores.get(1));
-        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), NO_OP, hasher).join();
-
-        MessageEnvelope msg1 = chat3.addMessage(text("Hey All!"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
-        chat2.merge("chat-uid", chat3.host, stores.get(2), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-        Assert.assertTrue(stores.get(1).messages.get(5).msg.equals(msg1));
-
-        chat1.merge("chat-uid", chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-        Assert.assertTrue(stores.get(0).messages.get(5).msg.equals(msg1));
-    }
-
-    @Test
-    public void partitionAndJoin() {
-        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(4);
-        List<PrivateChatState> chatIdentities = generateChatIdentities(4);
-        List<RamMessageStore> stores = IntStream.range(0, 4).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
-
-        List<Chat> chats = Chat.createNew(
-                Arrays.asList("user1", "user2", "user3", "user4"),
-                identities.stream().map(p -> p.publicKeyHash).collect(Collectors.toList()));
-        TreeClock genesis = chats.get(0).current;
-        Chat chat1 = chats.get(0);
-        Chat chat2 = chats.get(1);
-        Chat chat3 = chats.get(2);
-        Chat chat4 = chats.get(3);
-        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
-
-        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        chat2.join(chat2.host(), user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
-
-        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-        chat3.join(chat3.host(), user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), NO_OP, hasher).join();
-
-        OwnerProof user4ChatId = OwnerProof.build(identities.get(3), chatIdentities.get(3).chatIdentity.publicKeyHash);
-        chat4.join(chat4.host(), user4ChatId, chatIdentities.get(3).chatIdPublic, identities.get(3), stores.get(3), NO_OP, hasher).join();
-
-        // partition and chat between user1 and user2
-        TreeClock t1_0 = chat1.current;
-        MessageEnvelope msg1 = chat1.addMessage(text("Hey All, I'm user1!"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
-        Assert.assertTrue(msg1.timestamp.isIncrementOf(t1_0));
-
-        String chatUid = "chat-uid";
-        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-        TreeClock t2_0 = chat2.current;
-        MessageEnvelope msg2 = chat2.addMessage(text("Hey user1! I'm user2."), chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
-        Assert.assertTrue(msg2.timestamp.isIncrementOf(t2_0));
-
-        chat1.merge(chatUid, chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-        TreeClock t1_1 = chat1.current;
-        MessageEnvelope msg3 = chat1.addMessage(text("Hey user2, whats up?"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
-        Assert.assertTrue(msg3.timestamp.isIncrementOf(t1_1));
-
-        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-        TreeClock t2_1 = chat2.current;
-        MessageEnvelope msg4 = chat2.addMessage(text("Just saving the world one decentralized chat at a time.."),
-                chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
-        Assert.assertTrue(msg4.timestamp.isIncrementOf(t2_1));
-
-        chat1.merge(chatUid, chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
-        Assert.assertEquals(stores.get(1).messages.size(), 6);
-
-        // also between user3 and user4
-        MessageEnvelope msg5 = chat3.addMessage(text("Hey All, I'm user3!"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
-        chat4.merge(chatUid, chat3.host, stores.get(2), stores.get(3), ipfs, NO_OP, NO_OP2).join();
-        MessageEnvelope msg6 = chat4.addMessage(text("Hey user3! I'm user4."), chatIdentities.get(3).chatIdentity, stores.get(3), hasher).join();
-        chat3.merge(chatUid, chat4.host, stores.get(3), stores.get(2), ipfs, NO_OP, NO_OP2).join();
-        MessageEnvelope msg7 = chat3.addMessage(text("Hey user4, whats up?"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
-        chat4.merge(chatUid, chat3.host, stores.get(2), stores.get(3), ipfs, NO_OP, NO_OP2).join();
-        MessageEnvelope msg8 = chat4.addMessage(text("Just saving the world one encrypted chat at a time.."), chatIdentities.get(3).chatIdentity, stores.get(3), hasher).join();
-        chat3.merge(chatUid, chat4.host, stores.get(3), stores.get(2), ipfs, NO_OP, NO_OP2).join();
-        Assert.assertTrue(stores.get(3).messages.containsAll(stores.get(2).messages));
-        Assert.assertEquals(stores.get(3).messages.size(), 6);
-
-        // now resolve the partition and merge states
-        chat1.merge(chatUid, chat4.host, stores.get(3), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-        Assert.assertEquals(stores.get(0).messages.size(), 12);
-        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
-
-        // check ordering
-        for (int i=0; i < stores.size(); i++)
-            validateMessageLog(stores.get(i).getMessagesFrom(0).join(), genesis);
-    }
+//    @Test
+//    public void multipleInvites() {
+//        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
+//        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
+//        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
+//
+//        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
+//        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
+//        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
+//
+//        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
+//                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
+//        Chat chat2 = chat1.copy(user2);
+//        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
+//        stores.get(1).mirror(stores.get(0));
+//        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
+//        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
+//
+//        Member user3 = chat1.inviteMember("user3", identities.get(2).publicKeyHash,
+//                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
+//        Chat chat3 = chat1.copy(user3);
+//        chat3.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
+//        stores.get(2).mirror(stores.get(0));
+//        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
+//        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(0), NO_OP, hasher).join();
+//
+//        Assert.assertTrue(! user2.id.equals(user3.id));
+//    }
+//
+//    @Test
+//    public void messagePropagation() {
+//        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
+//        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
+//        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
+//
+//        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
+//        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
+//        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
+//
+//        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
+//                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
+//        Chat chat2 = chat1.copy(user2);
+//        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
+//        stores.get(1).mirror(stores.get(0));
+//        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
+//        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
+//
+//        Member user3 = chat2.inviteMember("user3", identities.get(2).publicKeyHash,
+//                chatIdentities.get(1).chatIdentity, stores.get(1), NO_OP, hasher).join();
+//        Chat chat3 = chat2.copy(user3);
+//        chat3.host().messagesMergedUpto = chat2.host().messagesMergedUpto;
+//        stores.get(2).mirror(stores.get(1));
+//        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
+//        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), NO_OP, hasher).join();
+//
+//        MessageEnvelope msg1 = chat3.sendMessage(text("Hey All!"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
+//        chat2.merge("chat-uid", chat3.host, stores.get(2), stores.get(1), ipfs, NO_OP, NO_OP2).join();
+//        Assert.assertTrue(stores.get(1).messages.get(5).msg.equals(msg1));
+//
+//        chat1.merge("chat-uid", chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
+//        Assert.assertTrue(stores.get(0).messages.get(5).msg.equals(msg1));
+//    }
+//
+//    @Test
+//    public void partitionAndJoin() {
+//        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(4);
+//        List<PrivateChatState> chatIdentities = generateChatIdentities(4);
+//        List<RamMessageStore> stores = IntStream.range(0, 4).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
+//
+//        List<Chat> chats = Chat.createNew(
+//                Arrays.asList("user1", "user2", "user3", "user4"),
+//                identities.stream().map(p -> p.publicKeyHash).collect(Collectors.toList()));
+//        TreeClock genesis = chats.get(0).current;
+//        Chat chat1 = chats.get(0);
+//        Chat chat2 = chats.get(1);
+//        Chat chat3 = chats.get(2);
+//        Chat chat4 = chats.get(3);
+//        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
+//        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
+//
+//        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
+//        chat2.join(chat2.host(), user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
+//
+//        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
+//        chat3.join(chat3.host(), user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), NO_OP, hasher).join();
+//
+//        OwnerProof user4ChatId = OwnerProof.build(identities.get(3), chatIdentities.get(3).chatIdentity.publicKeyHash);
+//        chat4.join(chat4.host(), user4ChatId, chatIdentities.get(3).chatIdPublic, identities.get(3), stores.get(3), NO_OP, hasher).join();
+//
+//        // partition and chat between user1 and user2
+//        TreeClock t1_0 = chat1.current;
+//        MessageEnvelope msg1 = chat1.sendMessage(text("Hey All, I'm user1!"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
+//        Assert.assertTrue(msg1.timestamp.isIncrementOf(t1_0));
+//
+//        String chatUid = "chat-uid";
+//        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
+//        TreeClock t2_0 = chat2.current;
+//        MessageEnvelope msg2 = chat2.sendMessage(text("Hey user1! I'm user2."), chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
+//        Assert.assertTrue(msg2.timestamp.isIncrementOf(t2_0));
+//
+//        chat1.merge(chatUid, chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
+//        TreeClock t1_1 = chat1.current;
+//        MessageEnvelope msg3 = chat1.sendMessage(text("Hey user2, whats up?"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
+//        Assert.assertTrue(msg3.timestamp.isIncrementOf(t1_1));
+//
+//        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
+//        TreeClock t2_1 = chat2.current;
+//        MessageEnvelope msg4 = chat2.sendMessage(text("Just saving the world one decentralized chat at a time.."),
+//                chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
+//        Assert.assertTrue(msg4.timestamp.isIncrementOf(t2_1));
+//
+//        chat1.merge(chatUid, chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
+//        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
+//        Assert.assertEquals(stores.get(1).messages.size(), 6);
+//
+//        // also between user3 and user4
+//        MessageEnvelope msg5 = chat3.sendMessage(text("Hey All, I'm user3!"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
+//        chat4.merge(chatUid, chat3.host, stores.get(2), stores.get(3), ipfs, NO_OP, NO_OP2).join();
+//        MessageEnvelope msg6 = chat4.sendMessage(text("Hey user3! I'm user4."), chatIdentities.get(3).chatIdentity, stores.get(3), hasher).join();
+//        chat3.merge(chatUid, chat4.host, stores.get(3), stores.get(2), ipfs, NO_OP, NO_OP2).join();
+//        MessageEnvelope msg7 = chat3.sendMessage(text("Hey user4, whats up?"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
+//        chat4.merge(chatUid, chat3.host, stores.get(2), stores.get(3), ipfs, NO_OP, NO_OP2).join();
+//        MessageEnvelope msg8 = chat4.sendMessage(text("Just saving the world one encrypted chat at a time.."), chatIdentities.get(3).chatIdentity, stores.get(3), hasher).join();
+//        chat3.merge(chatUid, chat4.host, stores.get(3), stores.get(2), ipfs, NO_OP, NO_OP2).join();
+//        Assert.assertTrue(stores.get(3).messages.containsAll(stores.get(2).messages));
+//        Assert.assertEquals(stores.get(3).messages.size(), 6);
+//
+//        // now resolve the partition and merge states
+//        chat1.merge(chatUid, chat4.host, stores.get(3), stores.get(0), ipfs, NO_OP, NO_OP2).join();
+//        Assert.assertEquals(stores.get(0).messages.size(), 12);
+//        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
+//        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
+//
+//        // check ordering
+//        for (int i=0; i < stores.size(); i++)
+//            validateMessageLog(stores.get(i).getMessagesFrom(0).join(), genesis);
+//    }
 
     private static void validateMessageLog(List<SignedMessage> msgs, TreeClock genesis) {
         TreeClock current = genesis;
@@ -230,16 +241,20 @@ public class MessagingTests {
         }
 
         @Override
-        public CompletableFuture<Boolean> addMessage(long msgIndex, SignedMessage msg) {
+        public CompletableFuture<Snapshot> addMessage(Snapshot initialVersion, Committer committer, long msgIndex, SignedMessage msg) {
             if (messages.size() != msgIndex)
                 throw new IllegalStateException();
             messages.add(msg);
-            return Futures.of(true);
+            return Futures.of(initialVersion);
         }
 
         @Override
-        public CompletableFuture<Boolean> revokeAccess(String username) {
-            return Futures.of(true);
+        public CompletableFuture<Snapshot> revokeAccess(Set<String> usernames) {
+            return Futures.of(new Snapshot(Collections.emptyMap()));
+        }
+
+        public void apply(ChatUpdate u) {
+            messages.addAll(u.newMessages);
         }
 
         public void mirror(RamMessageStore other) {

--- a/src/peergos/server/tests/MessagingTests.java
+++ b/src/peergos/server/tests/MessagingTests.java
@@ -42,7 +42,6 @@ public class MessagingTests {
         stores.get(0).apply(u1_2);
         Member user2 = u1_2.state.getMember("user2");
         Chat chat2 = u1_2.state.copy(user2);
-//        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
         stores.get(1).mirror(stores.get(0));
         OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
         ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
@@ -65,69 +64,83 @@ public class MessagingTests {
         Assert.assertTrue(stores.get(0).messages.get(4).msg.equals(msg2));
     }
 
-//    @Test
-//    public void multipleInvites() {
-//        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
-//        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
-//        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
-//
-//        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
-//        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-//        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
-//
-//        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
-//                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-//        Chat chat2 = chat1.copy(user2);
-//        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
-//        stores.get(1).mirror(stores.get(0));
-//        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-//        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
-//
-//        Member user3 = chat1.inviteMember("user3", identities.get(2).publicKeyHash,
-//                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-//        Chat chat3 = chat1.copy(user3);
-//        chat3.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
-//        stores.get(2).mirror(stores.get(0));
-//        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-//        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(0), NO_OP, hasher).join();
-//
-//        Assert.assertTrue(! user2.id.equals(user3.id));
-//    }
-//
-//    @Test
-//    public void messagePropagation() {
-//        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
-//        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
-//        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
-//
-//        Chat chat1 = Chat.createNew("user1", identities.get(0).publicKeyHash);
-//        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-//        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
-//
-//        Member user2 = chat1.inviteMember("user2", identities.get(1).publicKeyHash,
-//                chatIdentities.get(0).chatIdentity, stores.get(0), NO_OP, hasher).join();
-//        Chat chat2 = chat1.copy(user2);
-//        chat2.host().messagesMergedUpto = chat1.host().messagesMergedUpto;
-//        stores.get(1).mirror(stores.get(0));
-//        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-//        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
-//
-//        Member user3 = chat2.inviteMember("user3", identities.get(2).publicKeyHash,
-//                chatIdentities.get(1).chatIdentity, stores.get(1), NO_OP, hasher).join();
-//        Chat chat3 = chat2.copy(user3);
-//        chat3.host().messagesMergedUpto = chat2.host().messagesMergedUpto;
-//        stores.get(2).mirror(stores.get(1));
-//        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-//        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), NO_OP, hasher).join();
-//
-//        MessageEnvelope msg1 = chat3.sendMessage(text("Hey All!"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
-//        chat2.merge("chat-uid", chat3.host, stores.get(2), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-//        Assert.assertTrue(stores.get(1).messages.get(5).msg.equals(msg1));
-//
-//        chat1.merge("chat-uid", chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-//        Assert.assertTrue(stores.get(0).messages.get(5).msg.equals(msg1));
-//    }
-//
+    @Test
+    public void multipleInvites() {
+        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
+        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
+        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
+
+        Chat chat1 = Chat.createNew("uid", "user1", identities.get(0).publicKeyHash);
+        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_1);
+
+        ChatUpdate u1_2 = u1_1.state.inviteMember("user2", identities.get(1).publicKeyHash,
+                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_2);
+        Member user2 = u1_2.state.getMember("user2");
+
+        Chat chat2 = u1_2.state.copy(user2);
+        stores.get(1).mirror(stores.get(0));
+        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
+        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+
+        ChatUpdate u1_3 = u1_2.state.inviteMember("user3", identities.get(2).publicKeyHash,
+                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_3);
+        Member user3 = u1_3.state.getMember("user3");
+
+        Chat chat3 = u1_3.state.copy(user3);
+        stores.get(2).mirror(stores.get(0));
+        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
+        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(0), ipfs, hasher).join();
+
+        Assert.assertTrue(! user2.id.equals(user3.id));
+    }
+
+    @Test
+    public void messagePropagation() {
+        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(3);
+        List<PrivateChatState> chatIdentities = generateChatIdentities(3);
+        List<RamMessageStore> stores = IntStream.range(0, 3).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
+
+        Chat chat1 = Chat.createNew("uid", "user1", identities.get(0).publicKeyHash);
+        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_1);
+
+        ChatUpdate u1_2 = u1_1.state.inviteMember("user2", identities.get(1).publicKeyHash,
+                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_2);
+        Member user2 = u1_2.state.getMember("user2");
+        Chat chat2 = u1_2.state.copy(user2);
+        stores.get(1).mirror(stores.get(0));
+        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
+        ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_1);
+
+        ChatUpdate u2_2 = u2_1.state.inviteMember("user3", identities.get(2).publicKeyHash,
+                chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_2);
+        Member user3 = u2_2.state.getMember("user3");
+        Chat chat3 = u2_2.state.copy(user3);
+        stores.get(2).mirror(stores.get(1));
+        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
+        ChatUpdate u3_1 = chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), ipfs, hasher).join();
+        stores.get(2).apply(u3_1);
+
+        ChatUpdate u3_2 = u3_1.state.sendMessage(text("Hey All!"), chatIdentities.get(2).chatIdentity, stores.get(2), ipfs, hasher).join();
+        stores.get(2).apply(u3_2);
+        MessageEnvelope msg1 = u3_2.newMessages.get(u3_2.newMessages.size() - 1).msg;
+        ChatUpdate u2_3 = u2_2.state.merge("chat-uid", chat3.host, stores.get(2), ipfs).join();
+        stores.get(1).apply(u2_3);
+        Assert.assertTrue(stores.get(1).messages.get(5).msg.equals(msg1));
+
+        ChatUpdate u1_3 = u1_2.state.merge("chat-uid", chat2.host, stores.get(1), ipfs).join();
+        stores.get(0).apply(u1_3);
+        Assert.assertTrue(stores.get(0).messages.get(5).msg.equals(msg1));
+    }
+
 //    @Test
 //    public void partitionAndJoin() {
 //        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(4);

--- a/src/peergos/server/tests/MessagingTests.java
+++ b/src/peergos/server/tests/MessagingTests.java
@@ -141,80 +141,110 @@ public class MessagingTests {
         Assert.assertTrue(stores.get(0).messages.get(5).msg.equals(msg1));
     }
 
-//    @Test
-//    public void partitionAndJoin() {
-//        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(4);
-//        List<PrivateChatState> chatIdentities = generateChatIdentities(4);
-//        List<RamMessageStore> stores = IntStream.range(0, 4).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
-//
-//        List<Chat> chats = Chat.createNew(
-//                Arrays.asList("user1", "user2", "user3", "user4"),
-//                identities.stream().map(p -> p.publicKeyHash).collect(Collectors.toList()));
-//        TreeClock genesis = chats.get(0).current;
-//        Chat chat1 = chats.get(0);
-//        Chat chat2 = chats.get(1);
-//        Chat chat3 = chats.get(2);
-//        Chat chat4 = chats.get(3);
-//        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-//        chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), NO_OP, hasher).join();
-//
-//        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-//        chat2.join(chat2.host(), user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), NO_OP, hasher).join();
-//
-//        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-//        chat3.join(chat3.host(), user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), NO_OP, hasher).join();
-//
-//        OwnerProof user4ChatId = OwnerProof.build(identities.get(3), chatIdentities.get(3).chatIdentity.publicKeyHash);
-//        chat4.join(chat4.host(), user4ChatId, chatIdentities.get(3).chatIdPublic, identities.get(3), stores.get(3), NO_OP, hasher).join();
-//
-//        // partition and chat between user1 and user2
-//        TreeClock t1_0 = chat1.current;
-//        MessageEnvelope msg1 = chat1.sendMessage(text("Hey All, I'm user1!"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
-//        Assert.assertTrue(msg1.timestamp.isIncrementOf(t1_0));
-//
-//        String chatUid = "chat-uid";
-//        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-//        TreeClock t2_0 = chat2.current;
-//        MessageEnvelope msg2 = chat2.sendMessage(text("Hey user1! I'm user2."), chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
-//        Assert.assertTrue(msg2.timestamp.isIncrementOf(t2_0));
-//
-//        chat1.merge(chatUid, chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-//        TreeClock t1_1 = chat1.current;
-//        MessageEnvelope msg3 = chat1.sendMessage(text("Hey user2, whats up?"), chatIdentities.get(0).chatIdentity, stores.get(0), hasher).join();
-//        Assert.assertTrue(msg3.timestamp.isIncrementOf(t1_1));
-//
-//        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-//        TreeClock t2_1 = chat2.current;
-//        MessageEnvelope msg4 = chat2.sendMessage(text("Just saving the world one decentralized chat at a time.."),
-//                chatIdentities.get(1).chatIdentity, stores.get(1), hasher).join();
-//        Assert.assertTrue(msg4.timestamp.isIncrementOf(t2_1));
-//
-//        chat1.merge(chatUid, chat2.host, stores.get(1), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-//        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
-//        Assert.assertEquals(stores.get(1).messages.size(), 6);
-//
-//        // also between user3 and user4
-//        MessageEnvelope msg5 = chat3.sendMessage(text("Hey All, I'm user3!"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
-//        chat4.merge(chatUid, chat3.host, stores.get(2), stores.get(3), ipfs, NO_OP, NO_OP2).join();
-//        MessageEnvelope msg6 = chat4.sendMessage(text("Hey user3! I'm user4."), chatIdentities.get(3).chatIdentity, stores.get(3), hasher).join();
-//        chat3.merge(chatUid, chat4.host, stores.get(3), stores.get(2), ipfs, NO_OP, NO_OP2).join();
-//        MessageEnvelope msg7 = chat3.sendMessage(text("Hey user4, whats up?"), chatIdentities.get(2).chatIdentity, stores.get(2), hasher).join();
-//        chat4.merge(chatUid, chat3.host, stores.get(2), stores.get(3), ipfs, NO_OP, NO_OP2).join();
-//        MessageEnvelope msg8 = chat4.sendMessage(text("Just saving the world one encrypted chat at a time.."), chatIdentities.get(3).chatIdentity, stores.get(3), hasher).join();
-//        chat3.merge(chatUid, chat4.host, stores.get(3), stores.get(2), ipfs, NO_OP, NO_OP2).join();
-//        Assert.assertTrue(stores.get(3).messages.containsAll(stores.get(2).messages));
-//        Assert.assertEquals(stores.get(3).messages.size(), 6);
-//
-//        // now resolve the partition and merge states
-//        chat1.merge(chatUid, chat4.host, stores.get(3), stores.get(0), ipfs, NO_OP, NO_OP2).join();
-//        Assert.assertEquals(stores.get(0).messages.size(), 12);
-//        chat2.merge(chatUid, chat1.host, stores.get(0), stores.get(1), ipfs, NO_OP, NO_OP2).join();
-//        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
-//
-//        // check ordering
-//        for (int i=0; i < stores.size(); i++)
-//            validateMessageLog(stores.get(i).getMessagesFrom(0).join(), genesis);
-//    }
+    @Test
+    public void partitionAndJoin() {
+        List<SigningPrivateKeyAndPublicHash> identities = generateUsers(4);
+        List<PrivateChatState> chatIdentities = generateChatIdentities(4);
+        List<RamMessageStore> stores = IntStream.range(0, 4).mapToObj(i -> new RamMessageStore()).collect(Collectors.toList());
+
+        List<Chat> chats = Chat.createNew("uid",
+                Arrays.asList("user1", "user2", "user3", "user4"),
+                identities.stream().map(p -> p.publicKeyHash).collect(Collectors.toList()));
+        TreeClock genesis = chats.get(0).current;
+        Chat chat1 = chats.get(0);
+        Chat chat2 = chats.get(1);
+        Chat chat3 = chats.get(2);
+        Chat chat4 = chats.get(3);
+        OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_1);
+
+        OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
+        ChatUpdate u2_1 = chat2.join(chat2.host(), user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_1);
+
+        OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
+        ChatUpdate u3_1 = chat3.join(chat3.host(), user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), ipfs, hasher).join();
+        stores.get(2).apply(u3_1);
+
+        OwnerProof user4ChatId = OwnerProof.build(identities.get(3), chatIdentities.get(3).chatIdentity.publicKeyHash);
+        ChatUpdate u4_1 = chat4.join(chat4.host(), user4ChatId, chatIdentities.get(3).chatIdPublic, identities.get(3), stores.get(3), ipfs, hasher).join();
+        stores.get(3).apply(u4_1);
+
+        // partition and chat between user1 and user2
+        TreeClock t1_0 = u1_1.state.current;
+        ChatUpdate u1_2 = u1_1.state.sendMessage(text("Hey All, I'm user1!"), chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_2);
+        MessageEnvelope msg1 = u1_2.newMessages.get(u1_2.newMessages.size() - 1).msg;
+        Assert.assertTrue(msg1.timestamp.isIncrementOf(t1_0));
+
+        String chatUid = "chat-uid";
+        ChatUpdate u2_2 = u2_1.state.merge(chatUid, chat1.host, stores.get(0), ipfs).join();
+        stores.get(1).apply(u2_2);
+        TreeClock t2_0 = u2_2.state.current;
+        ChatUpdate u2_3 = u2_2.state.sendMessage(text("Hey user1! I'm user2."), chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_3);
+        MessageEnvelope msg2 = u2_3.newMessages.get(u2_3.newMessages.size() - 1).msg;
+        Assert.assertTrue(msg2.timestamp.isIncrementOf(t2_0));
+
+        ChatUpdate u1_3 = u1_2.state.merge(chatUid, chat2.host, stores.get(1), ipfs).join();
+        stores.get(0).apply(u1_3);
+        TreeClock t1_1 = u1_3.state.current;
+        ChatUpdate u1_4 = u1_3.state.sendMessage(text("Hey user2, whats up?"), chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        stores.get(0).apply(u1_4);
+        MessageEnvelope msg3 = u1_4.newMessages.get(u1_4.newMessages.size() - 1).msg;
+        Assert.assertTrue(msg3.timestamp.isIncrementOf(t1_1));
+
+        ChatUpdate u2_4 = u2_3.state.merge(chatUid, chat1.host, stores.get(0), ipfs).join();
+        stores.get(1).apply(u2_4);
+        TreeClock t2_1 = u2_4.state.current;
+        ChatUpdate u2_5 = u2_4.state.sendMessage(text("Just saving the world one decentralized chat at a time.."),
+                chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+        stores.get(1).apply(u2_5);
+        MessageEnvelope msg4 = u2_5.newMessages.get(u2_5.newMessages.size() - 1).msg;
+        Assert.assertTrue(msg4.timestamp.isIncrementOf(t2_1));
+
+        ChatUpdate u1_5 = u1_4.state.merge(chatUid, chat2.host, stores.get(1), ipfs).join();
+        stores.get(0).apply(u1_5);
+        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
+        Assert.assertEquals(stores.get(1).messages.size(), 6);
+
+        // also between user3 and user4
+        ChatUpdate u3_2 = u3_1.state.sendMessage(text("Hey All, I'm user3!"), chatIdentities.get(2).chatIdentity, stores.get(2), ipfs, hasher).join();
+        stores.get(2).apply(u3_2);
+
+        ChatUpdate u4_2 = u4_1.state.merge(chatUid, chat3.host, stores.get(2), ipfs).join();
+        stores.get(3).apply(u4_2);
+        ChatUpdate u4_3 = u4_2.state.sendMessage(text("Hey user3! I'm user4."), chatIdentities.get(3).chatIdentity, stores.get(3), ipfs, hasher).join();
+        stores.get(3).apply(u4_3);
+
+        ChatUpdate u3_3 = u3_2.state.merge(chatUid, chat4.host, stores.get(3), ipfs).join();
+        stores.get(2).apply(u3_3);
+        ChatUpdate u3_4 = u3_3.state.sendMessage(text("Hey user4, whats up?"), chatIdentities.get(2).chatIdentity, stores.get(2), ipfs, hasher).join();
+        stores.get(2).apply(u3_4);
+
+        ChatUpdate u4_4 = u4_3.state.merge(chatUid, chat3.host, stores.get(2), ipfs).join();
+        stores.get(3).apply(u4_4);
+        ChatUpdate u4_5 = u4_4.state.sendMessage(text("Just saving the world one encrypted chat at a time.."), chatIdentities.get(3).chatIdentity, stores.get(3), ipfs, hasher).join();
+        stores.get(3).apply(u4_5);
+
+        ChatUpdate u3_5 = u3_4.state.merge(chatUid, chat4.host, stores.get(3), ipfs).join();
+        stores.get(2).apply(u3_5);
+        Assert.assertTrue(stores.get(3).messages.containsAll(stores.get(2).messages));
+        Assert.assertEquals(stores.get(3).messages.size(), 6);
+
+        // now resolve the partition and merge states
+        ChatUpdate u1_6 = u1_5.state.merge(chatUid, chat4.host, stores.get(3), ipfs).join();
+        stores.get(0).apply(u1_6);
+        Assert.assertEquals(stores.get(0).messages.size(), 12);
+        ChatUpdate u2_6 = u2_5.state.merge(chatUid, chat1.host, stores.get(0), ipfs).join();
+        stores.get(1).apply(u2_6);
+        Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
+
+        // check ordering
+        for (int i=0; i < stores.size(); i++)
+            validateMessageLog(stores.get(i).getMessagesFrom(0).join(), genesis);
+    }
 
     private static void validateMessageLog(List<SignedMessage> msgs, TreeClock genesis) {
         TreeClock current = genesis;

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -220,6 +220,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void concurrentChatMerges() {
+        PeergosNetworkUtils.concurrentChatMerges(network, random);
+    }
+
+    @Test
     public void chatLeaveAndDelete() {
         PeergosNetworkUtils.memberLeaveAndDeleteChat(network, random);
     }
@@ -245,7 +250,7 @@ public class MultiUserTests {
                 (u1, dirToShare, usersToAdd) ->
                         u1.shareReadAccessWith(dirToShare, usersToAdd);
 
-        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> unshareFunction =
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> unshareFunction =
                 (u1, dirToShare, usersToRemove) -> u1.unShareReadAccessWith(dirToShare, usersToRemove);
 
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =
@@ -259,7 +264,7 @@ public class MultiUserTests {
         TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
                 (u1, dirToShare, usersToAdd) ->
                         u1.shareWriteAccessWith(dirToShare, usersToAdd);
-        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> unshareFunction =
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> unshareFunction =
                 (u1, dirToShare, usersToRemove) ->
                         u1.unShareWriteAccessWith(dirToShare, usersToRemove);
         TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc =

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -485,14 +485,14 @@ public class MultiUserTests {
                 u1.network.mutable, u1.network.dhtClient, u1.network.hasher).join();
         Assert.assertTrue("New writer key present", keysOwnedByRootSigner.contains(theFile.writer()));
 
-        Set<String> sharedWriteAccessWithBefore = u1.sharedWithCache.getSharedWith(filePath).join().get(SharedWithCache.Access.WRITE);
+        Set<String> sharedWriteAccessWithBefore = u1.sharedWith(filePath).join().get(SharedWithCache.Access.WRITE);
         Assert.assertTrue("file shared", ! sharedWriteAccessWithBefore.isEmpty());
 
         theFile.remove(parentFolder, filePath, u1).get();
         Optional<FileWrapper> removedFile = u1.getByPath(filePath).get();
         Assert.assertTrue("file removed", ! removedFile.isPresent());
 
-        Set<String> sharedWriteAccessWithAfter = u1.sharedWithCache.getSharedWith(filePath).join().get(SharedWithCache.Access.WRITE);
+        Set<String> sharedWriteAccessWithAfter = u1.sharedWith(filePath).join().get(SharedWithCache.Access.WRITE);
         Assert.assertTrue("file shared", sharedWriteAccessWithAfter.isEmpty());
 
         for (UserContext userContext : userContexts) {
@@ -555,7 +555,7 @@ public class MultiUserTests {
         FileWrapper theFile = u1.getByPath(filePath).get().get();
         FileWrapper parentFolder = u1.getByPath(subdirPath).get().get();
 
-        Set<String> sharedAccessWithBefore = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedAccessWithBefore = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", ! sharedAccessWithBefore.isEmpty());
 
         String newFilename = "newfilename.txt";
@@ -563,7 +563,7 @@ public class MultiUserTests {
 
         filePath = Paths.get(u1.username, subdirName, newFilename);
 
-        Set<String> sharedAccessWithAfter = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedAccessWithAfter = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", ! sharedAccessWithAfter.isEmpty());
     }
 
@@ -610,7 +610,7 @@ public class MultiUserTests {
         FileWrapper theDir = u1.getByPath(filePath).get().get();
         FileWrapper parentFolder = u1.getUserRoot().get();
 
-        Set<String> sharedAccessWithBefore = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedAccessWithBefore = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", ! sharedAccessWithBefore.isEmpty());
 
         String newDirectoryName = "newDir";
@@ -618,7 +618,7 @@ public class MultiUserTests {
 
         filePath = Paths.get(u1.username, newDirectoryName);
 
-        Set<String> sharedAccessWithAfter = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedAccessWithAfter = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", ! sharedAccessWithAfter.isEmpty());
     }
 
@@ -670,7 +670,7 @@ public class MultiUserTests {
         shareFunction.apply(u1, userContexts, filePath);
 
         FileWrapper theFile = u1.getByPath(filePath).get().get();
-        Set<String> sharedWriteAccessWithBefore = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithBefore = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", ! sharedWriteAccessWithBefore.isEmpty());
 
         //copy file
@@ -679,12 +679,12 @@ public class MultiUserTests {
         theFile.copyTo(destSubdir, u1);
 
         //old copy should retain sharedWith entries
-        Set<String> sharedWriteAccessWithOriginal = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", ! sharedWriteAccessWithOriginal.isEmpty());
 
         filePath = Paths.get(u1.username, destinationSubdirName, filename);
 
-        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", sharedWriteAccessWithNewCopy.isEmpty());
     }
 
@@ -728,7 +728,7 @@ public class MultiUserTests {
         shareFunction.apply(u1, userContexts, dirPath);
 
         FileWrapper theDir = u1.getByPath(dirPath).get().get();
-        Set<String> sharedWriteAccessWithBefore = u1.sharedWithCache.getSharedWith(dirPath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithBefore = u1.sharedWith(dirPath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", ! sharedWriteAccessWithBefore.isEmpty());
 
         //copy file
@@ -737,12 +737,12 @@ public class MultiUserTests {
         theDir.copyTo(destDir, u1).join();
 
         //old copy should retain sharedWith entries
-        Set<String> sharedWriteAccessWithOriginal = u1.sharedWithCache.getSharedWith(dirPath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(dirPath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", ! sharedWriteAccessWithOriginal.isEmpty());
 
         dirPath = Paths.get(u1.username, destinationDirName, subdirName);
 
-        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWithCache.getSharedWith(dirPath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(dirPath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", sharedWriteAccessWithNewCopy.isEmpty());
     }
 
@@ -794,7 +794,7 @@ public class MultiUserTests {
         Path parentPath = Paths.get(u1.username, subdirName);
         FileWrapper theParent = u1.getByPath(parentPath).get().get();
         AbsoluteCapability cap = theFile.getPointer().capability;
-        Set<String> sharedWriteAccessWithBefore = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithBefore = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", ! sharedWriteAccessWithBefore.isEmpty());
 
         //move file
@@ -804,7 +804,7 @@ public class MultiUserTests {
         theFile.moveTo(destSubdir, theParent, filePath, u1).join();
 
         //old copy sharedWith entries should be removed
-        Set<String> sharedWriteAccessWithOriginal = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", sharedWriteAccessWithOriginal.isEmpty());
 
         filePath = Paths.get(u1.username, destinationSubdirName, filename);
@@ -812,7 +812,7 @@ public class MultiUserTests {
         cap = theFile.getPointer().capability;
 
         //new copy sharedWith entry should also be empty
-        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWithCache.getSharedWith(filePath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(filePath).join().get(sharedWithAccess);
         Assert.assertTrue("file shared", sharedWriteAccessWithNewCopy.isEmpty());
     }
 
@@ -857,7 +857,7 @@ public class MultiUserTests {
         Path parentPath = Paths.get(u1.username);
         FileWrapper theParent = u1.getByPath(parentPath).get().get();
         AbsoluteCapability cap = theDir.getPointer().capability;
-        Set<String> sharedWriteAccessWithBefore = u1.sharedWithCache.getSharedWith(dirPath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithBefore = u1.sharedWith(dirPath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", ! sharedWriteAccessWithBefore.isEmpty());
 
         //move directory
@@ -867,7 +867,7 @@ public class MultiUserTests {
         theDir.moveTo(destSubdir, theParent, dirPath, u1);
 
         //old copy sharedWith entries should be removed
-        Set<String> sharedWriteAccessWithOriginal = u1.sharedWithCache.getSharedWith(dirPath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(dirPath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", sharedWriteAccessWithOriginal.isEmpty());
 
         dirPath = Paths.get(u1.username, destinationSubdirName, subdirName);
@@ -875,7 +875,7 @@ public class MultiUserTests {
         cap = theDir.getPointer().capability;
 
         //new copy sharedWith entry should also be empty
-        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWithCache.getSharedWith(dirPath).join().get(sharedWithAccess);
+        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(dirPath).join().get(sharedWithAccess);
         Assert.assertTrue("directory shared", sharedWriteAccessWithNewCopy.isEmpty());
     }
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -246,7 +246,7 @@ public class MultiUserTests {
 
     @Test
     public void groupAwareSharingReadAccess() {
-        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> shareFunction =
                 (u1, dirToShare, usersToAdd) ->
                         u1.shareReadAccessWith(dirToShare, usersToAdd);
 
@@ -261,7 +261,7 @@ public class MultiUserTests {
 
     @Test
     public void groupAwareSharingWriteAccess() {
-        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction =
+        TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> shareFunction =
                 (u1, dirToShare, usersToAdd) ->
                         u1.shareWriteAccessWith(dirToShare, usersToAdd);
         TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> unshareFunction =
@@ -275,7 +275,7 @@ public class MultiUserTests {
 
     @Test
     public void safeCopyOfFriendsReadAccess() throws Exception {
-        TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, UserContext, String, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2, filename) ->
         u1.shareReadAccessWith(Paths.get(u1.username, filename), Collections.singleton(u2.username));
         safeCopyOfFriends(readAccessSharingFunction);
@@ -283,13 +283,13 @@ public class MultiUserTests {
 
     @Test
     public void safeCopyOfFriendsWriteAccess() throws Exception {
-        TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, UserContext, String, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2, filename) ->
                         u1.shareWriteAccessWith(Paths.get(u1.username, filename), Collections.singleton(u2.username));
         safeCopyOfFriends(writeAccessSharingFunction);
     }
 
-    private void safeCopyOfFriends(TriFunction<UserContext, UserContext, String, CompletableFuture<Boolean>> sharingFunction) throws Exception {
+    private void safeCopyOfFriends(TriFunction<UserContext, UserContext, String, CompletableFuture<Snapshot>> sharingFunction) throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
         UserContext u2 = PeergosNetworkUtils.ensureSignedUp(random(), "b", network.clear(), crypto);
 
@@ -359,7 +359,7 @@ public class MultiUserTests {
 
     @Test
     public void shareTwoFilesWithSameNameReadAccess() throws Exception {
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, userContexts, path) ->
                         u1.shareReadAccessWith(path, userContexts.stream().map(u -> u.username).collect(Collectors.toSet()));
         shareTwoFilesWithSameName(readAccessSharingFunction);
@@ -367,13 +367,13 @@ public class MultiUserTests {
 
     @Test
     public void shareTwoFilesWithSameNameWriteAccess() throws Exception {
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, userContexts, path) ->
                         u1.shareWriteAccessWith(path, userContexts.stream().map(u -> u.username).collect(Collectors.toSet()));
         shareTwoFilesWithSameName(writeAccessSharingFunction);
     }
 
-    private void shareTwoFilesWithSameName(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> sharingFunction) throws Exception {
+    private void shareTwoFilesWithSameName(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> sharingFunction) throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
 
         // send follow requests from each other user to u1
@@ -508,20 +508,20 @@ public class MultiUserTests {
     @Test
     public void renamedFileSharedWith() throws Exception {
         //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
 
         renamedFileSharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
         //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
         renamedFileSharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
     }
 
     private void renamedFileSharedWith(
-            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> shareFunction,
+            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
             SharedWithCache.Access sharedWithAccess)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
@@ -570,20 +570,20 @@ public class MultiUserTests {
     @Test
     public void renamedDirectorySharedWith() throws Exception {
         //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
 
         renamedDirectorySharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
         //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
         renamedDirectorySharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
     }
 
     private void renamedDirectorySharedWith(
-            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> shareFunction,
+            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
             SharedWithCache.Access sharedWithAccess)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
@@ -625,20 +625,20 @@ public class MultiUserTests {
     @Test
     public void copyToFileSharedWith() throws Exception {
         //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
 
         copyToFileSharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
         //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
         copyToFileSharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
     }
 
     private void copyToFileSharedWith(
-            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> shareFunction,
+            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
             SharedWithCache.Access sharedWithAccess)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
@@ -691,20 +691,20 @@ public class MultiUserTests {
     @Test
     public void copyToDirectorySharedWith() throws Exception {
         //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
 
         copyToDirectorySharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
         //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
         copyToDirectorySharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
     }
 
     private void copyToDirectorySharedWith(
-            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> shareFunction,
+            TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
             SharedWithCache.Access sharedWithAccess)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
@@ -750,19 +750,19 @@ public class MultiUserTests {
     public void moveToFileSharedWith()
             throws Exception {
         //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
 
         moveToFileSharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
         //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
         moveToFileSharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
     }
 
-    private void moveToFileSharedWith(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> shareFunction,
+    private void moveToFileSharedWith(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
             SharedWithCache.Access sharedWithAccess)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
@@ -820,19 +820,19 @@ public class MultiUserTests {
     public void moveToDirectorySharedWith()
             throws Exception {
         //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> readAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
 
         moveToDirectorySharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
         //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> writeAccessSharingFunction =
+        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
                 (u1, u2List, filePath) ->
                         u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
         moveToDirectorySharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
     }
 
-    private void moveToDirectorySharedWith(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Boolean>> shareFunction,
+    private void moveToDirectorySharedWith(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
                                       SharedWithCache.Access sharedWithAccess)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -621,7 +621,7 @@ public class PeergosNetworkUtils {
         sharer.shareReadAccessWith(Paths.get(path),
                 shareeUsers.stream()
                         .map(c -> c.username)
-                        .collect(Collectors.toSet())).get();
+                        .collect(Collectors.toSet())).join();
 
         // check each user can see the shared folder and directory
         for (UserContext sharee : shareeUsers) {

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -230,7 +230,7 @@ public class PeergosNetworkUtils {
         Pair<Path, FileWrapper> result = receiverFeed.createNewPost(replySocialPost).join();
         String friendGroup = SocialState.FRIENDS_GROUP_NAME;
         String receiverGroupUid = sharee.getSocialState().join().groupNameToUid.get(friendGroup);
-        Boolean res = sharee.shareReadAccessWith(result.left, Set.of(receiverGroupUid)).join();
+        sharee.shareReadAccessWith(result.left, Set.of(receiverGroupUid)).join();
 
         //now sharer should see the reply
         SocialFeed feed = sharer.getSocialFeed().join().update().join();
@@ -618,7 +618,7 @@ public class PeergosNetworkUtils {
                 .collect(Collectors.toSet());
 
         // file is uploaded, do the actual sharing
-        boolean finished = sharer.shareReadAccessWith(Paths.get(path),
+        sharer.shareReadAccessWith(Paths.get(path),
                 shareeUsers.stream()
                         .map(c -> c.username)
                         .collect(Collectors.toSet())).get();
@@ -735,9 +735,9 @@ public class PeergosNetworkUtils {
         }
 
         // file is uploaded, do the actual sharing
-        boolean finished = sharer.shareWriteAccessWith(Paths.get(path), shareeUsers.stream()
+        sharer.shareWriteAccessWith(Paths.get(path), shareeUsers.stream()
                 .map(c -> c.username)
-                .collect(Collectors.toSet())).get();
+                .collect(Collectors.toSet())).join();
 
         // upload a image
         String imagename = "small.png";
@@ -1423,7 +1423,7 @@ public class PeergosNetworkUtils {
         String groupUid = state.groupNameToUid.get(friendGroup);
         // was Set.of(groupUid)
         //boolean res = sharer.shareReadAccessWith(result.left, Set.of(sharee.username)).join();
-        boolean res = sharer.shareReadAccessWith(result.left, Set.of(groupUid)).join();
+        sharer.shareReadAccessWith(result.left, Set.of(groupUid)).join();
 
         SocialFeed receiverFeed = sharee.getSocialFeed().join().update().join();
         List<Pair<SharedItem, FileWrapper>> files = receiverFeed.getSharedFiles(0, 100).join();
@@ -1445,7 +1445,7 @@ public class PeergosNetworkUtils {
         SocialPost replySocialPost = SocialPost.createComment(parent, resharingType, sharee.username, Arrays.asList(new Text(replyText)));
         result = receiverFeed.createNewPost(replySocialPost).join();
         String receiverGroupUid = sharee.getSocialState().join().groupNameToUid.get(friendGroup);
-        res = sharee.shareReadAccessWith(result.left, Set.of(receiverGroupUid)).join();
+        sharee.shareReadAccessWith(result.left, Set.of(receiverGroupUid)).join();
 
         //now sharer should see the reply
         sharer = UserContext.signIn(sharer.username, password, sharer.network, sharer.crypto, c -> {}).join();
@@ -1480,7 +1480,7 @@ public class PeergosNetworkUtils {
         String friendGroup = SocialState.FRIENDS_GROUP_NAME;
         SocialState state = sharer.getSocialState().join();
         String groupUid = state.groupNameToUid.get(friendGroup);
-        boolean res = sharer.shareReadAccessWith(result.left, Set.of(groupUid)).join();
+        sharer.shareReadAccessWith(result.left, Set.of(groupUid)).join();
 
         SocialFeed receiverFeed = sharee.getSocialFeed().join().update().join();
         List<Pair<SharedItem, FileWrapper>> files = receiverFeed.getSharedFiles(0, 100).join();
@@ -1499,7 +1499,7 @@ public class PeergosNetworkUtils {
                 Arrays.asList(new Text(replyText)));
         result = receiverFeed.createNewPost(replySocialPost).join();
         String receiverGroupUid = sharee.getSocialState().join().groupNameToUid.get(friendGroup);
-        res = sharee.shareReadAccessWith(result.left, Set.of(receiverGroupUid)).join();
+        sharee.shareReadAccessWith(result.left, Set.of(receiverGroupUid)).join();
 
         //now sharer should see the reply
         feed = sharer.getSocialFeed().join().update().join();
@@ -2016,7 +2016,7 @@ public class PeergosNetworkUtils {
     }
 
     public static void groupAwareSharing(NetworkAccess network, Random random,
-                                         TriFunction<UserContext, Path, Set<String>, CompletableFuture<Boolean>> shareFunction,
+                                         TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> shareFunction,
                                          TriFunction<UserContext, Path, Set<String>, CompletableFuture<Snapshot>> unshareFunction,
                                          TriFunction<UserContext, Path, FileSharedWithState, Integer> resultFunc) {
         CryptreeNode.setMaxChildLinkPerBlob(10);
@@ -2110,10 +2110,10 @@ public class PeergosNetworkUtils {
         System.out.println("PATH "+ path);
 
         // file is uploaded, do the actual sharing
-        boolean finished = sharer.shareWriteAccessWith(Paths.get(path),
+        sharer.shareWriteAccessWith(Paths.get(path),
                 shareeUsers.stream()
                         .map(c -> c.username)
-                        .collect(Collectors.toSet())).get();
+                        .collect(Collectors.toSet())).join();
 
         // check each user can see the shared folder, and write to it
         for (UserContext sharee : shareeUsers) {

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -130,7 +130,7 @@ public class RamUserTests extends UserTests {
                 final int blockSize = length > maxBlockSize ? maxBlockSize : length;
                 return pump(seekReader, length, blockSize, resultBytes);
             });
-        }).join().get();
+        }).join().join();
 
         List<byte[]> resultBytes2 = new ArrayList<>();
         boolean result2 = file.getInputStream(network, crypto, sizeHigh, sizeLow, l -> {}).thenCompose(reader -> {
@@ -138,7 +138,7 @@ public class RamUserTests extends UserTests {
                 final int blockSize = length > maxBlockSize ? maxBlockSize : length;
                 return pump(seekReader, length, blockSize, resultBytes2);
             });
-        }).join().get();
+        }).join().join();
         compare(resultBytes, resultBytes2);
     }
 
@@ -229,7 +229,7 @@ public class RamUserTests extends UserTests {
                 final int blockSize = length > maxBlockSize ? maxBlockSize : length;
                 return pump(seekReader, length, blockSize, resultBytes2);
             });
-        }).join().get();
+        }).join().join();
 
         List<byte[]> resultBytes3 = new ArrayList<>();
 
@@ -241,7 +241,7 @@ public class RamUserTests extends UserTests {
             currentAsyncReader.add(seekReader);
             final int blockSize = length > maxBlockSize ? maxBlockSize : length;
             return pump(currentAsyncReader.get(0), length, blockSize, resultBytes3);
-        }).join().get();
+        }).join().join();
 
         compare(resultBytes2, resultBytes3);
         return currentAsyncReader.get(0);
@@ -288,7 +288,7 @@ public class RamUserTests extends UserTests {
         String username1 = generateUsername();
         String password = "test";
         UserContext user1 = PeergosNetworkUtils.ensureSignedUp(username1, password, network, crypto);
-        FileWrapper user1Root = user1.getUserRoot().get();
+        FileWrapper user1Root = user1.getUserRoot().join();
 
         String folder1 = "folder1";
         user1Root.mkdir(folder1, user1.network, false, crypto).join();
@@ -302,7 +302,7 @@ public class RamUserTests extends UserTests {
         byte[] data = new byte[0];
         user1.getByPath(Paths.get(username1, folder1, folder11)).join().get()
                 .uploadOrReplaceFile(filename, new AsyncReader.ArrayBacked(data), data.length, user1.network,
-                crypto, l -> {}, crypto.random.randomBytes(32)).get();
+                crypto, l -> {}, crypto.random.randomBytes(32)).join();
 
         // create 2nd user and friend user1
         String username2 = generateUsername();

--- a/src/peergos/server/tests/RequestCountTests.java
+++ b/src/peergos/server/tests/RequestCountTests.java
@@ -51,7 +51,7 @@ public class RequestCountTests {
 
         storageCounter.reset();
         UserContext sharer = PeergosNetworkUtils.ensureSignedUp(generateUsername(random), password, network, crypto);
-        Assert.assertTrue("signup request count: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 25);
+        Assert.assertTrue("signup request count: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 32);
 
         storageCounter.reset();
         PeergosNetworkUtils.ensureSignedUp(sharer.username, password, network, crypto);

--- a/src/peergos/server/tests/RestartTests.java
+++ b/src/peergos/server/tests/RestartTests.java
@@ -33,7 +33,7 @@ public class RestartTests {
     private static Process server;
 
     public RestartTests() throws Exception {
-        this.network = Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).get();
+        this.network = Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).join();
     }
 
     @BeforeClass
@@ -70,7 +70,7 @@ public class RestartTests {
     private static void waitUntilReady() {
         for (int i=0; i < 30; i++) {
             try {
-                Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).get();
+                Builder.buildJavaNetworkAccess(new URL("http://localhost:" + args.getInt("port")), false).join();
                 return;
             } catch (Exception e) {
                 try {
@@ -115,11 +115,11 @@ public class RestartTests {
         String username2 = random();
         String password2 = random();
         UserContext u2 = PeergosNetworkUtils.ensureSignedUp(username2, password2, network, crypto);
-        u2.sendFollowRequest(u1.username, SymmetricKey.random()).get();
-        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().get();
-        u1.sendReplyFollowRequest(u1Requests.get(0), true, true).get();
+        u2.sendFollowRequest(u1.username, SymmetricKey.random()).join();
+        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().join();
+        u1.sendReplyFollowRequest(u1Requests.get(0), true, true).join();
         // complete connection
-        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().get();
+        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().join();
 
         // change password for u2
         String password3 = random();
@@ -129,7 +129,7 @@ public class RestartTests {
         restart();
 
         UserContext freshU1 = UserContext.signIn(username1, password1, network.clear(), crypto).join();
-        Optional<FileWrapper> u2ToU1 = freshU1.getByPath("/" + u2.username).get();
+        Optional<FileWrapper> u2ToU1 = freshU1.getByPath("/" + u2.username).join();
         assertTrue("Friend root present after their password change", u2ToU1.isPresent());
     }
 }

--- a/src/peergos/server/tests/UserPublicKeyLinkTests.java
+++ b/src/peergos/server/tests/UserPublicKeyLinkTests.java
@@ -30,7 +30,7 @@ public class UserPublicKeyLinkTests {
     private final List<Multihash> id;
 
     public UserPublicKeyLinkTests() throws Exception {
-        id = Arrays.asList(ipfs.id().get());
+        id = Arrays.asList(ipfs.id().join());
     }
 
     @BeforeClass
@@ -43,7 +43,7 @@ public class UserPublicKeyLinkTests {
         return ipfs.putSigningKey(
                 user.secretSigningKey.signMessage(user.publicSigningKey.serialize()),
                 owner,
-                user.publicSigningKey, ipfs.startTransaction(owner).get()).get();
+                user.publicSigningKey, ipfs.startTransaction(owner).join()).get();
     }
 
     @Test

--- a/src/peergos/server/util/TimeLimited.java
+++ b/src/peergos/server/util/TimeLimited.java
@@ -20,7 +20,7 @@ public class TimeLimited {
      */
     public static long isAllowedTime(byte[] signedTime, int durationSeconds, ContentAddressedStorage ipfs, PublicKeyHash owner) {
         try {
-            Optional<PublicSigningKey> ownerOpt = ipfs.getSigningKey(owner).get();
+            Optional<PublicSigningKey> ownerOpt = ipfs.getSigningKey(owner).join();
             if (! ownerOpt.isPresent())
                 throw new IllegalStateException("Couldn't retrieve owner key!");
             byte[] raw = ownerOpt.get().unsignMessage(signedTime);
@@ -49,7 +49,7 @@ public class TimeLimited {
      */
     public static long isAllowed(String expectedPath, byte[] signedReq, int durationSeconds, ContentAddressedStorage ipfs, PublicKeyHash owner) {
         try {
-            Optional<PublicSigningKey> ownerOpt = ipfs.getSigningKey(owner).get();
+            Optional<PublicSigningKey> ownerOpt = ipfs.getSigningKey(owner).join();
             if (! ownerOpt.isPresent())
                 throw new IllegalStateException("Couldn't retrieve owner key!");
             byte[] raw = ownerOpt.get().unsignMessage(signedReq);

--- a/src/peergos/shared/crypto/password/PasswordProtected.java
+++ b/src/peergos/shared/crypto/password/PasswordProtected.java
@@ -34,7 +34,7 @@ public class PasswordProtected {
         String salt = ArrayOps.bytesToHex(saltBytes);
 
         try {
-            byte[] derivedKeyBytes = hasher.hashToKeyBytes(salt, password, algorithm).get();
+            byte[] derivedKeyBytes = hasher.hashToKeyBytes(salt, password, algorithm).join();
             SymmetricKey key = new TweetNaClKey(derivedKeyBytes, false, provider, random);
             byte[] nonce = key.createNonce();
             byte[] cipherText = key.encrypt(cleartext, nonce);
@@ -63,7 +63,7 @@ public class PasswordProtected {
         byte[] cipherText = ((CborObject.CborByteArray) list.get(3)).value;
 
         try {
-            byte[] derivedKeyBytes = hasher.hashToKeyBytes(salt, password, algorithm).get();
+            byte[] derivedKeyBytes = hasher.hashToKeyBytes(salt, password, algorithm).join();
 
             SymmetricKey key = new TweetNaClKey(derivedKeyBytes, false, provider, random);
             return key.decrypt(cipherText, nonce);

--- a/src/peergos/shared/display/Reference.java
+++ b/src/peergos/shared/display/Reference.java
@@ -33,6 +33,11 @@ class Reference implements Content {
     }
 
     @Override
+    public String toString() {
+        return "REFERENCE(" + ref.path + ")";
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/src/peergos/shared/display/Text.java
+++ b/src/peergos/shared/display/Text.java
@@ -30,6 +30,11 @@ class Text implements Content {
     }
 
     @Override
+    public String toString() {
+        return content;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/src/peergos/shared/messaging/Chat.java
+++ b/src/peergos/shared/messaging/Chat.java
@@ -112,7 +112,7 @@ public class Chat implements Cborable {
 
     /** Apply message to this Chat's state
      *
-     * @return
+     * @return The state after applying the message
      */
     public CompletableFuture<ChatUpdate> applyMessage(SignedMessage signed,
                                                       String chatUid,

--- a/src/peergos/shared/messaging/Chat.java
+++ b/src/peergos/shared/messaging/Chat.java
@@ -193,7 +193,14 @@ public class Chat implements Cborable {
                 }
                 break;
             }
-            case ReplyTo:
+            case ReplyTo: {
+                ReplyTo content = (ReplyTo) msg.payload;
+                List<FileRef> fileRefs = content.content.body.stream()
+                        .flatMap(c -> c.reference().stream())
+                        .collect(Collectors.toList());
+                // note media to mirror our storage
+                return Futures.of(new ChatUpdate(addToRecent(msg), Arrays.asList(signed), fileRefs, Collections.emptySet()));
+            }
             case Delete:
                 break;
         }

--- a/src/peergos/shared/messaging/Chat.java
+++ b/src/peergos/shared/messaging/Chat.java
@@ -12,27 +12,29 @@ import peergos.shared.util.*;
 import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.function.*;
 import java.util.stream.*;
 
 public class Chat implements Cborable {
 
+    public final String chatUid;
     public final Id host;
-    public TreeClock current;
+    public final TreeClock current;
     public final Map<Id, Member> members;
     public final Map<String, GroupProperty> groupState;
     private final List<MessageEnvelope> recentMessages;
 
-    public Chat(Id host,
+    public Chat(String chatUid,
+                Id host,
                 TreeClock current,
                 Map<Id, Member> members,
                 Map<String, GroupProperty> groupState,
                 List<MessageEnvelope> recentMessages) {
+        this.chatUid = chatUid;
         this.host = host;
         this.current = current;
-        this.members = members;
-        this.groupState = groupState;
-        this.recentMessages = recentMessages;
+        this.members = Collections.unmodifiableMap(members);
+        this.groupState = Collections.unmodifiableMap(groupState);
+        this.recentMessages = Collections.unmodifiableList(recentMessages);
     }
 
     public String getTitle() {
@@ -62,10 +64,11 @@ public class Chat implements Cborable {
         return members.values().stream().filter(m -> m.username.equals(username)).findFirst().get();
     }
 
-    public CompletableFuture<MessageEnvelope> addMessage(Message body,
-                                                         SigningPrivateKeyAndPublicHash signer,
-                                                         MessageStore store,
-                                                         Hasher hasher) {
+    public CompletableFuture<ChatUpdate> sendMessage(Message body,
+                                                     SigningPrivateKeyAndPublicHash signer,
+                                                     MessageStore store,
+                                                     ContentAddressedStorage ipfs,
+                                                     Hasher hasher) {
         TreeClock msgTime = current.increment(host);
         boolean nonEmpty = host().messagesMergedUpto > 0;
         return (nonEmpty ?
@@ -77,11 +80,9 @@ public class Chat implements Cborable {
                         .collect(Collectors.toList())))
                 .thenCompose(recentRefs -> {
                     MessageEnvelope msg = new MessageEnvelope(host, msgTime, LocalDateTime.now(ZoneOffset.UTC), recentRefs, body);
-                    current = msgTime;
                     byte[] signature = signer.secret.signatureOnly(msg.serialize());
-                    host().messagesMergedUpto++;
-                    long msgCount = host().messagesMergedUpto;
-                    return store.addMessage(msgCount - 1, new SignedMessage(signature, msg)).thenApply(x -> msg);
+                    SignedMessage signed = new SignedMessage(signature, msg);
+                    return mergeMessage(chatUid, signed, host(), ipfs);
                 });
     }
 
@@ -89,35 +90,50 @@ public class Chat implements Cborable {
         return new ArrayList<>(recentMessages);
     }
 
-    private synchronized boolean addToRecent(MessageEnvelope m) {
-        if (recentMessages.size() >= 10)
-            recentMessages.remove(0);
-        recentMessages.add(m);
-        return true;
+    private Chat withMembers(Map<Id, Member> updated) {
+        return new Chat(chatUid, host, current, updated, groupState, recentMessages);
+    }
+
+    private Chat withTime(TreeClock newTime) {
+        return new Chat(chatUid, host, newTime, members, groupState, recentMessages);
+    }
+
+    private Chat withProperties(Map<String, GroupProperty> updated) {
+        return new Chat(chatUid, host, current, members, updated, recentMessages);
+    }
+
+    private Chat addToRecent(MessageEnvelope m) {
+        ArrayList<MessageEnvelope> updated = new ArrayList<>(recentMessages);
+        if (updated.size() >= 10)
+            updated.remove(0);
+        updated.add(m);
+        return new Chat(chatUid, host, current, members, groupState, updated);
     }
 
     /** Apply message to this Chat's state
      *
-     * @param msg
      * @return
      */
-    public CompletableFuture<Boolean> apply(MessageEnvelope msg,
-                                            String chatUid,
-                                            Function<FileRef, CompletableFuture<Boolean>> mediaCopier,
-                                            MessageStore ourStore,
-                                            ContentAddressedStorage ipfs) {
+    public CompletableFuture<ChatUpdate> applyMessage(SignedMessage signed,
+                                                      String chatUid,
+                                                      ContentAddressedStorage ipfs) {
+        MessageEnvelope msg = signed.msg;
         Member author = members.get(msg.author);
         switch (msg.payload.type()) {
             case Invite: {
-                Set<Id> newMembers = current.newMembersFrom(msg.timestamp);
-                for (Id newMember : newMembers) {
-                    long indexIntoParent = getMember(newMember.parent()).messagesMergedUpto;
-                    Invite invite = (Invite) msg.payload;
-                    String username = invite.username;
-                    PublicKeyHash identity = invite.identity;
-                    members.put(newMember, new Member(username, newMember, identity, indexIntoParent, 0));
-                }
-                break;
+                Invite invite = (Invite) msg.payload;
+                Id newMember = invite.recipientId;
+                if (members.containsKey(newMember))
+                    throw new IllegalStateException("Id already exists in this chat!");
+                if (!newMember.parent().equals(author.id))
+                    throw new IllegalStateException("Invalid invite Id!");
+                HashMap<Id, Member> updated = new HashMap<>(members);
+                updated.put(author.id, members.get(author.id).incrementInvited());
+                long indexIntoParent = getMember(newMember.parent()).messagesMergedUpto;
+                String username = invite.username;
+                PublicKeyHash identity = invite.identity;
+                updated.put(newMember, new Member(username, newMember, identity, indexIntoParent, 0));
+                return Futures.of(new ChatUpdate(withMembers(updated).addToRecent(msg), Arrays.asList(signed), Collections.emptyList(), Collections.emptySet()));
             }
             case Join:
                 if (author.chatIdentity.isEmpty()) {
@@ -128,9 +144,9 @@ public class Chat implements Cborable {
                         throw new IllegalStateException("Identity keys don't match!");
                     // verify signature
                     return chatIdentity.getOwner(ipfs).thenApply(x -> {
-                        members.put(author.id, author.withChatId(chatIdentity));
-                        addToRecent(msg);
-                        return true;
+                        Map<Id, Member> updated = new HashMap<>(members);
+                        updated.put(author.id, author.withChatId(chatIdentity));
+                        return new ChatUpdate(withMembers(updated).addToRecent(msg), Arrays.asList(signed), Collections.emptyList(), Collections.emptySet());
                     });
                 }
                 break;
@@ -144,7 +160,9 @@ public class Chat implements Cborable {
                                 (existing.updateTimestamp.isBeforeOrEqual(msg.timestamp) ||
                                         (existing.updateTimestamp.isConcurrentWith(msg.timestamp) &&
                                                 msg.author.compareTo(existing.author) < 0)))) {
-                    groupState.put(update.key, new GroupProperty(msg.author, msg.timestamp, update.value));
+                    Map<String, GroupProperty> updated = new HashMap<>(groupState);
+                    updated.put(update.key, new GroupProperty(msg.author, msg.timestamp, update.value));
+                    return Futures.of(new ChatUpdate(withProperties(updated).addToRecent(msg), Arrays.asList(signed), Collections.emptyList(), Collections.emptySet()));
                 }
                 break;
             }
@@ -155,23 +173,23 @@ public class Chat implements Cborable {
                 List<FileRef> fileRefs = content.body.stream()
                         .flatMap(c -> c.reference().stream())
                         .collect(Collectors.toList());
-                // mirror media to our storage
-                List<CompletableFuture<Boolean>> mirroredMedia = fileRefs.stream().parallel()
-                        .map(mediaCopier)
-                        .collect(Collectors.toList());
-                return Futures.combineAll(mirroredMedia).thenApply(x -> addToRecent(msg));
+                // note media to mirror our storage
+                return Futures.of(new ChatUpdate(addToRecent(msg), Arrays.asList(signed), fileRefs, Collections.emptySet()));
             }
             case RemoveMember: {
                 RemoveMember rem = (RemoveMember) msg.payload;
                 if (!rem.chatUid.equals(chatUid))
-                    return Futures.of(true); // ignore message from incorrect chat
+                    return Futures.of(new ChatUpdate(this, Collections.emptyList(), Collections.emptyList(), Collections.emptySet())); // ignore message from incorrect chat
                 // anyone can remove themselves
                 // an admin can remove anyone
                 if (rem.memberToRemove.equals(msg.author) || getAdmins().contains(author.username)) {
                     String username = getMember(rem.memberToRemove).username;
-                    members.get(rem.memberToRemove).removed = true;
-                    // revoke read access to shared chat state from removee
-                    return ourStore.revokeAccess(username).thenApply(b -> addToRecent(msg));
+                    Member updatedMember = members.get(rem.memberToRemove).removed(true);
+                    Map<Id, Member> updated = new HashMap<>(members);
+                    updated.put(rem.memberToRemove, updatedMember);
+                    // revoke read access to shared chat state from removee (unless removee is us!)
+                    return Futures.of(new ChatUpdate(addToRecent(msg).withMembers(updated), Arrays.asList(signed), Collections.emptyList(),
+                                    username.equals(host().username) ? Collections.emptySet() : Collections.singleton(username)));
                 }
                 break;
             }
@@ -179,29 +197,26 @@ public class Chat implements Cborable {
             case Delete:
                 break;
         }
-        return Futures.of(addToRecent(msg));
+        return Futures.of(new ChatUpdate(addToRecent(msg), Arrays.asList(signed), Collections.emptyList(), Collections.emptySet()));
     }
 
-    public CompletableFuture<Boolean> merge(String chatUid,
-                                            Id mirrorHostId,
-                                            MessageStore mirrorStore,
-                                            MessageStore ourStore,
-                                            ContentAddressedStorage ipfs,
-                                            Function<Chat, CompletableFuture<Boolean>> committer,
-                                            Function<FileRef, CompletableFuture<Boolean>> mediaCopier) {
+    public CompletableFuture<ChatUpdate> merge(String chatUid,
+                                               Id mirrorHostId,
+                                               MessageStore mirrorStore,
+                                               ContentAddressedStorage ipfs) {
         Member host = getMember(mirrorHostId);
         return mirrorStore.getMessagesFrom(host.messagesMergedUpto)
-                .thenCompose(newMessages -> Futures.reduceAll(newMessages, true,
-                        (b, msg) -> mergeMessage(chatUid, msg, host, ourStore, ipfs, committer, mediaCopier), (a, b) -> a && b));
+                .thenCompose(newMessages -> Futures.reduceAll(newMessages,
+                        ChatUpdate.empty(this),
+                        (u, msg) -> u.state.mergeMessage(chatUid, msg, u.state.getMember(mirrorHostId), ipfs)
+                                .thenApply(u::apply),
+                        (a, b) -> a.apply(b)));
     }
 
-    private CompletableFuture<Boolean> mergeMessage(String chatUid,
-                                                    SignedMessage signed,
-                                                    Member host,
-                                                    MessageStore ourStore,
-                                                    ContentAddressedStorage ipfs,
-                                                    Function<Chat, CompletableFuture<Boolean>> committer,
-                                                    Function<FileRef, CompletableFuture<Boolean>> mediaCopier) {
+    private CompletableFuture<ChatUpdate> mergeMessage(String chatUid,
+                                                       SignedMessage signed,
+                                                       Member host,
+                                                       ContentAddressedStorage ipfs) {
         Member author = members.get(signed.msg.author);
         MessageEnvelope msg = signed.msg;
         if (! msg.timestamp.isBeforeOrEqual(current)) {
@@ -214,37 +229,35 @@ public class Chat implements Cborable {
                         if (signerOpt.isEmpty())
                             throw new IllegalStateException("Couldn't retrieve public signing key!");
                         signerOpt.get().unsignMessage(ArrayOps.concat(signed.signature, signed.msg.serialize()));
-                        return apply(msg, chatUid, mediaCopier, ourStore, ipfs);
-                    }).thenCompose(b -> ourStore.addMessage(host().messagesMergedUpto, signed)
-                            .thenCompose(x -> {
-                                current = current.merge(msg.timestamp);
-                                host.messagesMergedUpto++;
-                                host().messagesMergedUpto++;
-                                return committer.apply(this);
-                            }))
-                    .exceptionally(t -> {
-                        t.printStackTrace();
-                        return true;
-                    });
+                        return applyMessage(signed, chatUid, ipfs);
+                    }).thenApply(u -> u.withState(u.state.mergeMessageTimestamp(msg.timestamp, host)));
         }
-        host.messagesMergedUpto++;
-        return committer.apply(this);
+        return Futures.of(ChatUpdate.empty(incrementHost(host)));
     }
 
-    public CompletableFuture<Boolean> join(Member host,
-                                           OwnerProof chatId,
-                                           PublicSigningKey chatIdPublic,
-                                           SigningPrivateKeyAndPublicHash identity,
-                                           MessageStore ourStore,
-                                           Function<Chat, CompletableFuture<Boolean>> committer,
-                                           Hasher hasher) {
+    private Chat incrementHost(Member source) {
+        Map<Id, Member> updated = new HashMap<>(members);
+        updated.put(source.id, source.incrementMessages());
+        return new Chat(chatUid, host, current, updated, groupState, recentMessages);
+    }
+
+    private Chat mergeMessageTimestamp(TreeClock timestamp, Member source) {
+        TreeClock newTime = current.merge(timestamp);
+        Map<Id, Member> updated = new HashMap<>(members);
+        updated.put(source.id, members.get(source.id).incrementMessages());
+        updated.put(host, host().incrementMessages());
+        return new Chat(chatUid, host, newTime, updated, groupState, recentMessages);
+    }
+
+    public CompletableFuture<ChatUpdate> join(Member host,
+                                              OwnerProof chatId,
+                                              PublicSigningKey chatIdPublic,
+                                              SigningPrivateKeyAndPublicHash identity,
+                                              MessageStore ourStore,
+                                              ContentAddressedStorage ipfs,
+                                              Hasher hasher) {
         Join joinMsg = new Join(host.username, host.identity, chatId, chatIdPublic);
-        return addMessage(joinMsg, identity, ourStore, hasher)
-                .thenApply(x -> {
-                    this.host().chatIdentity = Optional.of(chatId);
-                    members.put(this.host, this.host());
-                    return true;
-                }).thenCompose(x -> committer.apply(this));
+        return withTime(current.withMember(host.id)).sendMessage(joinMsg, identity, ourStore, ipfs, hasher);
     }
 
     public Chat copy(Member host) {
@@ -253,58 +266,45 @@ public class Chat implements Cborable {
         Map<Id, Member> clonedMembers = members.entrySet().stream()
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().copy()));
         clonedMembers.put(host.id, host.copy());
-        return new Chat(host.id, current, clonedMembers, new HashMap<>(groupState), new ArrayList<>(recentMessages));
+        return new Chat(chatUid, host.id, current, clonedMembers, new HashMap<>(groupState), new ArrayList<>(recentMessages));
     }
 
-    public CompletableFuture<Member> inviteMember(String username,
-                                                  PublicKeyHash identity,
-                                                  SigningPrivateKeyAndPublicHash ourChatIdentity,
-                                                  MessageStore ourStore,
-                                                  Function<Chat, CompletableFuture<Boolean>> committer,
-                                                  Hasher hasher) {
-        Id newMember = host.fork(host().membersInvited);
-        Member member = new Member(username, newMember, identity, host().messagesMergedUpto, 0);
-        host().membersInvited++;
-        members.put(newMember, member);
-        current = current.withMember(newMember);
-        Invite invite = new Invite(username, identity);
-        return addMessage(invite, ourChatIdentity, ourStore, hasher)
-                .thenCompose(x -> committer.apply(this))
-                .thenApply(x -> member);
+    public CompletableFuture<ChatUpdate> inviteMember(String username,
+                                                      PublicKeyHash identity,
+                                                      SigningPrivateKeyAndPublicHash ourChatIdentity,
+                                                      MessageStore ourStore,
+                                                      ContentAddressedStorage ipfs,
+                                                      Hasher hasher) {
+        return inviteMembers(Arrays.asList(username), Arrays.asList(identity), ourChatIdentity, ourStore, ipfs, hasher);
     }
 
-    public CompletableFuture<List<Member>> inviteMembers(List<String> usernames,
-                                                         List<PublicKeyHash> identities,
-                                                         SigningPrivateKeyAndPublicHash ourChatIdentity,
-                                                         MessageStore ourStore,
-                                                         Function<Chat, CompletableFuture<Boolean>> committer,
-                                                         Hasher hasher) {
-        List<Member> newMembers = new ArrayList<>();
-        List<Invite> invites = new ArrayList<>();
-        for (int i=0; i < usernames.size(); i++) {
-            String username = usernames.get(i);
-            PublicKeyHash identity = identities.get(i);
-            Id newMember = host.fork(host().membersInvited);
-            Member member = new Member(username, newMember, identity, host().messagesMergedUpto, 0);
-            newMembers.add(member);
-            host().membersInvited++;
-            members.put(newMember, member);
-            current = current.withMember(newMember);
-            Invite invite = new Invite(username, identity);
-            invites.add(invite);
-        }
-        return Futures.reduceAll(invites, true,
-                (b, m) -> addMessage(m, ourChatIdentity, ourStore, hasher)
-                        .thenApply(x -> true),
-                (a, b) -> b)
-                .thenCompose(x -> committer.apply(this))
-                .thenApply(x -> newMembers);
+    public CompletableFuture<ChatUpdate> inviteMembers(List<String> usernames,
+                                                       List<PublicKeyHash> identities,
+                                                       SigningPrivateKeyAndPublicHash ourChatIdentity,
+                                                       MessageStore ourStore,
+                                                       ContentAddressedStorage ipfs,
+                                                       Hasher hasher) {
+        List<Integer> range = IntStream.range(0, usernames.size()).mapToObj(i -> i).collect(Collectors.toList());
+        return Futures.reduceAll(range, ChatUpdate.empty(this),
+                (u, i) -> {
+                    String username = usernames.get(i);
+                    PublicKeyHash identity = identities.get(i);
+
+                    Member us = u.state.host();
+                    Id newMember = u.state.host.fork(us.membersInvited);
+                    Invite invite = new Invite(username, identity, newMember);
+
+                    TreeClock newTime = u.state.current.withMember(newMember);
+                    return u.state.sendMessage(invite, ourChatIdentity, ourStore, ipfs, hasher);
+                },
+                (a, b) -> a.apply(b));
     }
 
     @Override
     public CborObject toCbor() {
         Map<String, Cborable> result = new TreeMap<>();
         result.put("v", new CborObject.CborLong(0));
+        result.put("i", new CborObject.CborString(chatUid));
         result.put("h", host);
         result.put("c", current);
         result.put("m", new CborObject.CborList(members));
@@ -320,25 +320,26 @@ public class Chat implements Cborable {
             throw new IllegalStateException("Incorrect cbor: " + cbor);
         CborObject.CborMap m = (CborObject.CborMap) cbor;
         long version = m.getLong("v");
+        String chatUid = m.getString("i");
         Id host = m.get("h", Id::fromCbor);
         TreeClock current = m.get("c", TreeClock::fromCbor);
         Map<Id, Member> members = m.getListMap("m", Id::fromCbor, Member::fromCbor);
         Map<String, GroupProperty> group = m.getMap("g", CborObject.CborString::getString, GroupProperty::fromCbor);
         List<MessageEnvelope> recent = new ArrayList<>(m.getList("r", MessageEnvelope::fromCbor));
-        return new Chat(host, current, members, group, recent);
+        return new Chat(chatUid, host, current, members, group, recent);
     }
 
-    public static Chat createNew(String username, PublicKeyHash identity) {
+    public static Chat createNew(String uid, String username, PublicKeyHash identity) {
         Id creator = Id.creator();
         Member us = new Member(username, creator, identity, 0, 0);
         HashMap<Id, Member> members = new HashMap<>();
         members.put(creator, us);
         TreeClock zero = TreeClock.init(Arrays.asList(us.id));
         HashMap<String, GroupProperty> groupState = new HashMap<>();
-        return new Chat(creator, zero, members, groupState, new ArrayList<>());
+        return new Chat(uid, creator, zero, members, groupState, new ArrayList<>());
     }
 
-    public static List<Chat> createNew(List<String> usernames, List<PublicKeyHash> identities) {
+    public static List<Chat> createNew(String uid, List<String> usernames, List<PublicKeyHash> identities) {
         HashMap<Id, Member> members = new HashMap<>();
         List<Id> initialMembers = new ArrayList<>();
 
@@ -351,7 +352,7 @@ public class Chat implements Cborable {
         TreeClock genesis = TreeClock.init(initialMembers);
 
         return initialMembers.stream()
-                .map(id -> new Chat(id, genesis, members.entrySet().stream()
+                .map(id -> new Chat(uid, id, genesis, members.entrySet().stream()
                         .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().copy())), new HashMap<>(), new ArrayList<>()))
                 .collect(Collectors.toList());
     }

--- a/src/peergos/shared/messaging/ChatUpdate.java
+++ b/src/peergos/shared/messaging/ChatUpdate.java
@@ -1,0 +1,37 @@
+package peergos.shared.messaging;
+
+import peergos.shared.display.*;
+
+import java.util.*;
+
+public class ChatUpdate {
+    public final Chat state;
+    public final List<SignedMessage> newMessages;
+    public final List<FileRef> mediaToCopy;
+    public final Set<String> toRevokeAccess;
+
+    public ChatUpdate(Chat state, List<SignedMessage> newMessages, List<FileRef> mediaToCopy, Set<String> toRevokeAccess) {
+        this.state = state;
+        this.newMessages = newMessages;
+        this.mediaToCopy = mediaToCopy;
+        this.toRevokeAccess = toRevokeAccess;
+    }
+
+    public ChatUpdate apply(ChatUpdate next) {
+        ArrayList<SignedMessage> msgs = new ArrayList<>(newMessages);
+        msgs.addAll(next.newMessages);
+        ArrayList<FileRef> refs = new ArrayList<>(mediaToCopy);
+        refs.addAll(next.mediaToCopy);
+        Set<String> toRevoke = new HashSet(toRevokeAccess);
+        toRevoke.addAll(next.toRevokeAccess);
+        return new ChatUpdate(next.state, msgs, refs, toRevoke);
+    }
+
+    public ChatUpdate withState(Chat c) {
+        return new ChatUpdate(c, newMessages, mediaToCopy, toRevokeAccess);
+    }
+
+    public static ChatUpdate empty(Chat c) {
+        return new ChatUpdate(c, Collections.emptyList(), Collections.emptyList(), Collections.emptySet());
+    }
+}

--- a/src/peergos/shared/messaging/Member.java
+++ b/src/peergos/shared/messaging/Member.java
@@ -10,10 +10,10 @@ public class Member implements Cborable {
     public final String username;
     public final Id id;
     public final PublicKeyHash identity;
-    public Optional<OwnerProof> chatIdentity;
-    public long messagesMergedUpto;
-    public int membersInvited;
-    public boolean removed;
+    public final Optional<OwnerProof> chatIdentity;
+    public final  long messagesMergedUpto;
+    public final int membersInvited;
+    public final boolean removed;
 
     public Member(String username,
                   Id id,
@@ -33,6 +33,18 @@ public class Member implements Cborable {
 
     public Member(String username, Id id, PublicKeyHash identity, long messagesMergedUpto, int membersInvited) {
         this(username, id, identity, Optional.empty(), messagesMergedUpto, membersInvited, false);
+    }
+
+    public Member incrementInvited() {
+        return new Member(username, id, identity, chatIdentity, messagesMergedUpto, membersInvited + 1, removed);
+    }
+
+    public Member incrementMessages() {
+        return new Member(username, id, identity, chatIdentity, messagesMergedUpto + 1, membersInvited, removed);
+    }
+
+    public Member removed(boolean updated) {
+        return new Member(username, id, identity, chatIdentity, messagesMergedUpto, membersInvited, updated);
     }
 
     public Member withChatId(OwnerProof proof) {

--- a/src/peergos/shared/messaging/MessageStore.java
+++ b/src/peergos/shared/messaging/MessageStore.java
@@ -1,5 +1,7 @@
 package peergos.shared.messaging;
 
+import peergos.shared.user.*;
+
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -9,7 +11,7 @@ public interface MessageStore {
 
     CompletableFuture<List<SignedMessage>> getMessages(long fromIndex, long toIndex);
 
-    CompletableFuture<Boolean> addMessage(long msgIndex, SignedMessage msg);
+    CompletableFuture<Snapshot> addMessage(Snapshot initialVersion, Committer committer, long msgIndex, SignedMessage msg);
 
-    CompletableFuture<Boolean> revokeAccess(String username);
+    CompletableFuture<Snapshot> revokeAccess(Set<String> usernames);
 }

--- a/src/peergos/shared/messaging/messages/ApplicationMessage.java
+++ b/src/peergos/shared/messaging/messages/ApplicationMessage.java
@@ -16,6 +16,11 @@ public class ApplicationMessage implements Message {
     }
 
     @Override
+    public String toString() {
+        return body.stream().map(Object::toString).collect(Collectors.joining());
+    }
+
+    @Override
     public Type type() {
         return Type.Application;
     }

--- a/src/peergos/shared/messaging/messages/Invite.java
+++ b/src/peergos/shared/messaging/messages/Invite.java
@@ -9,10 +9,12 @@ import java.util.*;
 public class Invite implements Message {
     public final String username;
     public final PublicKeyHash identity;
+    public final Id recipientId;
 
-    public Invite(String username, PublicKeyHash identity) {
+    public Invite(String username, PublicKeyHash identity, Id recipientId) {
         this.username = username;
         this.identity = identity;
+        this.recipientId = recipientId;
     }
 
     @Override
@@ -25,6 +27,7 @@ public class Invite implements Message {
         SortedMap<String, Cborable> state = new TreeMap<>();
         state.put("c", new CborObject.CborLong(type().value));
         state.put("u", new CborObject.CborString(username));
+        state.put("r", recipientId);
         state.put("i", identity);
         return CborObject.CborMap.build(state);
     }
@@ -34,7 +37,13 @@ public class Invite implements Message {
             throw new IllegalStateException("Invalid cbor! " + cbor);
         CborObject.CborMap m = (CborObject.CborMap) cbor;
         String username = m.getString("u");
+        Id recipientId = m.get("r", Id::fromCbor);
         PublicKeyHash identity = m.get("i", PublicKeyHash::fromCbor);
-        return new Invite(username, identity);
+        return new Invite(username, identity, recipientId);
+    }
+
+    @Override
+    public String toString() {
+        return "INVITE(" + username + ")";
     }
 }

--- a/src/peergos/shared/messaging/messages/Join.java
+++ b/src/peergos/shared/messaging/messages/Join.java
@@ -47,4 +47,9 @@ public class Join implements Message {
         PublicSigningKey chatIdPublic = m.get("p", PublicSigningKey::fromCbor);
         return new Join(username, identity, chatIdentity, chatIdPublic);
     }
+
+    @Override
+    public String toString() {
+        return "JOIN(" + username + ")";
+    }
 }

--- a/src/peergos/shared/messaging/messages/SetGroupState.java
+++ b/src/peergos/shared/messaging/messages/SetGroupState.java
@@ -45,6 +45,11 @@ public class SetGroupState implements Message {
     }
 
     @Override
+    public String toString() {
+        return "SET-GROUP-STATE(" + key + ", " + value + ")";
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -218,7 +218,9 @@ public class IncomingCapCache {
                 .thenCompose(capsOpt -> {
                     if (capsOpt.isEmpty())
                         return recurse.get();
-                    return Serialize.readFully(capsOpt.get(), crypto, network)
+                    FileWrapper capsFile = capsOpt.get();
+                    return capsFile.getInputStream(capsFile.version.get(capsFile.writer()).props, network, crypto, x-> {})
+                            .thenCompose(r -> Serialize.readFully(r, capsFile.getSize()))
                             .thenApply(CborObject::fromByteArray)
                             .thenApply(CapsInDirectory::fromCbor)
                             .thenCompose(caps -> caps.getChild(path.get(childIndex))

--- a/src/peergos/shared/user/ProfilePaths.java
+++ b/src/peergos/shared/user/ProfilePaths.java
@@ -176,7 +176,7 @@ public class ProfilePaths {
                     if (path.length() == 0) {
                         return Futures.of(false);
                     }
-                    return user.unPublishFile(Paths.get(path));
+                    return user.unPublishFile(Paths.get(path)).thenApply(x -> true);
                 });
     }
 

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -154,11 +154,12 @@ public class SharedWithCache {
                 .thenCompose(child -> getOrMkdirs(child, remaining.subList(1, remaining.size()), network, crypto, child.version, c));
     }
 
-    public CompletableFuture<SharedWithState> getDirSharingState(Path dir) {
+    public CompletableFuture<SharedWithState> getDirSharingState(Path dir, Snapshot in) {
         if (this.ourname == null) {
             return Futures.of(SharedWithState.empty());
         }
-        return base.getDescendentByPath(dir.resolve(DIR_CACHE_FILENAME).toString(), crypto.hasher, network)
+        return base.getUpdated(base.version.mergeAndOverwriteWith(in), network)
+                .thenCompose(updated -> updated.getDescendentByPath(dir.resolve(DIR_CACHE_FILENAME).toString(), crypto.hasher, network))
                 .thenCompose(fopt -> fopt.map(f -> parseCacheFile(f, network, crypto)).orElse(Futures.of(SharedWithState.empty())));
     }
 

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -65,14 +65,14 @@ public class SharedWithCache {
                 );
     }
 
-    private static CompletableFuture<Snapshot> staticAddSharedWith(FileWrapper base,
-                                                                   Access access,
-                                                                   Path toFile,
-                                                                   Set<String> names,
-                                                                   NetworkAccess network,
-                                                                   Crypto crypto,
-                                                                   Snapshot in,
-                                                                   Committer committer) {
+    private static CompletableFuture<Snapshot> addSharedWith(FileWrapper base,
+                                                             Access access,
+                                                             Path toFile,
+                                                             Set<String> names,
+                                                             NetworkAccess network,
+                                                             Crypto crypto,
+                                                             Snapshot in,
+                                                             Committer committer) {
         return base.getUpdated(in, network)
                 .thenCompose(updateed -> retrieveWithFileOrCreate(updateed, toFile.getParent(), network, crypto, in, committer))
                 .thenCompose(p -> {
@@ -100,14 +100,14 @@ public class SharedWithCache {
                                                                         friendDirectory.signingPair(),
                                                                         (s, c) -> Futures.reduceAll(readCaps.getRetrievedCapabilities(),
                                                                                 s,
-                                                                                (v, rc) -> staticAddSharedWith(cacheDirOpt.get(), Access.READ, Paths.get(rc.path), Collections.singleton(friendDirectory.getName()), network, crypto, v, c),
+                                                                                (v, rc) -> addSharedWith(cacheDirOpt.get(), Access.READ, Paths.get(rc.path), Collections.singleton(friendDirectory.getName()), network, crypto, v, c),
                                                                                 (a, b) -> b)
                                                                                 .thenCompose(s2 -> friendDirectory.getUpdated(network)
                                                                                         .thenCompose(updatedFriendDir -> CapabilityStore.loadWriteableLinks(cacheDirOpt.get(), updatedFriendDir,
                                                                                                 ourname, network, crypto, false))
                                                                                         .thenCompose(writeCaps ->
                                                                                                 Futures.reduceAll(writeCaps.getRetrievedCapabilities(), s2,
-                                                                                                        (v, rc) -> staticAddSharedWith(cacheDirOpt.get(), Access.WRITE, Paths.get(rc.path), Collections.singleton(friendDirectory.getName()), network, crypto, v, c),
+                                                                                                        (v, rc) -> addSharedWith(cacheDirOpt.get(), Access.WRITE, Paths.get(rc.path), Collections.singleton(friendDirectory.getName()), network, crypto, v, c),
                                                                                                         (a, b) -> b)
                                                                                         ))))
                                                         .thenApply(y -> true),

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -99,7 +99,7 @@ public class TrieNodeImpl implements TrieNode {
         String[] elements = finalPath.split("/");
         // There may be an entry point further down the tree, but it will have <= permission than this one, unless this is read only
         if (value.isPresent() && (value.get().pointer.isWritable() || !children.containsKey(elements[0])))
-            return network.retrieveEntryPoint(value.get())
+            return network.getFile(version, value.get().pointer, Optional.empty(), value.get().ownerName)
                     .thenCompose(dir -> dir.get().getDescendentByPath(finalPath, hasher, network));
         if (!children.containsKey(elements[0]))
             return CompletableFuture.completedFuture(Optional.empty());

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1632,7 +1632,7 @@ public class UserContext {
 
         return network.synchronizer.applyComplexUpdate(signer.publicKeyHash,
                 parent.signingPair(), (s, c) -> rotateAllKeys(file, parent, true, s, c)
-                        .thenCompose(s2 -> getByPath(pathToFile)
+                        .thenCompose(s2 -> getByPath(pathToFile.toString(), s2)
                                 .thenCompose(newFileOpt -> sharedWithCache
                                         .addSharedWith(SharedWithCache.Access.WRITE, pathToFile, writersToAdd, s2, c))
                                 .thenCompose(s3 -> reSendAllWriteAccessRecursive(pathToFile)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1499,7 +1499,7 @@ public class UserContext {
         // The global root and home folders cannot be shared
         if (dir.getNameCount() == 0 || username == null)
             return Futures.of(SharedWithState.empty());
-        return sharedWithCache.getDirSharingState(dir);
+        return getUserRoot().thenCompose(home -> sharedWithCache.getDirSharingState(dir, home.version));
     }
 
     @JsMethod

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1491,7 +1491,7 @@ public class UserContext {
 
     @JsMethod
     public CompletableFuture<FileSharedWithState> sharedWith(Path p) {
-        return sharedWithCache.getSharedWith(p);
+        return getUserRoot().thenCompose(home -> sharedWithCache.getSharedWith(p, home.version));
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -135,11 +135,13 @@ public class FileWrapper {
     }
 
     public CompletableFuture<FileWrapper> getUpdated(Snapshot version, NetworkAccess network) {
-        if (this.version.get(writer()).equals(version.get(writer())))
-            return CompletableFuture.completedFuture(this);
-        return network.getFile(version, pointer.capability, entryWriter, ownername)
-                .thenApply(Optional::get)
-                .thenApply(f -> f.withTrieNodeOpt(capTrie));
+        return version.withWriter(owner(), writer(), network).thenCompose(v -> {
+            if (this.version.get(writer()).equals(v.get(writer())))
+                return CompletableFuture.completedFuture(this);
+            return network.getFile(v, pointer.capability, entryWriter, ownername)
+                    .thenApply(Optional::get)
+                    .thenApply(f -> f.withTrieNodeOpt(capTrie));
+        });
     }
 
     public PublicKeyHash owner() {


### PR DESCRIPTION
This is a large rewrite of the chat implementation and sharing functions. 

The trigger for this was Chat ending up with duplicated messages because of concurrent updates to our own log. 

Now all the Chat related classes are immutable. 