### PR TITLE
Support webp and jpeg thumbnails

### DIFF
--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -3,7 +3,7 @@ package peergos.server.tests.simulation;
 import peergos.server.simulation.AccessControl;
 import peergos.server.simulation.FileSystem;
 import peergos.server.simulation.Stat;
-import peergos.shared.user.fs.FileProperties;
+import peergos.shared.user.fs.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -155,7 +155,7 @@ public class NativeFileSystemImpl implements FileSystem {
                         ZoneOffset.systemDefault());
 
                 // These things are a bit awkward, not supporting them for now
-                Optional<byte[]> thumbnail = Optional.empty();
+                Optional<Thumbnail> thumbnail = Optional.empty();
                 boolean isHidden = false;
                 String mimeType="NOT_SUPPORTED";
 

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -36,7 +36,7 @@ import java.util.stream.*;
 public class FileWrapper {
 	private static final Logger LOG = Logger.getGlobal();
 
-    private final static int THUMBNAIL_SIZE = 100;
+    private final static int THUMBNAIL_SIZE = 400;
     private static final NativeJSThumbnail thumbnail = new NativeJSThumbnail();
 
     private final RetrievedCapability pointer;

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1757,9 +1757,9 @@ public class FileWrapper {
         if (data.length == 0)
             return Optional.empty();
         if (base64Url.startsWith("data:image/jpeg;base64,"))
-            return Optional.of(new Thumbnail("/image/jpeg", data));
+            return Optional.of(new Thumbnail("image/jpeg", data));
         if (base64Url.startsWith("data:image/webp;base64,"))
-            return Optional.of(new Thumbnail("/image/webp", data));
+            return Optional.of(new Thumbnail("image/webp", data));
         throw new IllegalStateException("Unknown image type for generated thumbnail!");
     }
 

--- a/src/peergos/shared/user/fs/Thumbnail.java
+++ b/src/peergos/shared/user/fs/Thumbnail.java
@@ -1,0 +1,16 @@
+package peergos.shared.user.fs;
+
+import jsinterop.annotations.*;
+
+public class Thumbnail {
+    public final String mimeType;
+    public final byte[] data;
+
+    @JsConstructor
+    public Thumbnail(String mimeType, byte[] data) {
+        if (data.length > 100*1024)
+            throw new IllegalStateException("Image thumbnails must be < 100 KiB!");
+        this.mimeType = mimeType;
+        this.data = data;
+    }
+}

--- a/src/peergos/shared/user/fs/VideoThumbnail.java
+++ b/src/peergos/shared/user/fs/VideoThumbnail.java
@@ -13,6 +13,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -69,7 +70,7 @@ public class VideoThumbnail {
         return true;
     }
 
-    public static byte[] create(String filename, int height, int width) {
+    public static Optional<Thumbnail> create(String filename, int height, int width) {
 //        new JFXPanel(); // initialises toolkit
 //        Media video = new Media("file://" + filename);
 //        MediaPlayer mediaPlayer = new MediaPlayer(video);
@@ -105,7 +106,7 @@ public class VideoThumbnail {
 //                ex.printStackTrace();
 //            }
 //        }
-        return new byte[0];
+        return Optional.empty();
     }
 }
 


### PR DESCRIPTION
This adds support for webp and jpeg thumbnails. 

Existing files with png thumbnails are support with backwards compatible cbor decoding. 

We also put a hard limit of 100KiB for a thumbnail. 