### PR TITLE
Make local chat modification a sequence of atomic CASes

### DIFF
--- a/src/peergos/server/tests/MessagingTests.java
+++ b/src/peergos/server/tests/MessagingTests.java
@@ -284,15 +284,15 @@ public class MessagingTests {
         }
 
         @Override
-        public CompletableFuture<Snapshot> addMessage(Snapshot initialVersion, Committer committer, long msgIndex, SignedMessage msg) {
+        public CompletableFuture<Snapshot> addMessages(Snapshot initialVersion, Committer committer, long msgIndex, List<SignedMessage> msgs) {
             if (messages.size() != msgIndex)
                 throw new IllegalStateException();
-            messages.add(msg);
+            messages.addAll(msgs);
             return Futures.of(initialVersion);
         }
 
         @Override
-        public CompletableFuture<Snapshot> revokeAccess(Set<String> usernames) {
+        public CompletableFuture<Snapshot> revokeAccess(Set<String> usernames, Snapshot initialVersion, Committer committer) {
             return Futures.of(new Snapshot(Collections.emptyMap()));
         }
 

--- a/src/peergos/shared/messaging/ChatController.java
+++ b/src/peergos/shared/messaging/ChatController.java
@@ -13,6 +13,7 @@ import peergos.shared.util.*;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class ChatController {
@@ -128,8 +129,8 @@ public class ChatController {
 
     @JsMethod
     public CompletableFuture<ChatController> sendMessage(Message message) {
-        return state.sendMessage(message, privateChatState.chatIdentity, store, context.network.dhtClient, hasher)
-                .thenCompose(u -> commitUpdate(u, context.username));
+        return applyAndCommit(chat -> chat.sendMessage(message, privateChatState.chatIdentity, store,
+                context.network.dhtClient, hasher), context.username);
     }
 
     @JsMethod
@@ -156,14 +157,18 @@ public class ChatController {
         return new ChatController(chatUuid, c, store, privateChatState, root, cache, context);
     }
 
+    private ChatController withStore(MessageStore newStore) {
+        return new ChatController(chatUuid, state, newStore, privateChatState, root, cache, context);
+    }
+
     private ChatController withRoot(FileWrapper root) {
         return new ChatController(chatUuid, state, store, privateChatState, root, cache, context);
     }
 
     public CompletableFuture<ChatController> join(SigningPrivateKeyAndPublicHash identity) {
         OwnerProof chatId = OwnerProof.build(identity, privateChatState.chatIdentity.publicKeyHash);
-        return state.join(state.host(), chatId, privateChatState.chatIdPublic, identity, store, context.network.dhtClient, hasher)
-                .thenCompose(u -> commitUpdate(u, context.username));
+        return applyAndCommit(chat -> chat.join(state.host(), chatId, privateChatState.chatIdPublic, identity, store,
+                context.network.dhtClient, hasher), context.username);
     }
 
     @JsMethod
@@ -191,15 +196,14 @@ public class ChatController {
 
     public CompletableFuture<ChatController> invite(List<String> usernames,
                                                     List<PublicKeyHash> identities) {
-        return state.inviteMembers(usernames, identities, privateChatState.chatIdentity, store, context.network.dhtClient, hasher)
-                .thenCompose(u -> commitUpdate(u, context.username));
+        return applyAndCommit(chat -> chat.inviteMembers(usernames, identities, privateChatState.chatIdentity,
+                store, context.network.dhtClient, hasher), context.username);
     }
 
     public CompletableFuture<ChatController> mergeMessages(String username,
                                                            MessageStore mirrorStore) {
         Member mirrorHost = state.getMember(username);
-        return state.merge(chatUuid, mirrorHost.id, mirrorStore, context.network.dhtClient)
-                .thenCompose(u -> commitUpdate(u, username));
+        return applyAndCommit(chat -> chat.merge(chatUuid, mirrorHost.id, mirrorStore, context.network.dhtClient), username);
     }
 
     private CompletableFuture<Snapshot> copyFile(FileWrapper dir, Path sourcePath, String mirrorUsername, Snapshot v, Committer c) {
@@ -242,22 +246,34 @@ public class ChatController {
                 .thenCompose(file -> file.get().overwriteFile(AsyncReader.build(raw), raw.length, context.network, context.crypto, x -> {}, v, com));
     }
 
-    private CompletableFuture<ChatController> commitUpdate(ChatUpdate u, String mirrorUsername) {
+    private CompletableFuture<ChatController> applyAndCommit(Function<Chat, CompletableFuture<ChatUpdate>> modifier,
+                                                             String mirrorUsername) {
+        NetworkAccess network = context.network;
+        return network.synchronizer.applyComplexComputation(context.signer.publicKeyHash, root.signingPair(),
+                (s, c) -> root.getUpdated(s, network)
+                        .thenCompose(updated -> updated.getChild("shared", hasher, network)
+                                .thenCompose(sharedDir -> getChatState(sharedDir.get(), network, context.crypto))
+                                .thenCompose(chatState -> modifier.apply(chatState)
+                                        .thenCompose(u -> commitUpdate(u, mirrorUsername, s, c)))))
+                .thenApply(res -> res.right);
+    }
+
+    private CompletableFuture<Pair<Snapshot, ChatController>> commitUpdate(ChatUpdate u, String mirrorUsername, Snapshot in, Committer c) {
         // 1. rotate access control
         // 2. copy media
         // 3. append messages
         // 4. commit state file
-        return (u.toRevokeAccess.isEmpty() ? Futures.of(store) : store.revokeAccess(u.toRevokeAccess))
-                .thenCompose(x -> context.network.synchronizer.applyComplexUpdate(context.signer.publicKeyHash, root.signingPair(),
-                (s, c) -> Futures.reduceAll(u.mediaToCopy, s, (v, f) -> mirrorMedia(f, this, mirrorUsername, v, c),
-                                (a, b) -> a.merge(b))
+        boolean noRemovals = u.toRevokeAccess.isEmpty();
+        return (noRemovals ? Futures.of(in) : store.revokeAccess(u.toRevokeAccess, in, c))
+                .thenCompose(s -> Futures.reduceAll(u.mediaToCopy, s, (v, f) -> mirrorMedia(f, this, mirrorUsername, v, c),
+                        (a, b) -> a.merge(b))
                         .thenCompose(s2 -> root.getUpdated(s2, context.network)
-                                .thenCompose(base -> Futures.reduceAll(u.newMessages, s2,
-                                        (v, m) -> store.addMessage(v, c, state.host().messagesMergedUpto + u.newMessages.indexOf(m), m),
-                                        (a, b) -> a.merge(b))
-                                        .thenCompose(s4 -> overwriteState(base, u.state, s4, c)))))
-                        .thenCompose(s -> root.getUpdated(s, context.network)
-                                .thenApply(newRoot -> withState(u.state).withRoot(newRoot))));
+                                .thenCompose(base -> (noRemovals ? Futures.of(store) : getChatMessageStore(base, context))
+                                        .thenCompose(newStore -> newStore.addMessages(s2, c, state.host().messagesMergedUpto, u.newMessages))
+                                        .thenCompose(s4 -> overwriteState(base, u.state, s4, c))))
+                        .thenCompose(s5 -> root.getUpdated(s5, context.network)
+                                .thenCompose(newRoot -> getChatMessageStore(newRoot, context)
+                                        .thenApply(newStore -> new Pair<>(s5, withState(u.state).withRoot(newRoot).withStore(newStore))))));
     }
 
     private static CompletableFuture<Pair<FileWrapper, FileWrapper>> getSharedLogAndIndex(FileWrapper chatRoot, Hasher hasher, NetworkAccess network) {
@@ -276,8 +292,8 @@ public class ChatController {
                                 .thenCompose(d -> getSharedLogAndIndex(d, context.crypto.hasher, context.network))));
     }
 
-    public static CompletableFuture<Chat> getChatState(FileWrapper chatRoot, NetworkAccess network, Crypto crypto) {
-        return chatRoot.getChild(SHARED_CHAT_STATE, crypto.hasher, network)
+    public static CompletableFuture<Chat> getChatState(FileWrapper chatSharedDir, NetworkAccess network, Crypto crypto) {
+        return chatSharedDir.getChild(SHARED_CHAT_STATE, crypto.hasher, network)
                 .thenCompose(chatStateOpt -> Serialize.parse(chatStateOpt.get(), Chat::fromCbor, network, crypto));
     }
 

--- a/src/peergos/shared/messaging/MessageStore.java
+++ b/src/peergos/shared/messaging/MessageStore.java
@@ -11,7 +11,7 @@ public interface MessageStore {
 
     CompletableFuture<List<SignedMessage>> getMessages(long fromIndex, long toIndex);
 
-    CompletableFuture<Snapshot> addMessage(Snapshot initialVersion, Committer committer, long msgIndex, SignedMessage msg);
+    CompletableFuture<Snapshot> addMessages(Snapshot initialVersion, Committer committer, long msgIndex, List<SignedMessage> msgs);
 
-    CompletableFuture<Snapshot> revokeAccess(Set<String> usernames);
+    CompletableFuture<Snapshot> revokeAccess(Set<String> usernames, Snapshot initialVersion, Committer committer);
 }

--- a/src/peergos/shared/util/Serialize.java
+++ b/src/peergos/shared/util/Serialize.java
@@ -122,7 +122,7 @@ public class Serialize
                                                  NetworkAccess network,
                                                  Crypto crypto) {
         byte[] res = new byte[(int)f.getSize()];
-        return f.getInputStream(network, crypto, x -> {})
+        return f.getInputStream(f.version.get(f.writer()).props,network, crypto, x -> {})
                 .thenCompose(reader -> reader.readIntoArray(res, 0, (int) f.getSize()))
                 .thenApply(i -> Cborable.parser(parser).apply(res));
     }


### PR DESCRIPTION
This also makes a bulk message log append function.

In the process, FileBackedMessageLog is made immutable, and revoking read access is made to work inside a transaction.