### PR TITLE
Update chat protocol

### DIFF
--- a/src/peergos/server/tests/MessagingTests.java
+++ b/src/peergos/server/tests/MessagingTests.java
@@ -34,32 +34,32 @@ public class MessagingTests {
 
         Chat chat1 = Chat.createNew("uid", "user1", identities.get(0).publicKeyHash);
         OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_1);
 
         ChatUpdate u1_2 = u1_1.state.inviteMember("user2", identities.get(1).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+                chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_2);
         Member user2 = u1_2.state.getMember("user2");
         Chat chat2 = u1_2.state.copy(user2);
         stores.get(1).mirror(stores.get(0));
         OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_1);
 
-        ChatUpdate u1_3 = u1_2.state.sendMessage(text("Welcome!"), chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_3 = u1_2.state.sendMessage(text("Welcome!"), chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_3);
         MessageEnvelope msg1 = u1_3.newMessages.get(u1_3.newMessages.size() - 1).msg;
-        ChatUpdate u2_2 = u2_1.state.merge("chat-uid", chat1.host, stores.get(0), ipfs).join();
+        ChatUpdate u2_2 = u2_1.state.merge("chat-uid", chat1.host, identities.get(1), stores.get(0), ipfs, crypto).join();
         stores.get(1).apply(u2_2);
         Assert.assertTrue(stores.get(1).messages.get(3).msg.equals(msg1));
 
         ReplyTo reply = ReplyTo.build(msg1, text("This is cool!"), hasher).join();
-        ChatUpdate u2_3 = u2_2.state.sendMessage(reply, chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+        ChatUpdate u2_3 = u2_2.state.sendMessage(reply, chatIdentities.get(1).chatIdentity, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_3);
         MessageEnvelope msg2 = u2_3.newMessages.get(u2_3.newMessages.size() - 1).msg;;
 
-        ChatUpdate u1_4 = u1_3.state.merge("chat-uid", chat2.host, stores.get(1), ipfs).join();
+        ChatUpdate u1_4 = u1_3.state.merge("chat-uid", chat2.host, identities.get(0), stores.get(1), ipfs, crypto).join();
         stores.get(0).apply(u1_4);
         Assert.assertTrue(stores.get(0).messages.get(4).msg.equals(msg2));
     }
@@ -72,28 +72,28 @@ public class MessagingTests {
 
         Chat chat1 = Chat.createNew("uid", "user1", identities.get(0).publicKeyHash);
         OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_1);
 
         ChatUpdate u1_2 = u1_1.state.inviteMember("user2", identities.get(1).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+                chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_2);
         Member user2 = u1_2.state.getMember("user2");
 
         Chat chat2 = u1_2.state.copy(user2);
         stores.get(1).mirror(stores.get(0));
         OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, crypto).join();
 
         ChatUpdate u1_3 = u1_2.state.inviteMember("user3", identities.get(2).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+                chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_3);
         Member user3 = u1_3.state.getMember("user3");
 
         Chat chat3 = u1_3.state.copy(user3);
         stores.get(2).mirror(stores.get(0));
         OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(0), ipfs, hasher).join();
+        chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(0), ipfs, crypto).join();
 
         Assert.assertTrue(! user2.id.equals(user3.id));
     }
@@ -106,37 +106,37 @@ public class MessagingTests {
 
         Chat chat1 = Chat.createNew("uid", "user1", identities.get(0).publicKeyHash);
         OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_1);
 
         ChatUpdate u1_2 = u1_1.state.inviteMember("user2", identities.get(1).publicKeyHash,
-                chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+                chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_2);
         Member user2 = u1_2.state.getMember("user2");
         Chat chat2 = u1_2.state.copy(user2);
         stores.get(1).mirror(stores.get(0));
         OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        ChatUpdate u2_1 = chat2.join(user2, user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_1);
 
         ChatUpdate u2_2 = u2_1.state.inviteMember("user3", identities.get(2).publicKeyHash,
-                chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+                chatIdentities.get(1).chatIdentity, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_2);
         Member user3 = u2_2.state.getMember("user3");
         Chat chat3 = u2_2.state.copy(user3);
         stores.get(2).mirror(stores.get(1));
         OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-        ChatUpdate u3_1 = chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), ipfs, hasher).join();
+        ChatUpdate u3_1 = chat3.join(user3, user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), ipfs, crypto).join();
         stores.get(2).apply(u3_1);
 
-        ChatUpdate u3_2 = u3_1.state.sendMessage(text("Hey All!"), chatIdentities.get(2).chatIdentity, stores.get(2), ipfs, hasher).join();
+        ChatUpdate u3_2 = u3_1.state.sendMessage(text("Hey All!"), chatIdentities.get(2).chatIdentity, identities.get(2), stores.get(2), ipfs, crypto).join();
         stores.get(2).apply(u3_2);
         MessageEnvelope msg1 = u3_2.newMessages.get(u3_2.newMessages.size() - 1).msg;
-        ChatUpdate u2_3 = u2_2.state.merge("chat-uid", chat3.host, stores.get(2), ipfs).join();
+        ChatUpdate u2_3 = u2_2.state.merge("chat-uid", chat3.host, identities.get(1), stores.get(2), ipfs, crypto).join();
         stores.get(1).apply(u2_3);
         Assert.assertTrue(stores.get(1).messages.get(5).msg.equals(msg1));
 
-        ChatUpdate u1_3 = u1_2.state.merge("chat-uid", chat2.host, stores.get(1), ipfs).join();
+        ChatUpdate u1_3 = u1_2.state.merge("chat-uid", chat2.host, identities.get(0), stores.get(1), ipfs, crypto).join();
         stores.get(0).apply(u1_3);
         Assert.assertTrue(stores.get(0).messages.get(5).msg.equals(msg1));
     }
@@ -156,88 +156,88 @@ public class MessagingTests {
         Chat chat3 = chats.get(2);
         Chat chat4 = chats.get(3);
         OwnerProof user1ChatId = OwnerProof.build(identities.get(0), chatIdentities.get(0).chatIdentity.publicKeyHash);
-        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_1 = chat1.join(chat1.host(), user1ChatId, chatIdentities.get(0).chatIdPublic, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_1);
 
         OwnerProof user2ChatId = OwnerProof.build(identities.get(1), chatIdentities.get(1).chatIdentity.publicKeyHash);
-        ChatUpdate u2_1 = chat2.join(chat2.host(), user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, hasher).join();
+        ChatUpdate u2_1 = chat2.join(chat2.host(), user2ChatId, chatIdentities.get(1).chatIdPublic, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_1);
 
         OwnerProof user3ChatId = OwnerProof.build(identities.get(2), chatIdentities.get(2).chatIdentity.publicKeyHash);
-        ChatUpdate u3_1 = chat3.join(chat3.host(), user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), ipfs, hasher).join();
+        ChatUpdate u3_1 = chat3.join(chat3.host(), user3ChatId, chatIdentities.get(2).chatIdPublic, identities.get(2), stores.get(2), ipfs, crypto).join();
         stores.get(2).apply(u3_1);
 
         OwnerProof user4ChatId = OwnerProof.build(identities.get(3), chatIdentities.get(3).chatIdentity.publicKeyHash);
-        ChatUpdate u4_1 = chat4.join(chat4.host(), user4ChatId, chatIdentities.get(3).chatIdPublic, identities.get(3), stores.get(3), ipfs, hasher).join();
+        ChatUpdate u4_1 = chat4.join(chat4.host(), user4ChatId, chatIdentities.get(3).chatIdPublic, identities.get(3), stores.get(3), ipfs, crypto).join();
         stores.get(3).apply(u4_1);
 
         // partition and chat between user1 and user2
         TreeClock t1_0 = u1_1.state.current;
-        ChatUpdate u1_2 = u1_1.state.sendMessage(text("Hey All, I'm user1!"), chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_2 = u1_1.state.sendMessage(text("Hey All, I'm user1!"), chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_2);
         MessageEnvelope msg1 = u1_2.newMessages.get(u1_2.newMessages.size() - 1).msg;
         Assert.assertTrue(msg1.timestamp.isIncrementOf(t1_0));
 
         String chatUid = "chat-uid";
-        ChatUpdate u2_2 = u2_1.state.merge(chatUid, chat1.host, stores.get(0), ipfs).join();
+        ChatUpdate u2_2 = u2_1.state.merge(chatUid, chat1.host, identities.get(1), stores.get(0), ipfs, crypto).join();
         stores.get(1).apply(u2_2);
         TreeClock t2_0 = u2_2.state.current;
-        ChatUpdate u2_3 = u2_2.state.sendMessage(text("Hey user1! I'm user2."), chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+        ChatUpdate u2_3 = u2_2.state.sendMessage(text("Hey user1! I'm user2."), chatIdentities.get(1).chatIdentity, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_3);
         MessageEnvelope msg2 = u2_3.newMessages.get(u2_3.newMessages.size() - 1).msg;
         Assert.assertTrue(msg2.timestamp.isIncrementOf(t2_0));
 
-        ChatUpdate u1_3 = u1_2.state.merge(chatUid, chat2.host, stores.get(1), ipfs).join();
+        ChatUpdate u1_3 = u1_2.state.merge(chatUid, chat2.host, identities.get(0), stores.get(1), ipfs, crypto).join();
         stores.get(0).apply(u1_3);
         TreeClock t1_1 = u1_3.state.current;
-        ChatUpdate u1_4 = u1_3.state.sendMessage(text("Hey user2, whats up?"), chatIdentities.get(0).chatIdentity, stores.get(0), ipfs, hasher).join();
+        ChatUpdate u1_4 = u1_3.state.sendMessage(text("Hey user2, whats up?"), chatIdentities.get(0).chatIdentity, identities.get(0), stores.get(0), ipfs, crypto).join();
         stores.get(0).apply(u1_4);
         MessageEnvelope msg3 = u1_4.newMessages.get(u1_4.newMessages.size() - 1).msg;
         Assert.assertTrue(msg3.timestamp.isIncrementOf(t1_1));
 
-        ChatUpdate u2_4 = u2_3.state.merge(chatUid, chat1.host, stores.get(0), ipfs).join();
+        ChatUpdate u2_4 = u2_3.state.merge(chatUid, chat1.host, identities.get(1), stores.get(0), ipfs, crypto).join();
         stores.get(1).apply(u2_4);
         TreeClock t2_1 = u2_4.state.current;
         ChatUpdate u2_5 = u2_4.state.sendMessage(text("Just saving the world one decentralized chat at a time.."),
-                chatIdentities.get(1).chatIdentity, stores.get(1), ipfs, hasher).join();
+                chatIdentities.get(1).chatIdentity, identities.get(1), stores.get(1), ipfs, crypto).join();
         stores.get(1).apply(u2_5);
         MessageEnvelope msg4 = u2_5.newMessages.get(u2_5.newMessages.size() - 1).msg;
         Assert.assertTrue(msg4.timestamp.isIncrementOf(t2_1));
 
-        ChatUpdate u1_5 = u1_4.state.merge(chatUid, chat2.host, stores.get(1), ipfs).join();
+        ChatUpdate u1_5 = u1_4.state.merge(chatUid, chat2.host, identities.get(0), stores.get(1), ipfs, crypto).join();
         stores.get(0).apply(u1_5);
         Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
         Assert.assertEquals(stores.get(1).messages.size(), 6);
 
         // also between user3 and user4
-        ChatUpdate u3_2 = u3_1.state.sendMessage(text("Hey All, I'm user3!"), chatIdentities.get(2).chatIdentity, stores.get(2), ipfs, hasher).join();
+        ChatUpdate u3_2 = u3_1.state.sendMessage(text("Hey All, I'm user3!"), chatIdentities.get(2).chatIdentity, identities.get(2), stores.get(2), ipfs, crypto).join();
         stores.get(2).apply(u3_2);
 
-        ChatUpdate u4_2 = u4_1.state.merge(chatUid, chat3.host, stores.get(2), ipfs).join();
+        ChatUpdate u4_2 = u4_1.state.merge(chatUid, chat3.host, identities.get(3), stores.get(2), ipfs, crypto).join();
         stores.get(3).apply(u4_2);
-        ChatUpdate u4_3 = u4_2.state.sendMessage(text("Hey user3! I'm user4."), chatIdentities.get(3).chatIdentity, stores.get(3), ipfs, hasher).join();
+        ChatUpdate u4_3 = u4_2.state.sendMessage(text("Hey user3! I'm user4."), chatIdentities.get(3).chatIdentity, identities.get(3), stores.get(3), ipfs, crypto).join();
         stores.get(3).apply(u4_3);
 
-        ChatUpdate u3_3 = u3_2.state.merge(chatUid, chat4.host, stores.get(3), ipfs).join();
+        ChatUpdate u3_3 = u3_2.state.merge(chatUid, chat4.host, identities.get(2), stores.get(3), ipfs, crypto).join();
         stores.get(2).apply(u3_3);
-        ChatUpdate u3_4 = u3_3.state.sendMessage(text("Hey user4, whats up?"), chatIdentities.get(2).chatIdentity, stores.get(2), ipfs, hasher).join();
+        ChatUpdate u3_4 = u3_3.state.sendMessage(text("Hey user4, whats up?"), chatIdentities.get(2).chatIdentity, identities.get(2), stores.get(2), ipfs, crypto).join();
         stores.get(2).apply(u3_4);
 
-        ChatUpdate u4_4 = u4_3.state.merge(chatUid, chat3.host, stores.get(2), ipfs).join();
+        ChatUpdate u4_4 = u4_3.state.merge(chatUid, chat3.host, identities.get(3), stores.get(2), ipfs, crypto).join();
         stores.get(3).apply(u4_4);
-        ChatUpdate u4_5 = u4_4.state.sendMessage(text("Just saving the world one encrypted chat at a time.."), chatIdentities.get(3).chatIdentity, stores.get(3), ipfs, hasher).join();
+        ChatUpdate u4_5 = u4_4.state.sendMessage(text("Just saving the world one encrypted chat at a time.."), chatIdentities.get(3).chatIdentity, identities.get(3), stores.get(3), ipfs, crypto).join();
         stores.get(3).apply(u4_5);
 
-        ChatUpdate u3_5 = u3_4.state.merge(chatUid, chat4.host, stores.get(3), ipfs).join();
+        ChatUpdate u3_5 = u3_4.state.merge(chatUid, chat4.host, identities.get(2), stores.get(3), ipfs, crypto).join();
         stores.get(2).apply(u3_5);
         Assert.assertTrue(stores.get(3).messages.containsAll(stores.get(2).messages));
         Assert.assertEquals(stores.get(3).messages.size(), 6);
 
         // now resolve the partition and merge states
-        ChatUpdate u1_6 = u1_5.state.merge(chatUid, chat4.host, stores.get(3), ipfs).join();
+        ChatUpdate u1_6 = u1_5.state.merge(chatUid, chat4.host, identities.get(0), stores.get(3), ipfs, crypto).join();
         stores.get(0).apply(u1_6);
         Assert.assertEquals(stores.get(0).messages.size(), 12);
-        ChatUpdate u2_6 = u2_5.state.merge(chatUid, chat1.host, stores.get(0), ipfs).join();
+        ChatUpdate u2_6 = u2_5.state.merge(chatUid, chat1.host, identities.get(1), stores.get(0), ipfs, crypto).join();
         stores.get(1).apply(u2_6);
         Assert.assertTrue(stores.get(1).messages.containsAll(stores.get(0).messages));
 

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1747,6 +1747,27 @@ public class PeergosNetworkUtils {
         // recent messages
         List<MessageEnvelope> recentA = controllerA.getRecent();
         Assert.assertTrue(recentA.size() > 0);
+
+        // removal status
+        Member originalB = controllerA.getMember(b.username);
+        Id originalBId = originalB.id;
+        Assert.assertTrue(originalB.removed);
+
+        // reinvite member
+        controllerA = msgA.invite(controllerA, Arrays.asList(b.username), Arrays.asList(b.signer.publicKeyHash)).join();
+        Assert.assertTrue(! controllerA.getMember(b.username).removed);
+
+        // rejoin chat
+        controllerB = msgB.mergeMessages(controllerB, a.username).join();
+        Member newB = controllerB.getMember(b.username);
+        boolean bRemoved2 = newB.removed;
+        Assert.assertTrue(! bRemoved2);
+
+        Id newBId = newB.id;
+        Assert.assertTrue(! originalBId.equals(newBId));
+        PublicKeyHash newChatId = newB.chatIdentity.get().getOwner(network.dhtClient).join();
+        PublicKeyHash oldChatId = originalB.chatIdentity.get().getOwner(network.dhtClient).join();
+        Assert.assertTrue("New chat identity", !newChatId.equals(oldChatId));
     }
 
     public static void concurrentChatMerges(NetworkAccess network, Random random) {

--- a/src/peergos/shared/messaging/ChatUpdate.java
+++ b/src/peergos/shared/messaging/ChatUpdate.java
@@ -9,12 +9,25 @@ public class ChatUpdate {
     public final List<SignedMessage> newMessages;
     public final List<FileRef> mediaToCopy;
     public final Set<String> toRevokeAccess;
+    public final Optional<PrivateChatState> priv;
 
-    public ChatUpdate(Chat state, List<SignedMessage> newMessages, List<FileRef> mediaToCopy, Set<String> toRevokeAccess) {
+    public ChatUpdate(Chat state,
+                      List<SignedMessage> newMessages,
+                      List<FileRef> mediaToCopy,
+                      Set<String> toRevokeAccess,
+                      Optional<PrivateChatState> priv) {
         this.state = state;
         this.newMessages = newMessages;
         this.mediaToCopy = mediaToCopy;
         this.toRevokeAccess = toRevokeAccess;
+        this.priv = priv;
+    }
+
+    public ChatUpdate(Chat state,
+                      List<SignedMessage> newMessages,
+                      List<FileRef> mediaToCopy,
+                      Set<String> toRevokeAccess) {
+        this(state, newMessages, mediaToCopy, toRevokeAccess, Optional.empty());
     }
 
     public ChatUpdate apply(ChatUpdate next) {
@@ -24,14 +37,14 @@ public class ChatUpdate {
         refs.addAll(next.mediaToCopy);
         Set<String> toRevoke = new HashSet(toRevokeAccess);
         toRevoke.addAll(next.toRevokeAccess);
-        return new ChatUpdate(next.state, msgs, refs, toRevoke);
+        return new ChatUpdate(next.state, msgs, refs, toRevoke, priv.flatMap(a -> next.priv.map(a::apply)));
     }
 
     public ChatUpdate withState(Chat c) {
-        return new ChatUpdate(c, newMessages, mediaToCopy, toRevokeAccess);
+        return new ChatUpdate(c, newMessages, mediaToCopy, toRevokeAccess, priv);
     }
 
     public static ChatUpdate empty(Chat c) {
-        return new ChatUpdate(c, Collections.emptyList(), Collections.emptyList(), Collections.emptySet());
+        return new ChatUpdate(c, Collections.emptyList(), Collections.emptyList(), Collections.emptySet(), Optional.empty());
     }
 }

--- a/src/peergos/shared/messaging/Messenger.java
+++ b/src/peergos/shared/messaging/Messenger.java
@@ -149,9 +149,15 @@ public class Messenger {
                 .thenApply(f -> current.with(state));
     }
 
+    public boolean allOtherMembersRemoved(ChatController current) {
+        Set<String> memberNames = current.getMemberNames();
+        return memberNames.contains(context.username) && memberNames.size() == 1;
+    }
+
     @JsMethod
     public CompletableFuture<ChatController> mergeMessages(ChatController current, String mirrorUsername) {
-        if (mirrorUsername.equals(this.context.username)) {
+        if (mirrorUsername.equals(this.context.username) ||
+                (current.deletedMemberNames().contains(mirrorUsername) && ! allOtherMembersRemoved(current))) {
             return Futures.of(current);
         }
         return Futures.asyncExceptionally(

--- a/src/peergos/shared/messaging/PrivateChatState.java
+++ b/src/peergos/shared/messaging/PrivateChatState.java
@@ -27,6 +27,12 @@ public class PrivateChatState implements Cborable {
         return new PrivateChatState(chatIdentity, chatIdPublic, newDeleted);
     }
 
+    public PrivateChatState apply(PrivateChatState newer) {
+        HashSet<String> newDeleted = new HashSet<>(deletedMembers);
+        newDeleted.addAll(newer.deletedMembers);
+        return new PrivateChatState(newer.chatIdentity, newer.chatIdPublic, newDeleted);
+    }
+
     @Override
     public CborObject toCbor() {
         Map<String, Cborable> result = new TreeMap<>();


### PR DESCRIPTION
1. enforce dropping of messages from removed members of a chat
2. make users re-invited to a chat after being removed generate
   a new chat identity, under the new Id

We now need to keep polling removed members if we have been removed from a chat (all other members are deleted). Otherwise we won't get a new rejoin invite.