### PR TITLE
Decouple boxer and identity key pairs from login

### DIFF
--- a/src/peergos/server/AggregatedMetrics.java
+++ b/src/peergos/server/AggregatedMetrics.java
@@ -34,6 +34,9 @@ public class AggregatedMetrics {
     public static final Counter MUTABLE_POINTERS_SET  = build("mutable_pointers_set", "Total mutable-pointers set calls.");
     public static final Counter MUTABLE_POINTERS_GET  = build("mutable_pointers_get", "Total mutable-pointers get calls.");
 
+    public static final Counter LOGIN_SET  = build("login_set", "Total login set calls.");
+    public static final Counter LOGIN_GET  = build("login_get", "Total login get calls.");
+
     public static final Counter GET_ALL_USERNAMES  = build("core_node_get_all_usernames", "Total get-all-usernames calls.");
     public static final Counter GET_USERNAME  = build("core_node_get_username", "Total get-username calls.");
     public static final Counter GET_PUBLIC_KEY  = build("core_node_get_public_key", "Total get-public-key calls.");

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -7,6 +7,7 @@ import peergos.server.crypto.asymmetric.curve25519.*;
 import peergos.server.crypto.hash.*;
 import peergos.server.crypto.random.*;
 import peergos.server.crypto.symmetric.*;
+import peergos.server.login.*;
 import peergos.server.mutable.*;
 import peergos.server.space.*;
 import peergos.server.sql.*;
@@ -265,6 +266,7 @@ public class Builder {
                                          MutablePointersProxy proxingMutable,
                                          JdbcIpnsAndSocial localSocial,
                                          UsageStore usageStore,
+                                         JdbcAccount rawAccount,
                                          Account account,
                                          Hasher hasher) {
         Multihash nodeId = localStorage.id().join();
@@ -274,7 +276,7 @@ public class Builder {
         boolean isPkiNode = nodeId.equals(pkiServerId);
         return isPkiNode ?
                 buildPkiCorenode(new PinningMutablePointers(localPointers, localStorage), account, localStorage, a) :
-                new MirrorCoreNode(new HTTPCoreNode(buildP2pHttpProxy(a), pkiServerId), account, proxingMutable,
+                new MirrorCoreNode(new HTTPCoreNode(buildP2pHttpProxy(a), pkiServerId), rawAccount, account, proxingMutable,
                         localStorage, rawPointers, transactions, localSocial, usageStore, peergosId,
                         a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"), hasher);
     }

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -558,7 +558,9 @@ public class Main extends Builder {
             Admin storageAdmin = new Admin(adminUsernames, userQuotas, core, localStorage, enableWaitlist);
             ProxyingSpaceUsage p2pSpaceUsage = new ProxyingSpaceUsage(nodeId, corePropagator, spaceChecker, httpSpaceUsage);
 
-            VerifyingAccount verifyingAccount = new VerifyingAccount(account, core, localStorage);
+            AccountProxy accountProxy = new HttpAccount(p2pHttpProxy, pkiServerNodeId);
+            Account p2pAccount = new ProxyingAccount(nodeId, core, account, accountProxy);
+            VerifyingAccount verifyingAccount = new VerifyingAccount(p2pAccount, core, localStorage);
             UserService peergos = new UserService(p2pDht, crypto, corePropagator, verifyingAccount, p2pSocial, p2mMutable, storageAdmin,
                     p2pSpaceUsage, new ServerMessageStore(getDBConnector(a, "server-messages-sql-file", dbConnectionPool),
                     sqlCommands, core, p2pDht), gc);

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -141,6 +141,7 @@ public class Main extends Builder {
                     new Command.Arg("default-quota", "default maximum storage per user", false, Long.toString(1024L * 1024 * 1024)),
                     new Command.Arg("mirror.node.id", "Mirror a server's data locally", false),
                     new Command.Arg("mirror.username", "Mirror a user's data locally", false),
+                    new Command.Arg("login-keypair", "The keypair used to mirror the login data for a user (use with 'mirror.username' arg)", false),
                     new Command.Arg("public-server", "Are we a public server? (allow http GETs to API)", false, "false"),
                     new Command.Arg("run-gateway", "Run a local Peergos gateway", false, "true"),
                     new Command.Arg("gateway-port", "Port to run a local gateway on", false, "9000"),
@@ -616,6 +617,7 @@ public class Main extends Builder {
                     while (true) {
                         try {
                             Optional<SigningKeyPair> mirrorLoginDataPair = a.getOptionalArg("login-keypair").map(SigningKeyPair::fromString);
+                            System.out.println("WARNING: Mirroring users data, but not their login, see option 'login-keypair'");
                             String username = a.getArg("mirror.username");
                             Mirror.mirrorUser(username, mirrorLoginDataPair, core, p2mMutable, p2pAccount, localStorage,
                                     rawPointers, rawAccount, transactions, hasher);

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -516,10 +516,11 @@ public class Main extends Builder {
             UsageStore usageStore = new JdbcUsageStore(usageDb, sqlCommands);
             JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file", dbConnectionPool), sqlCommands);
             HttpSpaceUsage httpSpaceUsage = new HttpSpaceUsage(p2pHttpProxy, p2pHttpProxy);
-            Account rawAccount = new AccountWithStorage(localStorage, localPointers, new JdbcAccount(getDBConnector(a, "account-sql-file", dbConnectionPool), sqlCommands));
+            JdbcAccount rawAccount = new JdbcAccount(getDBConnector(a, "account-sql-file", dbConnectionPool), sqlCommands);
+            Account account = new AccountWithStorage(localStorage, localPointers, rawAccount);
 
             CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
-                    rawSocial, usageStore, rawAccount, hasher);
+                    rawSocial, usageStore, rawAccount, account, hasher);
 
             QuotaAdmin userQuotas = buildSpaceQuotas(a, localStorage, core,
                     getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
@@ -557,8 +558,8 @@ public class Main extends Builder {
             Admin storageAdmin = new Admin(adminUsernames, userQuotas, core, localStorage, enableWaitlist);
             ProxyingSpaceUsage p2pSpaceUsage = new ProxyingSpaceUsage(nodeId, corePropagator, spaceChecker, httpSpaceUsage);
 
-            VerifyingAccount account = new VerifyingAccount(rawAccount, core, localStorage);
-            UserService peergos = new UserService(p2pDht, crypto, corePropagator, account, p2pSocial, p2mMutable, storageAdmin,
+            VerifyingAccount verifyingAccount = new VerifyingAccount(rawAccount, core, localStorage);
+            UserService peergos = new UserService(p2pDht, crypto, corePropagator, verifyingAccount, p2pSocial, p2mMutable, storageAdmin,
                     p2pSpaceUsage, new ServerMessageStore(getDBConnector(a, "server-messages-sql-file", dbConnectionPool),
                     sqlCommands, core, p2pDht), gc);
             InetSocketAddress localAddress = new InetSocketAddress("localhost", userAPIAddress.getPort());

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -617,7 +617,8 @@ public class Main extends Builder {
                     while (true) {
                         try {
                             Optional<SigningKeyPair> mirrorLoginDataPair = a.getOptionalArg("login-keypair").map(SigningKeyPair::fromString);
-                            System.out.println("WARNING: Mirroring users data, but not their login, see option 'login-keypair'");
+                            if (mirrorLoginDataPair.isEmpty())
+                                System.out.println("WARNING: Mirroring users data, but not their login, see option 'login-keypair'");
                             String username = a.getArg("mirror.username");
                             Mirror.mirrorUser(username, mirrorLoginDataPair, core, p2mMutable, p2pAccount, localStorage,
                                     rawPointers, rawAccount, transactions, hasher);

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -558,7 +558,7 @@ public class Main extends Builder {
             Admin storageAdmin = new Admin(adminUsernames, userQuotas, core, localStorage, enableWaitlist);
             ProxyingSpaceUsage p2pSpaceUsage = new ProxyingSpaceUsage(nodeId, corePropagator, spaceChecker, httpSpaceUsage);
 
-            VerifyingAccount verifyingAccount = new VerifyingAccount(rawAccount, core, localStorage);
+            VerifyingAccount verifyingAccount = new VerifyingAccount(account, core, localStorage);
             UserService peergos = new UserService(p2pDht, crypto, corePropagator, verifyingAccount, p2pSocial, p2mMutable, storageAdmin,
                     p2pSpaceUsage, new ServerMessageStore(getDBConnector(a, "server-messages-sql-file", dbConnectionPool),
                     sqlCommands, core, p2pDht), gc);

--- a/src/peergos/server/NonWriteThroughNetwork.java
+++ b/src/peergos/server/NonWriteThroughNetwork.java
@@ -1,6 +1,7 @@
 package peergos.server;
 
 import peergos.server.corenode.*;
+import peergos.server.login.*;
 import peergos.server.mutable.*;
 import peergos.server.social.*;
 import peergos.server.storage.*;
@@ -18,6 +19,7 @@ import java.util.*;
 public class NonWriteThroughNetwork extends NetworkAccess {
 
     protected NonWriteThroughNetwork(CoreNode coreNode,
+                                     Account account,
                                      SocialNetwork social,
                                      ContentAddressedStorage ipfs,
                                      MutablePointers mutable,
@@ -28,17 +30,19 @@ public class NonWriteThroughNetwork extends NetworkAccess {
                                      Hasher hasher,
                                      List<String> usernames,
                                      boolean isJavascript) {
-        super(coreNode, social, ipfs, mutable, tree, synchronizer, instanceAdmin, spaceUsage, null, hasher, usernames, isJavascript);
+        super(coreNode, account, social, ipfs, mutable, tree, synchronizer, instanceAdmin, spaceUsage, null, hasher, usernames, isJavascript);
     }
 
     public static NetworkAccess build(NetworkAccess source) {
         ContentAddressedStorage nonWriteThroughIpfs = new NonWriteThroughStorage(source.dhtClient, source.hasher);
         MutablePointers nonWriteThroughPointers = new NonWriteThroughMutablePointers(source.mutable, nonWriteThroughIpfs);
         NonWriteThroughCoreNode nonWriteThroughCoreNode = new NonWriteThroughCoreNode(source.coreNode, nonWriteThroughIpfs);
+        NonWriteThroughAccount nonWriteThroughAccount = new NonWriteThroughAccount(source.account);
         NonWriteThroughSocialNetwork nonWriteThroughSocial = new NonWriteThroughSocialNetwork(source.social, nonWriteThroughIpfs);
         WriteSynchronizer synchronizer = new WriteSynchronizer(nonWriteThroughPointers, nonWriteThroughIpfs, source.hasher);
         MutableTree nonWriteThroughTree = new MutableTreeImpl(nonWriteThroughPointers, nonWriteThroughIpfs, source.hasher, synchronizer);
         return new NonWriteThroughNetwork(nonWriteThroughCoreNode,
+                nonWriteThroughAccount,
                 nonWriteThroughSocial,
                 nonWriteThroughIpfs,
                 nonWriteThroughPointers,

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -108,7 +108,7 @@ public class ServerMessages extends Builder {
         UsageStore usageStore = new JdbcUsageStore(getDBConnector(a, "space-usage-sql-file", dbConnectionPool), getSqlCommands(a));
         JdbcAccount account = new JdbcAccount(getDBConnector(a, "account-sql-file", dbConnectionPool), getSqlCommands(a));
         CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
-                rawSocial, usageStore, account, account, hasher);
+                rawSocial, usageStore, account, new AccountWithStorage(localStorage, localPointers, account), hasher);
         return buildSpaceQuotas(a, localStorage, core,
                 getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                 getDBConnector(a, "quotas-sql-file", dbConnectionPool));

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -1,6 +1,7 @@
 package peergos.server;
 
 import peergos.server.corenode.*;
+import peergos.server.login.*;
 import peergos.server.messages.*;
 import peergos.server.space.*;
 import peergos.server.sql.*;
@@ -105,8 +106,9 @@ public class ServerMessages extends Builder {
         MutablePointersProxy proxingMutable = new HttpMutablePointers(buildP2pHttpProxy(a), getPkiServerId(a));
         JdbcIpnsAndSocial rawSocial = new JdbcIpnsAndSocial(getDBConnector(a, "social-sql-file", dbConnectionPool), getSqlCommands(a));
         UsageStore usageStore = new JdbcUsageStore(getDBConnector(a, "space-usage-sql-file", dbConnectionPool), getSqlCommands(a));
+        JdbcAccount account = new JdbcAccount(getDBConnector(a, "account-sql-file", dbConnectionPool), getSqlCommands(a));
         CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
-                rawSocial, usageStore, hasher);
+                rawSocial, usageStore, account, hasher);
         return buildSpaceQuotas(a, localStorage, core,
                 getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                 getDBConnector(a, "quotas-sql-file", dbConnectionPool));

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -108,7 +108,7 @@ public class ServerMessages extends Builder {
         UsageStore usageStore = new JdbcUsageStore(getDBConnector(a, "space-usage-sql-file", dbConnectionPool), getSqlCommands(a));
         JdbcAccount account = new JdbcAccount(getDBConnector(a, "account-sql-file", dbConnectionPool), getSqlCommands(a));
         CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
-                rawSocial, usageStore, account, hasher);
+                rawSocial, usageStore, account, account, hasher);
         return buildSpaceQuotas(a, localStorage, core,
                 getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                 getDBConnector(a, "quotas-sql-file", dbConnectionPool));

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -20,6 +20,7 @@ import peergos.shared.storage.*;
 
 import peergos.server.net.*;
 import peergos.shared.storage.controller.*;
+import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import javax.net.ssl.*;
@@ -81,6 +82,7 @@ public class UserService {
     public final ContentAddressedStorage storage;
     public final Crypto crypto;
     public final CoreNode coreNode;
+    public final Account account;
     public final SocialNetwork social;
     public final MutablePointers mutable;
     public final InstanceAdmin controller;
@@ -91,6 +93,7 @@ public class UserService {
     public UserService(ContentAddressedStorage storage,
                        Crypto crypto,
                        CoreNode coreNode,
+                       Account account,
                        SocialNetwork social,
                        MutablePointers mutable,
                        InstanceAdmin controller,
@@ -100,6 +103,7 @@ public class UserService {
         this.storage = new CachingStorage(storage, 1000, 50 * 1024);
         this.crypto = crypto;
         this.coreNode = coreNode;
+        this.account = account;
         this.social = social;
         this.mutable = mutable;
         this.controller = controller;
@@ -233,6 +237,8 @@ public class UserService {
                 new SocialHandler(this.social, isPublicServer), basicAuth, local, host, nodeId, false);
         addHandler(localhostServer, tlsServer, "/" + Constants.MUTABLE_POINTERS_URL,
                 new MutationHandler(this.mutable, isPublicServer), basicAuth, local, host, nodeId, false);
+        addHandler(localhostServer, tlsServer, "/" + Constants.LOGIN_URL,
+                new AccountHandler(this.account, isPublicServer), basicAuth, local, host, nodeId, false);
         addHandler(localhostServer, tlsServer, "/" + Constants.ADMIN_URL,
                 new AdminHandler(this.controller, isPublicServer), basicAuth, local, host, nodeId, false);
         addHandler(localhostServer, tlsServer, "/" + Constants.SPACE_USAGE_URL,

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -358,9 +358,9 @@ public class MirrorCoreNode implements CoreNode {
         if (migrationTargetNode.equals(ourNodeId)) {
             // We are copying data to this node
             // Mirror all the data locally
-            Mirror.mirrorUser(username, this, p2pMutable, ipfs, localPointers, transactions, hasher);
-            Map<PublicKeyHash, byte[]> mirrored = Mirror.mirrorUser(username, this, p2pMutable, ipfs,
-                    localPointers, transactions, hasher);
+            Mirror.mirrorUser(username, Optional.empty(), this, p2pMutable, null, ipfs, localPointers, rawAccount, transactions, hasher);
+            Map<PublicKeyHash, byte[]> mirrored = Mirror.mirrorUser(username, Optional.empty(), this, p2pMutable,
+                    null, ipfs, localPointers, rawAccount, transactions, hasher);
 
             // Proxy call to their current storage server
             UserSnapshot res = writeTarget.migrateUser(username, newChain, currentStorageId).join();

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -367,7 +367,7 @@ public class MirrorCoreNode implements CoreNode {
             // pick up the new pki data locally
             update();
 
-            res.login.ifPresent(login -> rawAccount.setLoginData(login, new byte[0]));
+            res.login.ifPresent(login -> rawAccount.setLoginData(login));
 
             // commit diff since our mirror above
             for (Map.Entry<PublicKeyHash, byte[]> e : res.pointerState.entrySet()) {

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -30,6 +30,7 @@ public class MirrorCoreNode implements CoreNode {
     private static final Logger LOG = Logging.LOG();
 
     private final CoreNode writeTarget;
+    private final Account account;
     private final MutablePointers p2pMutable;
     private final DeletableContentAddressedStorage ipfs;
     private final JdbcIpnsAndSocial localPointers;
@@ -45,6 +46,7 @@ public class MirrorCoreNode implements CoreNode {
     private volatile boolean running = true;
 
     public MirrorCoreNode(CoreNode writeTarget,
+                          Account account,
                           MutablePointers p2pMutable,
                           DeletableContentAddressedStorage ipfs,
                           JdbcIpnsAndSocial localPointers,
@@ -55,6 +57,7 @@ public class MirrorCoreNode implements CoreNode {
                           Path statePath,
                           Hasher hasher) {
         this.writeTarget = writeTarget;
+        this.account = account;
         this.p2pMutable = p2pMutable;
         this.ipfs = ipfs;
         this.localPointers = localPointers;
@@ -285,7 +288,7 @@ public class MirrorCoreNode implements CoreNode {
         update();
         usageStore.addUserIfAbsent(username);
         usageStore.addWriter(username, chain.owner);
-        IpfsCoreNode.applyOpLog(chain.owner, setupOperations, ipfs, p2pMutable);
+        IpfsCoreNode.applyOpLog(username, chain.owner, setupOperations, ipfs, p2pMutable, account);
         return Futures.of(Optional.empty());
     }
 

--- a/src/peergos/server/login/AccountWithStorage.java
+++ b/src/peergos/server/login/AccountWithStorage.java
@@ -13,9 +13,9 @@ public class AccountWithStorage implements Account {
 
     private final ContentAddressedStorage storage;
     private final MutablePointers pointers;
-    private final Account target;
+    private final JdbcAccount target;
 
-    public AccountWithStorage(ContentAddressedStorage storage, MutablePointers pointers, Account target) {
+    public AccountWithStorage(ContentAddressedStorage storage, MutablePointers pointers, JdbcAccount target) {
         this.storage = storage;
         this.pointers = pointers;
         this.target = target;
@@ -32,11 +32,11 @@ public class AccountWithStorage implements Account {
             pointers.setPointer(pointer.writer, pointer.writer, pointer.writerSignedChampRootCas).join();
             storage.closeTransaction(pointer.writer, tid).join();
         }
-        return target.setLoginData(login, auth);
+        return target.setLoginData(login);
     }
 
     @Override
     public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
-        return target.getLoginData(username, authorisedReader, auth);
+        return target.getEntryData(username);
     }
 }

--- a/src/peergos/server/login/AccountWithStorage.java
+++ b/src/peergos/server/login/AccountWithStorage.java
@@ -37,6 +37,6 @@ public class AccountWithStorage implements Account {
 
     @Override
     public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
-        return target.getEntryData(username);
+        return target.getEntryData(username, authorisedReader);
     }
 }

--- a/src/peergos/server/login/AccountWithStorage.java
+++ b/src/peergos/server/login/AccountWithStorage.java
@@ -1,0 +1,42 @@
+package peergos.server.login;
+
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.mutable.*;
+import peergos.shared.storage.*;
+import peergos.shared.user.*;
+import peergos.shared.util.*;
+
+import java.util.concurrent.*;
+
+public class AccountWithStorage implements Account {
+
+    private final ContentAddressedStorage storage;
+    private final MutablePointers pointers;
+    private final Account target;
+
+    public AccountWithStorage(ContentAddressedStorage storage, MutablePointers pointers, Account target) {
+        this.storage = storage;
+        this.pointers = pointers;
+        this.target = target;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+        if (login.identityUpdate.isPresent()) {
+            Pair<OpLog.BlockWrite, OpLog.PointerWrite> pair = login.identityUpdate.get();
+            OpLog.BlockWrite block = pair.left;
+            OpLog.PointerWrite pointer = pair.right;
+            TransactionId tid = storage.startTransaction(block.writer).join();
+            storage.put(block.writer, block.writer, block.signature, block.block, tid).join();
+            pointers.setPointer(pointer.writer, pointer.writer, pointer.writerSignedChampRootCas).join();
+            storage.closeTransaction(pointer.writer, tid).join();
+        }
+        return target.setLoginData(login, auth);
+    }
+
+    @Override
+    public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
+        return target.getLoginData(username, authorisedReader, auth);
+    }
+}

--- a/src/peergos/server/login/JdbcAccount.java
+++ b/src/peergos/server/login/JdbcAccount.java
@@ -13,7 +13,7 @@ import java.util.concurrent.*;
 import java.util.function.*;
 import java.util.logging.*;
 
-public class JdbcAccount implements Account {
+public class JdbcAccount {
     private static final Logger LOG = Logging.LOG();
 
     private static final String CREATE = "INSERT INTO login (username, entry, reader) VALUES(?, ?, ?)";
@@ -66,8 +66,7 @@ public class JdbcAccount implements Account {
             }
     }
 
-    @Override
-    public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+    public CompletableFuture<Boolean> setLoginData(LoginData login) {
         if (hasEntry(login.username)) {
             try (Connection conn = getConnection();
                  PreparedStatement insert = conn.prepareStatement(UPDATE)) {
@@ -97,8 +96,7 @@ public class JdbcAccount implements Account {
         }
     }
 
-    @Override
-    public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
+    public CompletableFuture<UserStaticData> getEntryData(String username) {
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(GET)) {
             stmt.setString(1, username);

--- a/src/peergos/server/login/JdbcAccount.java
+++ b/src/peergos/server/login/JdbcAccount.java
@@ -107,7 +107,9 @@ public class JdbcAccount {
                 return CompletableFuture.completedFuture(UserStaticData.fromCbor(CborObject.fromByteArray(Base64.getDecoder().decode(rs.getString("entry")))));
             }
 
-            return Futures.errored(new IllegalStateException("Incorrect password"));
+            if (hasEntry(username))
+                return Futures.errored(new IllegalStateException("Incorrect password"));
+            return Futures.errored(new IllegalStateException("Unknown username. Did you enter it correctly?"));
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
             return Futures.errored(sqe);

--- a/src/peergos/server/login/NonWriteThroughAccount.java
+++ b/src/peergos/server/login/NonWriteThroughAccount.java
@@ -1,0 +1,33 @@
+package peergos.server.login;
+
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.user.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class NonWriteThroughAccount implements Account {
+
+    private final Account source;
+    private final Map<String, LoginData> modifications;
+
+    public NonWriteThroughAccount(Account source) {
+        this.source = source;
+        this.modifications = new HashMap<>();
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+        modifications.put(login.username, login);
+        return Futures.of(true);
+    }
+
+    @Override
+    public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
+        LoginData updated = modifications.get(username);
+        if (updated == null)
+            return source.getLoginData(username, authorisedReader, auth);
+        return Futures.of(updated.entryPoints);
+    }
+}

--- a/src/peergos/server/login/VerifyingAccount.java
+++ b/src/peergos/server/login/VerifyingAccount.java
@@ -1,0 +1,41 @@
+package peergos.server.login;
+
+import peergos.server.util.*;
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.mutable.*;
+import peergos.shared.storage.*;
+import peergos.shared.user.*;
+import peergos.shared.util.*;
+
+import java.util.concurrent.*;
+
+public class VerifyingAccount implements Account {
+
+    private final Account target;
+    private final CoreNode core;
+    private final ContentAddressedStorage storage;
+
+    public VerifyingAccount(Account target, CoreNode core, ContentAddressedStorage storage) {
+        this.target = target;
+        this.core = core;
+        this.storage = storage;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+        PublicKeyHash identityHash = core.getPublicKeyHash(login.username).join().get();
+        PublicSigningKey identity = storage.getSigningKey(identityHash).join().get();
+        identity.unsignMessage(ArrayOps.concat(auth, login.serialize()));
+        return target.setLoginData(login, auth);
+    }
+
+    @Override
+    public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
+        return target.getLoginData(username, authorisedReader, auth).thenApply(res -> {
+            TimeLimited.isAllowedTime(auth, 24*3600, authorisedReader);
+            return res;
+        });
+    }
+}

--- a/src/peergos/server/net/AccountHandler.java
+++ b/src/peergos/server/net/AccountHandler.java
@@ -1,0 +1,74 @@
+package peergos.server.net;
+
+import com.sun.net.httpserver.*;
+import peergos.server.*;
+import peergos.server.util.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.user.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.util.*;
+
+/** This is the http endpoint for MutablePointer calls
+ *
+ */
+public class AccountHandler implements HttpHandler {
+
+    private final Account account;
+    private final boolean isPublicServer;
+
+    public AccountHandler(Account account, boolean isPublicServer) {
+        this.account = account;
+        this.isPublicServer = isPublicServer;
+    }
+
+    public void handle(HttpExchange exchange) throws IOException {
+        DataInputStream din = new DataInputStream(exchange.getRequestBody());
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        DataOutputStream dout = new DataOutputStream(bout);
+
+        String path = exchange.getRequestURI().getPath();
+        if (path.startsWith("/"))
+            path = path.substring(1);
+        String[] subComponents = path.substring(Constants.LOGIN_URL.length()).split("/");
+        String method = subComponents[0];
+
+        Map<String, List<String>> params = HttpUtil.parseQuery(exchange.getRequestURI().getQuery());
+        byte[] auth = ArrayOps.hexToBytes(params.get("auth").get(0));
+        try {
+            if (! HttpUtil.allowedQuery(exchange, isPublicServer)) {
+                exchange.sendResponseHeaders(405, 0);
+                return;
+            }
+
+            switch (method) {
+                case "setLogin":
+                    AggregatedMetrics.LOGIN_SET.inc();
+                    byte[] payload = Serialize.readFully(din, 1024);
+                    boolean isAdded = account.setLoginData(LoginData.fromCbor(CborObject.fromByteArray(payload)), auth).join();
+                    dout.writeBoolean(isAdded);
+                    break;
+                case "getLogin":
+                    AggregatedMetrics.LOGIN_GET.inc();
+                    String username = params.get("username").get(0);
+                    PublicSigningKey authorisedReader = PublicSigningKey.fromByteArray(ArrayOps.hexToBytes(params.get("author").get(0)));
+                    byte[] res = account.getLoginData(username, authorisedReader, auth).join().serialize();
+                    dout.write(res);
+                    break;
+                default:
+                    throw new IOException("Unknown method in AccountHandler!");
+            }
+
+            byte[] b = bout.toByteArray();
+            exchange.sendResponseHeaders(200, b.length);
+            exchange.getResponseBody().write(b);
+        } catch (Exception e) {
+            HttpUtil.replyError(exchange, e);
+        } finally {
+            exchange.close();
+        }
+    }
+}

--- a/src/peergos/server/sql/SqlSupplier.java
+++ b/src/peergos/server/sql/SqlSupplier.java
@@ -21,6 +21,11 @@ public interface SqlSupplier {
                 "CREATE UNIQUE INDEX IF NOT EXISTS index_name ON metadatablobs (writingkey);";
     }
 
+    default String createAccountTableCommand() {
+        return "CREATE TABLE IF NOT EXISTS login (username text primary key not null, entry text not null, reader text not null); " +
+                "CREATE UNIQUE INDEX IF NOT EXISTS login_index ON login (username);";
+    }
+
     default String createSpaceRequestsTableCommand() {
         return "CREATE TABLE IF NOT EXISTS spacerequests (name text primary key not null, spacerequest text not null);";
     }

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -133,7 +133,7 @@ public class DelayingStorage implements ContentAddressedStorage {
 
     public static NetworkAccess buildNetwork(NetworkAccess source, int readDelay, int writeDelay) {
         ContentAddressedStorage delayingBlocks = new DelayingStorage(source.dhtClient, readDelay, writeDelay);
-        return new NetworkAccess(source.coreNode, source.social, delayingBlocks, source.mutable, source.tree,
+        return new NetworkAccess(source.coreNode, source.account, source.social, delayingBlocks, source.mutable, source.tree,
                 source.synchronizer, source.instanceAdmin, source.spaceUsage, source.serverMessager,
                 source.hasher, source.usernames, false);
     }

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -64,8 +64,8 @@ public class MultiNodeNetworkTests {
     @Parameterized.Parameters(name="nodes: {0}, {1} (0 == PKI, > 0 normal)")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
-//                {0, 1}, // PKI, normal-1
-//                {1, 0}, // normal-2, PKI
+                {0, 1}, // PKI, normal-1
+                {1, 0}, // normal-2, PKI
                 {2, 1}  // normal-1, normal-2
         });
     }

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -64,8 +64,8 @@ public class MultiNodeNetworkTests {
     @Parameterized.Parameters(name="nodes: {0}, {1} (0 == PKI, > 0 normal)")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
-                {0, 1}, // PKI, normal-1
-                {1, 0}, // normal-2, PKI
+//                {0, 1}, // PKI, normal-1
+//                {1, 0}, // normal-2, PKI
                 {2, 1}  // normal-1, normal-2
         });
     }
@@ -157,8 +157,8 @@ public class MultiNodeNetworkTests {
     @Test
     public void migrate() {
         migrate(0);
-        migrate(1);
-        migrate(2);
+//        migrate(1);
+//        migrate(2);
     }
 
     public void migrate(int nPasswordChanges) {

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -157,8 +157,8 @@ public class MultiNodeNetworkTests {
     @Test
     public void migrate() {
         migrate(0);
-//        migrate(1);
-//        migrate(2);
+        migrate(1);
+        migrate(2);
     }
 
     public void migrate(int nPasswordChanges) {

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -41,7 +41,7 @@ public class MultiUserTests {
         this.userCount = 2;
         WriteSynchronizer synchronizer = new WriteSynchronizer(service.mutable, service.storage, crypto.hasher);
         MutableTree mutableTree = new MutableTreeImpl(service.mutable, service.storage, crypto.hasher, synchronizer);
-        this.network = new NetworkAccess(service.coreNode, service.social, new CachingStorage(service.storage, 1_000, 50 * 1024),
+        this.network = new NetworkAccess(service.coreNode, service.account, service.social, new CachingStorage(service.storage, 1_000, 50 * 1024),
                 service.mutable, mutableTree, synchronizer, service.controller, service.usage, service.serverMessages,
                 crypto.hasher, Arrays.asList("peergos"), false);
     }

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -32,7 +32,7 @@ public class RamUserTests extends UserTests {
         MutableTree mutableTree = new MutableTreeImpl(service.mutable, service.storage, crypto.hasher, synchronizer);
         // use actual http messager
         ServerMessager.HTTP serverMessager = new ServerMessager.HTTP(new JavaPoster(new URI("http://localhost:" + args.getArg("port")).toURL(), false));
-        NetworkAccess network = new NetworkAccess(service.coreNode, service.social, service.storage,
+        NetworkAccess network = new NetworkAccess(service.coreNode, service.account, service.social, service.storage,
                 service.mutable, mutableTree, synchronizer, service.controller, service.usage,
                 serverMessager, service.crypto.hasher,
                 Arrays.asList("peergos"), false);

--- a/src/peergos/server/tests/RequestCountTests.java
+++ b/src/peergos/server/tests/RequestCountTests.java
@@ -34,7 +34,7 @@ public class RequestCountTests {
         RequestCountingStorage requestCounter = new RequestCountingStorage(service.storage);
         this.storageCounter = requestCounter;
         CachingVerifyingStorage dhtClient = new CachingVerifyingStorage(requestCounter, 50 * 1024, 1_000, crypto.hasher);
-        this.network = new NetworkAccess(service.coreNode, service.social, dhtClient,
+        this.network = new NetworkAccess(service.coreNode, service.account, service.social, dhtClient,
                 service.mutable, mutableTree, synchronizer, service.controller, service.usage, service.serverMessages,
                 crypto.hasher, Arrays.asList("peergos"), false);
     }

--- a/src/peergos/server/tests/TokenSignupTests.java
+++ b/src/peergos/server/tests/TokenSignupTests.java
@@ -37,7 +37,7 @@ public class TokenSignupTests {
         MutableTree mutableTree = new MutableTreeImpl(service.mutable, service.storage, crypto.hasher, synchronizer);
         // use actual http messager
         ServerMessager.HTTP serverMessager = new ServerMessager.HTTP(new JavaPoster(new URI("http://localhost:" + args.getArg("port")).toURL(), false));
-        NetworkAccess network = new NetworkAccess(service.coreNode, service.social, service.storage,
+        NetworkAccess network = new NetworkAccess(service.coreNode, service.account, service.social, service.storage,
                 service.mutable, mutableTree, synchronizer, service.controller, service.usage,
                 serverMessager, service.crypto.hasher,
                 Arrays.asList("peergos"), false);

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -136,6 +136,7 @@ public abstract class UserTests {
         String extraSalt = ArrayOps.bytesToHex(crypto.random.randomBytes(32));
         List<ScryptGenerator> params = Arrays.asList(
                 new ScryptGenerator(17, 8, 1, 96, extraSalt),
+                new ScryptGenerator(17, 8, 1, 64, extraSalt),
                 new ScryptGenerator(18, 8, 1, 96, extraSalt),
                 new ScryptGenerator(19, 8, 1, 96, extraSalt),
                 new ScryptGenerator(17, 9, 1, 96, extraSalt)
@@ -156,7 +157,7 @@ public abstract class UserTests {
 
         SafeRandomJava random = new SafeRandomJava();
         UserUtil.generateUser(username, password, new ScryptJava(), new Salsa20Poly1305Java(),
-                random, new Ed25519Java(), new Curve25519Java(), SecretGenerationAlgorithm.getDefault(random)).thenAccept(userWithRoot -> {
+                random, new Ed25519Java(), new Curve25519Java(), SecretGenerationAlgorithm.getLegacy(random)).thenAccept(userWithRoot -> {
 		    PublicSigningKey expected = PublicSigningKey.fromString("7HvEWP6yd1UD8rOorfFrieJ8S7yC8+l3VisV9kXNiHmI7Eav7+3GTRSVBRCymItrzebUUoCi39M6rdgeOU9sXXFD");
 		    if (! expected.equals(userWithRoot.getUser().publicSigningKey))
 		        throw new IllegalStateException("Generated user different from the Javascript! \n"+userWithRoot.getUser().publicSigningKey + " != \n"+expected);

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -389,7 +389,7 @@ public abstract class UserTests {
         String password = "password";
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         SecretGenerationAlgorithm algo = context.getKeyGenAlgorithm().get();
-        ScryptGenerator newAlgo = new ScryptGenerator(19, 8, 1, 96, algo.getExtraSalt());
+        ScryptGenerator newAlgo = new ScryptGenerator(19, 8, 1, 64, algo.getExtraSalt());
         context.changePassword(password, password, algo, newAlgo, LocalDate.now().plusMonths(2)).get();
         PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
     }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -351,24 +351,6 @@ public abstract class UserTests {
     }
 
     @Test
-    public void ownerUpdateAfterPasswordChange() throws Exception {
-        String username = generateUsername();
-        String password = "password";
-        UserContext userContext = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
-
-        PublicKeyHash originalOwner = userContext.getUserRoot().join().owner();
-
-        String newPassword = "newPassword";
-        userContext.changePassword(password, newPassword).get();
-        MultiUserTests.checkUserValidity(network, username);
-
-        UserContext changedPassword = PeergosNetworkUtils.ensureSignedUp(username, newPassword, network, crypto);
-        PublicKeyHash updatedOwner = changedPassword.getUserRoot().join().owner();
-
-        Assert.assertTrue(! updatedOwner.equals(originalOwner));
-    }
-
-    @Test
     public void changePasswordFAIL() throws Exception {
         String username = generateUsername();
         String password = "password";

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -295,10 +295,13 @@ public abstract class UserTests {
         String username = generateUsername();
         String password = "password";
         UserContext userContext = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        PublicBoxingKey initialBoxer = userContext.getPublicKeys(username).join().get().right;
         String newPassword = "newPassword";
         userContext.changePassword(password, newPassword).get();
         MultiUserTests.checkUserValidity(network, username);
 
+        PublicBoxingKey newBoxer = userContext.getPublicKeys(username).join().get().right;
+        Assert.assertTrue(newBoxer.equals(initialBoxer));
         UserContext changedPassword = PeergosNetworkUtils.ensureSignedUp(username, newPassword, network, crypto);
 
         // change it again

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -361,7 +361,7 @@ public abstract class UserTests {
         try {
             UserContext oldContext = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         } catch (Exception e) {
-            if (! e.getMessage().contains("Incorrect password"))
+            if (! e.getMessage().contains("Incorrect password") && ! e.getMessage().contains("Incorrect+password"))
                 throw e;
         }
     }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -260,7 +260,7 @@ public abstract class UserTests {
         try {
             context2.changePassword(password2, password1).join();
         } catch (Throwable t) {
-            Assert.assertTrue(t.getMessage().contains("You cannot reuse a previous password"));
+            Assert.assertTrue(t.getMessage().contains("You must change to a different password."));
         }
     }
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -312,6 +312,25 @@ public abstract class UserTests {
     }
 
     @Test
+    public void legacyLogin() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext userContext = UserContext.signUpGeneral(username, password, "", LocalDate.now().plusMonths(2),
+                network, crypto, SecretGenerationAlgorithm.getLegacy(crypto.random), x -> {}).join();
+        PublicBoxingKey initialBoxer = userContext.getPublicKeys(username).join().get().right;
+
+        UserContext login = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+
+        String newPassword = "newPassword";
+        userContext.changePassword(password, newPassword).get();
+        MultiUserTests.checkUserValidity(network, username);
+
+        UserContext changedPassword = PeergosNetworkUtils.ensureSignedUp(username, newPassword, network, crypto);
+        PublicBoxingKey newBoxer = changedPassword.getPublicKeys(username).join().get().right;
+        Assert.assertTrue(newBoxer.equals(initialBoxer));
+    }
+
+    @Test
     public void ownerUpdateAfterPasswordChange() throws Exception {
         String username = generateUsername();
         String password = "password";

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -231,7 +231,8 @@ public abstract class UserTests {
     public void expiredSigninAfterPasswordChange() {
         String username = generateUsername();
         String password = "password";
-        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        UserContext context = UserContext.signUpGeneral(username, password, "", LocalDate.now().minusDays(2),
+                network, crypto, SecretGenerationAlgorithm.getDefault(crypto.random), x -> {}).join();
         String newPassword = "G'day mate!";
 
         // change password and set username claim to an expiry in the past

--- a/src/peergos/server/tests/simulation/Simulator.java
+++ b/src/peergos/server/tests/simulation/Simulator.java
@@ -757,7 +757,7 @@ public class Simulator {
             try {
                 WriteSynchronizer synchronizer = new WriteSynchronizer(service.mutable, service.storage, crypto.hasher);
                 MutableTree mutableTree = new MutableTreeImpl(service.mutable, service.storage, crypto.hasher, synchronizer);
-                NetworkAccess networkAccess = new NetworkAccess(service.coreNode, service.social, service.storage,
+                NetworkAccess networkAccess = new NetworkAccess(service.coreNode, service.account, service.social, service.storage,
                         service.mutable, mutableTree, synchronizer, service.controller, service.usage,
                         service.serverMessages, service.crypto.hasher, Arrays.asList("peergos"), false);
                 UserContext userContext = PeergosNetworkUtils.ensureSignedUp(username, usernameToPassword(username), networkAccess, crypto);

--- a/src/peergos/server/tests/slow/PostgresUserTests.java
+++ b/src/peergos/server/tests/slow/PostgresUserTests.java
@@ -47,7 +47,7 @@ public class PostgresUserTests extends UserTests {
         UserService service = Main.PKI_INIT.main(args);
         WriteSynchronizer synchronizer = new WriteSynchronizer(service.mutable, service.storage, crypto.hasher);
         MutableTree mutableTree = new MutableTreeImpl(service.mutable, service.storage, crypto.hasher, synchronizer);
-        NetworkAccess network = new NetworkAccess(service.coreNode, service.social, service.storage,
+        NetworkAccess network = new NetworkAccess(service.coreNode, service.account, service.social, service.storage,
                 service.mutable, mutableTree, synchronizer, service.controller, service.usage, service.serverMessages,
                 service.crypto.hasher, Arrays.asList("peergos"), false);
         return Arrays.asList(new Object[][] {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -136,6 +136,7 @@ public class NetworkAccess {
     }
 
     public NetworkAccess clear() {
+        MutablePointers mutable = this.mutable.clearCache();
         WriteSynchronizer synchronizer = new WriteSynchronizer(mutable, dhtClient, hasher);
         MutableTree mutableTree = new MutableTreeImpl(mutable, dhtClient, hasher, synchronizer);
         return new NetworkAccess(coreNode, account, social, dhtClient, mutable, mutableTree, synchronizer, instanceAdmin,

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -257,7 +257,7 @@ public class NetworkAccess {
                     ContentAddressedStorage p2pDht = new CachingVerifyingStorage(new RetryStorage(storage, 3),
                             50 * 1024, 1_000, hasher);
                     MutablePointersProxy httpMutable = new HttpMutablePointers(apiPoster, p2pPoster);
-                    Account account = new HttpAccount(apiPoster);
+                    Account account = new HttpAccount(apiPoster, p2pPoster);
                     MutablePointers p2pMutable =
                             isPeergosServer ?
                                     httpMutable :

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -1,25 +1,29 @@
 package peergos.shared.corenode;
 
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
+import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.*;
 
-public class OpLog implements Cborable, MutablePointers, ContentAddressedStorage {
+public class OpLog implements Cborable, Account, MutablePointers, ContentAddressedStorage {
     private static final int ED25519_SIGNATURE_SIZE = 64;
 
     public final List<Either<PointerWrite, BlockWrite>> operations;
     private final Map<Multihash, byte[]> storage = new HashMap<>();
+    public Pair<LoginData, byte[]> loginData;
 
-    public OpLog(List<Either<PointerWrite, BlockWrite>> operations) {
+    public OpLog(List<Either<PointerWrite, BlockWrite>> operations, Pair<LoginData, byte[]> loginData) {
         this.operations = operations;
+        this.loginData = loginData;
     }
 
     @Override
@@ -36,6 +40,25 @@ public class OpLog implements Cborable, MutablePointers, ContentAddressedStorage
                 return Futures.of(Optional.of(op.a().writerSignedChampRootCas));
         }
         throw new IllegalStateException("Unknown writer: " + writer);
+    }
+
+    @Override
+    public synchronized CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+        loginData = new Pair<>(login, auth);
+        return Futures.of(true);
+    }
+
+    @Override
+    public synchronized CompletableFuture<UserStaticData> getLoginData(String username,
+                                                                       PublicSigningKey authorisedReader,
+                                                                       byte[] auth) {
+        if (loginData == null)
+            throw new IllegalStateException("No login data present!");
+        if (! loginData.left.username.equals(username))
+            throw new IllegalStateException("No login data present for " + username);
+        if (! loginData.left.authorisedReader.equals(authorisedReader))
+            throw new IllegalStateException("You are not authorised to login as " + username);
+        return Futures.of(loginData.left.entryPoints);
     }
 
     @Override
@@ -207,6 +230,8 @@ public class OpLog implements Cborable, MutablePointers, ContentAddressedStorage
         state.put("ops", new CborObject.CborList(operations.stream()
                 .map(e -> e.map(PointerWrite::toCbor, BlockWrite::toCbor))
                 .collect(Collectors.toList())));
+        state.put("login", loginData.left);
+        state.put("loginAuth", new CborObject.CborByteArray(loginData.right));
         return CborObject.CborMap.build(state);
     }
 
@@ -215,6 +240,8 @@ public class OpLog implements Cborable, MutablePointers, ContentAddressedStorage
             throw new IllegalStateException("Invalid cbor for OpLog!");
         CborObject.CborMap m = (CborObject.CborMap) cbor;
         List<Either<PointerWrite, BlockWrite>> ops = m.getList("ops", OpLog::parseOperation);
-        return new OpLog(ops);
+        LoginData login = m.get("login", LoginData::fromCbor);
+        byte[] loginAuth = m.getByteArray("loginAuth");
+        return new OpLog(ops, new Pair<>(login, loginAuth));
     }
 }

--- a/src/peergos/shared/crypto/BoxingKeyPair.java
+++ b/src/peergos/shared/crypto/BoxingKeyPair.java
@@ -24,7 +24,7 @@ public class BoxingKeyPair implements Cborable
                 secretBoxingKey.toCbor()));
     }
 
-    public static BoxingKeyPair fromCbor(CborObject cbor) {
+    public static BoxingKeyPair fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborList))
             throw new IllegalStateException("Incorrect cbor for SigningKeyPair: " + cbor);
 

--- a/src/peergos/shared/crypto/SigningKeyPair.java
+++ b/src/peergos/shared/crypto/SigningKeyPair.java
@@ -54,7 +54,7 @@ public class SigningKeyPair implements Cborable
         return fromCbor(CborObject.fromByteArray(raw));
     }
 
-    public static SigningKeyPair fromCbor(CborObject cbor) {
+    public static SigningKeyPair fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborList))
             throw new IllegalStateException("Incorrect cbor for SigningKeyPair: " + cbor);
 

--- a/src/peergos/shared/crypto/SigningKeyPair.java
+++ b/src/peergos/shared/crypto/SigningKeyPair.java
@@ -5,6 +5,7 @@ import peergos.shared.crypto.asymmetric.PublicSigningKey;
 import peergos.shared.crypto.asymmetric.SecretSigningKey;
 import peergos.shared.crypto.asymmetric.curve25519.*;
 import peergos.shared.crypto.random.*;
+import peergos.shared.io.ipfs.multibase.*;
 
 import java.util.*;
 
@@ -48,6 +49,15 @@ public class SigningKeyPair implements Cborable
         return new CborObject.CborList(Arrays.asList(
                 publicSigningKey.toCbor(),
                 secretSigningKey.toCbor()));
+    }
+
+    @Override
+    public String toString() {
+        return Multibase.encode(Multibase.Base.Base58BTC, serialize());
+    }
+
+    public static SigningKeyPair fromString(String multibaseEncoded) {
+        return fromByteArray(Multibase.decode(multibaseEncoded));
     }
 
     public static SigningKeyPair fromByteArray(byte[] raw) {

--- a/src/peergos/shared/mutable/CachingPointers.java
+++ b/src/peergos/shared/mutable/CachingPointers.java
@@ -49,4 +49,10 @@ public class CachingPointers implements MutablePointers {
             return res;
         });
     }
+
+    @Override
+    public MutablePointers clearCache() {
+        cache.clear();
+        return this;
+    }
 }

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -47,6 +47,10 @@ public interface MutablePointers {
                         CompletableFuture.completedFuture(MaybeMultihash.empty()));
     }
 
+    default MutablePointers clearCache() {
+        return this;
+    }
+
     static CompletableFuture<MaybeMultihash> parsePointerTarget(byte[] pointerCas,
                                                                 PublicKeyHash writerKeyHash,
                                                                 ContentAddressedStorage ipfs) {

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -1,6 +1,7 @@
 package peergos.shared.mutable;
 
 import peergos.shared.cbor.CborObject;
+import peergos.shared.crypto.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.multihash.*;
@@ -20,6 +21,11 @@ public interface MutablePointers {
      * @return True when successfully completed
      */
     CompletableFuture<Boolean> setPointer(PublicKeyHash owner, PublicKeyHash writer, byte[] writerSignedBtreeRootHash);
+
+    default CompletableFuture<Boolean> setPointer(PublicKeyHash owner, SigningPrivateKeyAndPublicHash writer, HashCasPair casUpdate) {
+        byte[] signed = writer.secret.signMessage(casUpdate.serialize());
+        return setPointer(owner, writer.publicKeyHash, signed);
+    }
 
     /** Get the current hash a public key maps to
      *

--- a/src/peergos/shared/user/Account.java
+++ b/src/peergos/shared/user/Account.java
@@ -1,0 +1,18 @@
+package peergos.shared.user;
+
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.asymmetric.*;
+
+import java.util.concurrent.*;
+
+public interface Account {
+
+    CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth);
+
+    default CompletableFuture<Boolean> setLoginData(LoginData login, SigningPrivateKeyAndPublicHash identity) {
+        byte[] auth = identity.secret.signatureOnly(login.serialize());
+        return setLoginData(login, auth);
+    }
+
+    CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth);
+}

--- a/src/peergos/shared/user/AccountProxy.java
+++ b/src/peergos/shared/user/AccountProxy.java
@@ -1,0 +1,17 @@
+package peergos.shared.user;
+
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.io.ipfs.multihash.*;
+
+import java.util.concurrent.*;
+
+/** A Mutable Pointers extension that proxies all calls over a p2p stream
+ *
+ */
+public interface AccountProxy extends Account {
+
+    CompletableFuture<Boolean> setLoginData(Multihash targetServerId, LoginData login, byte[] auth);
+
+    CompletableFuture<UserStaticData> getLoginData(Multihash targetServerId, String username, PublicSigningKey authorisedReader, byte[] auth);
+
+}

--- a/src/peergos/shared/user/HttpAccount.java
+++ b/src/peergos/shared/user/HttpAccount.java
@@ -3,22 +3,49 @@ package peergos.shared.user;
 
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.util.*;
 
 import java.io.*;
 import java.util.concurrent.*;
 
-public class HttpAccount implements Account {
+public class HttpAccount implements AccountProxy {
+    private static final String P2P_PROXY_PROTOCOL = "/http";
 
-    private final HttpPoster direct;
+    private final HttpPoster direct, p2p;
+    private final String directUrlPrefix;
 
-    public HttpAccount(HttpPoster direct) {
+    public HttpAccount(HttpPoster direct, HttpPoster p2p) {
         this.direct = direct;
+        this.p2p = p2p;
+        this.directUrlPrefix = "";
     }
-   
+
+    public HttpAccount(HttpPoster p2p, Multihash targetNodeID) {
+        this.directUrlPrefix = getProxyUrlPrefix(targetNodeID);
+        this.direct = p2p;
+        this.p2p = p2p;
+    }
+
+    private static String getProxyUrlPrefix(Multihash targetId) {
+        return "/p2p/" + targetId.toString() + P2P_PROXY_PROTOCOL + "/";
+    }
+
     @Override
     public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
-        return direct.postUnzip(Constants.LOGIN_URL + "setLogin?username=" + login.username + "&auth=" + ArrayOps.bytesToHex(auth), login.serialize()).thenApply(res -> {
+        return setLoginData(directUrlPrefix, direct, login, auth);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLoginData(Multihash targetServerId, LoginData login, byte[] auth) {
+        return setLoginData(getProxyUrlPrefix(targetServerId), p2p, login, auth);
+    }
+
+    private CompletableFuture<Boolean> setLoginData(String urlPrefix,
+                                                    HttpPoster poster,
+                                                    LoginData login,
+                                                    byte[] auth) {
+        return poster.postUnzip(urlPrefix + Constants.LOGIN_URL + "setLogin?username=" + login.username + "&auth=" + ArrayOps.bytesToHex(auth), login.serialize()).thenApply(res -> {
             DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
             try {
                 return din.readBoolean();
@@ -30,7 +57,23 @@ public class HttpAccount implements Account {
 
     @Override
     public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
-        return direct.get(Constants.LOGIN_URL + "getLogin?username=" + username + "&author=" + ArrayOps.bytesToHex(authorisedReader.serialize()) + "&auth=" + ArrayOps.bytesToHex(auth))
+        return getLoginData(directUrlPrefix, direct, username, authorisedReader, auth);
+    }
+
+    @Override
+    public CompletableFuture<UserStaticData> getLoginData(Multihash targetServerId,
+                                                          String username,
+                                                          PublicSigningKey authorisedReader,
+                                                          byte[] auth) {
+        return getLoginData(getProxyUrlPrefix(targetServerId), p2p, username, authorisedReader, auth);
+    }
+
+    private CompletableFuture<UserStaticData> getLoginData(String urlPrefix,
+                                                           HttpPoster poster,
+                                                           String username,
+                                                           PublicSigningKey authorisedReader,
+                                                           byte[] auth) {
+        return poster.get(urlPrefix + Constants.LOGIN_URL + "getLogin?username=" + username + "&author=" + ArrayOps.bytesToHex(authorisedReader.serialize()) + "&auth=" + ArrayOps.bytesToHex(auth))
                 .thenApply(res -> UserStaticData.fromCbor(CborObject.fromByteArray(res)));
     }
 }

--- a/src/peergos/shared/user/HttpAccount.java
+++ b/src/peergos/shared/user/HttpAccount.java
@@ -1,0 +1,36 @@
+
+package peergos.shared.user;
+
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.util.concurrent.*;
+
+public class HttpAccount implements Account {
+
+    private final HttpPoster direct;
+
+    public HttpAccount(HttpPoster direct) {
+        this.direct = direct;
+    }
+   
+    @Override
+    public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+        return direct.postUnzip(Constants.LOGIN_URL + "setLogin?username=" + login.username + "&auth=" + ArrayOps.bytesToHex(auth), login.serialize()).thenApply(res -> {
+            DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
+            try {
+                return din.readBoolean();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Override
+    public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
+        return direct.get(Constants.LOGIN_URL + "getLogin?username=" + username + "&author=" + ArrayOps.bytesToHex(authorisedReader.serialize()) + "&auth=" + ArrayOps.bytesToHex(auth))
+                .thenApply(res -> UserStaticData.fromCbor(CborObject.fromByteArray(res)));
+    }
+}

--- a/src/peergos/shared/user/LoginData.java
+++ b/src/peergos/shared/user/LoginData.java
@@ -1,0 +1,52 @@
+package peergos.shared.user;
+
+import peergos.shared.cbor.*;
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+
+public class LoginData implements Cborable {
+
+    public final String username;
+    public final UserStaticData entryPoints;
+    public final PublicSigningKey authorisedReader;
+    public final Optional<Pair<OpLog.BlockWrite, OpLog.PointerWrite>> identityUpdate;
+
+    public LoginData(String username,
+                     UserStaticData entryPoints,
+                     PublicSigningKey authorisedReader,
+                     Optional<Pair<OpLog.BlockWrite, OpLog.PointerWrite>> identityUpdate) {
+        this.username = username;
+        this.entryPoints = entryPoints;
+        this.authorisedReader = authorisedReader;
+        this.identityUpdate = identityUpdate;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("u", new CborObject.CborString(username));
+        state.put("e", entryPoints);
+        state.put("r", authorisedReader);
+        identityUpdate.ifPresent(p -> {
+            state.put("b", p.left);
+            state.put("p", p.right);
+        });
+        return CborObject.CborMap.build(state);
+    }
+
+    public static LoginData fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for LoginData!");
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        String username = m.getString("u");
+        UserStaticData entry = m.get("e", UserStaticData::fromCbor);
+        PublicSigningKey authorisedReader = m.get("r", PublicSigningKey::fromCbor);
+        Optional<Pair<OpLog.BlockWrite, OpLog.PointerWrite>> identityUpdate = m.containsKey("b") && m.containsKey("p") ?
+                Optional.of(new Pair<>(m.get("b", OpLog.BlockWrite::fromCbor), m.get("p", OpLog.PointerWrite::fromCbor))) :
+                Optional.empty();
+        return new LoginData(username, entry, authorisedReader, identityUpdate);
+    }
+}

--- a/src/peergos/shared/user/ProxyingAccount.java
+++ b/src/peergos/shared/user/ProxyingAccount.java
@@ -1,0 +1,43 @@
+package peergos.shared.user;
+
+import peergos.shared.corenode.*;
+import peergos.shared.crypto.asymmetric.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.mutable.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class ProxyingAccount implements Account {
+
+    private final Multihash serverId;
+    private final CoreNode core;
+    private final Account local;
+    private final AccountProxy p2p;
+
+    public ProxyingAccount(Multihash serverId, CoreNode core, Account local, AccountProxy p2p) {
+        this.serverId = serverId;
+        this.core = core;
+        this.local = local;
+        this.p2p = p2p;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth) {
+        return core.getPublicKeyHash(login.username).thenCompose(idOpt -> Proxy.redirectCall(core,
+                serverId,
+                idOpt.get(),
+                () -> local.setLoginData(login, auth),
+                target -> p2p.setLoginData(target, login, auth)));
+    }
+
+    @Override
+    public CompletableFuture<UserStaticData> getLoginData(String username, PublicSigningKey authorisedReader, byte[] auth) {
+        return core.getPublicKeyHash(username).thenCompose(idOpt -> Proxy.redirectCall(core,
+                serverId,
+                idOpt.get(),
+                () -> local.getLoginData(username, authorisedReader, auth),
+                target -> p2p.getLoginData(target, username, authorisedReader, auth)));
+    }
+}

--- a/src/peergos/shared/user/RandomSecretType.java
+++ b/src/peergos/shared/user/RandomSecretType.java
@@ -21,6 +21,11 @@ public class RandomSecretType implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public boolean includesBoxerGeneration() {
+        return false;
+    }
+
+    @Override
     public Type getType() {
         return Type.Random;
     }

--- a/src/peergos/shared/user/RandomSecretType.java
+++ b/src/peergos/shared/user/RandomSecretType.java
@@ -26,6 +26,11 @@ public class RandomSecretType implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public SecretGenerationAlgorithm withoutBoxer() {
+        return this;
+    }
+
+    @Override
     public Type getType() {
         return Type.Random;
     }

--- a/src/peergos/shared/user/RandomSecretType.java
+++ b/src/peergos/shared/user/RandomSecretType.java
@@ -21,12 +21,12 @@ public class RandomSecretType implements SecretGenerationAlgorithm {
     }
 
     @Override
-    public boolean includesBoxerGeneration() {
+    public boolean generateBoxerAndIdentity() {
         return false;
     }
 
     @Override
-    public SecretGenerationAlgorithm withoutBoxer() {
+    public SecretGenerationAlgorithm withoutBoxerOrIdentity() {
         return this;
     }
 

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -25,12 +25,12 @@ public class ScryptGenerator implements SecretGenerationAlgorithm {
     }
 
     @Override
-    public boolean includesBoxerGeneration() {
+    public boolean generateBoxerAndIdentity() {
         return outputBytes == 96;
     }
 
     @Override
-    public SecretGenerationAlgorithm withoutBoxer() {
+    public SecretGenerationAlgorithm withoutBoxerOrIdentity() {
         return new ScryptGenerator(memoryCost, cpuCost, parallelism, 64, extraSalt);
     }
 

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -30,6 +30,11 @@ public class ScryptGenerator implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public SecretGenerationAlgorithm withoutBoxer() {
+        return new ScryptGenerator(memoryCost, cpuCost, parallelism, 64, extraSalt);
+    }
+
+    @Override
     public String getExtraSalt() {
         return extraSalt;
     }

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -25,6 +25,11 @@ public class ScryptGenerator implements SecretGenerationAlgorithm {
     }
 
     @Override
+    public boolean includesBoxerGeneration() {
+        return outputBytes == 96;
+    }
+
+    @Override
     public String getExtraSalt() {
         return extraSalt;
     }

--- a/src/peergos/shared/user/SecretGenerationAlgorithm.java
+++ b/src/peergos/shared/user/SecretGenerationAlgorithm.java
@@ -33,9 +33,9 @@ public interface SecretGenerationAlgorithm extends Cborable {
 
     String getExtraSalt();
 
-    boolean includesBoxerGeneration();
+    boolean generateBoxerAndIdentity();
 
-    SecretGenerationAlgorithm withoutBoxer();
+    SecretGenerationAlgorithm withoutBoxerOrIdentity();
 
     static SecretGenerationAlgorithm getDefault(SafeRandom rnd) {
         return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 64, generateSalt(rnd));
@@ -46,7 +46,7 @@ public interface SecretGenerationAlgorithm extends Cborable {
     }
 
     static SecretGenerationAlgorithm getDefaultWithoutExtraSalt() {
-        return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 96, "");
+        return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 64, "");
     }
 
     static String generateSalt(SafeRandom rnd) {

--- a/src/peergos/shared/user/SecretGenerationAlgorithm.java
+++ b/src/peergos/shared/user/SecretGenerationAlgorithm.java
@@ -33,7 +33,13 @@ public interface SecretGenerationAlgorithm extends Cborable {
 
     String getExtraSalt();
 
+    boolean includesBoxerGeneration();
+
     static SecretGenerationAlgorithm getDefault(SafeRandom rnd) {
+        return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 64, generateSalt(rnd));
+    }
+
+    static SecretGenerationAlgorithm getLegacy(SafeRandom rnd) {
         return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 96, generateSalt(rnd));
     }
 

--- a/src/peergos/shared/user/SecretGenerationAlgorithm.java
+++ b/src/peergos/shared/user/SecretGenerationAlgorithm.java
@@ -35,6 +35,8 @@ public interface SecretGenerationAlgorithm extends Cborable {
 
     boolean includesBoxerGeneration();
 
+    SecretGenerationAlgorithm withoutBoxer();
+
     static SecretGenerationAlgorithm getDefault(SafeRandom rnd) {
         return new ScryptGenerator(ScryptGenerator.MIN_MEMORY_COST, 8, 1, 64, generateSalt(rnd));
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -702,7 +702,8 @@ public class UserContext {
     @JsMethod
     public CompletableFuture<UserContext> changePassword(String oldPassword, String newPassword) {
         return getKeyGenAlgorithm().thenCompose(alg -> {
-            SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random);
+            // Use a new salt, and if this is a legacy account with generated boxer, remove it from generation
+            SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random).withoutBoxer();
             // set claim expiry to two months from now
             return changePassword(oldPassword, newPassword, alg, newAlgorithm, LocalDate.now().plusMonths(2));
         });
@@ -749,7 +750,7 @@ public class UserContext {
                                                 wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient, network.hasher))
                                                 .thenCompose(version -> version.get(signer).props.changeKeys(signer,
                                                         newSigner,
-                                                        newBoxingKeypair.publicBoxingKey,
+                                                        newBoxingKeypair,
                                                         existingUser.getRoot(),
                                                         updatedUser.getRoot(),
                                                         newAlgorithm,

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -5,6 +5,7 @@ import java.util.logging.*;
 
 import peergos.shared.fingerprint.*;
 import peergos.shared.inode.*;
+import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.user.fs.transaction.TransactionService;
 import peergos.shared.user.fs.transaction.TransactionServiceImpl;
@@ -164,38 +165,49 @@ public class UserContext {
     }
 
     private static CompletableFuture<UserContext> login(String username,
-                                                        UserWithRoot userWithRoot,
+                                                        UserWithRoot generatedCredentials,
                                                         Pair<Multihash, CborObject> pair,
                                                         NetworkAccess network,
                                                         Crypto crypto,
                                                         Consumer<String> progressCallback) {
         try {
             WriterData userData = WriterData.fromCbor(pair.right);
-            return createOurFileTreeOnly(username, userWithRoot.getRoot(), userData, network, crypto)
-                    .thenCompose(root -> TofuCoreNode.load(username, root, network, crypto)
-                            .thenCompose(tofuCorenode -> {
-                                SigningPrivateKeyAndPublicHash signer = new SigningPrivateKeyAndPublicHash(userData.controller, userWithRoot.getUser().secretSigningKey);
-                                return buildTransactionService(root, username, network, crypto)
-                                        .thenCompose(transactions -> buildCapCache(root, username, network, crypto)
-                                                .thenCompose(capCache -> SharedWithCache.initOrBuild(root, username, network, crypto)
+            boolean legacyAccount = userData.staticData.isPresent();
+            PublicSigningKey loginPub = generatedCredentials.getUser().publicSigningKey;
+            SecretSigningKey loginSecret = generatedCredentials.getUser().secretSigningKey;
+//            PublicKeyHash loginHash = ContentAddressedStorage.hashKey(loginPub);
+            return (legacyAccount ?
+                    Futures.of(userData.staticData.get()) :
+                    network.account.getLoginData(username, loginPub, TimeLimitedClient.signNow(loginSecret))).thenCompose(entryData -> {
+                UserStaticData.EntryPoints staticData = entryData.getData(generatedCredentials.getRoot());
+                // Use generated signer for legacy logins, or get from UserStaticData for newer logins
+                SigningPrivateKeyAndPublicHash signer =
+                        new SigningPrivateKeyAndPublicHash(userData.controller,
+                                legacyAccount ? loginSecret : staticData.identity.get().secretSigningKey);
+                return createOurFileTreeOnly(username, staticData, userData, network)
+                        .thenCompose(root -> TofuCoreNode.load(username, root, network, crypto)
+                                .thenCompose(tofuCorenode -> {
+                                    return buildTransactionService(root, username, network, crypto)
+                                            .thenCompose(transactions -> buildCapCache(root, username, network, crypto)
+                                                    .thenCompose(capCache -> SharedWithCache.initOrBuild(root, username, network, crypto)
                                                         .thenCompose(sharedWith -> {
-                                                            UserStaticData.EntryPoints staticData = userData.staticData.get().getData(userWithRoot.getRoot());
-                                                            UserContext result = new UserContext(username,
-                                                                    signer,
-                                                                    staticData.boxer.orElse(userWithRoot.getBoxingPair()),
-                                                                    userWithRoot.getRoot(),
-                                                                    network.withCorenode(tofuCorenode),
-                                                                    crypto,
-                                                                    new CommittedWriterData(MaybeMultihash.of(pair.left), userData),
-                                                                    root,
-                                                                    transactions,
-                                                                    capCache,
-                                                                    sharedWith);
+                                                        UserContext result = new UserContext(username,
+                                                                signer,
+                                                                staticData.boxer.orElse(generatedCredentials.getBoxingPair()),
+                                                                generatedCredentials.getRoot(),
+                                                                network.withCorenode(tofuCorenode),
+                                                                crypto,
+                                                                new CommittedWriterData(MaybeMultihash.of(pair.left), userData),
+                                                                root,
+                                                                transactions,
+                                                                capCache,
+                                                                sharedWith);
 
-                                                            return result.init(progressCallback)
-                                                                    .exceptionally(Futures::logAndThrow);
-                                                        })));
-                            }));
+                                                        return result.init(progressCallback)
+                                                                .exceptionally(Futures::logAndThrow);
+                                                    })));
+                                }));
+            });
         } catch (Throwable t) {
             throw new IllegalStateException("Incorrect password");
         }
@@ -234,8 +246,8 @@ public class UserContext {
                                                                SecretGenerationAlgorithm algorithm,
                                                                Consumer<String> progressCallback) {
         // Using a local OpLog that doesn't commit anything allows us to group all the updates into a single atomic call
-        OpLog opLog = new OpLog(new ArrayList<>());
-        NetworkAccess network = NetworkAccess.nonCommittingForSignup(opLog, opLog, crypto.hasher);
+        OpLog opLog = new OpLog(new ArrayList<>(), null);
+        NetworkAccess network = NetworkAccess.nonCommittingForSignup(opLog, opLog, opLog, crypto.hasher);
         progressCallback.accept("Generating keys");
         return initialNetwork.coreNode.getChain(username)
                 .thenApply(existing -> {
@@ -246,41 +258,47 @@ public class UserContext {
                 .thenCompose(x -> UserUtil.generateUser(username, password, crypto.hasher, crypto.symmetricProvider,
                         crypto.random, crypto.signer, crypto.boxer, algorithm))
                 .thenCompose(userWithRoot -> {
-                    PublicSigningKey publicSigningKey = userWithRoot.getUser().publicSigningKey;
-                    SecretSigningKey secretSigningKey = userWithRoot.getUser().secretSigningKey;
-                    PublicKeyHash signerHash = ContentAddressedStorage.hashKey(publicSigningKey);
-                    SigningPrivateKeyAndPublicHash signer = new SigningPrivateKeyAndPublicHash(signerHash, secretSigningKey);
+                    PublicSigningKey loginPublicKey = userWithRoot.getUser().publicSigningKey;
+
+                    boolean isLegacy = algorithm.generateBoxerAndIdentity();
+                    SigningKeyPair identityPair = isLegacy ?
+                            userWithRoot.getUser() :
+                            SigningKeyPair.random(crypto.random, crypto.signer);
+                    PublicKeyHash identityHash = ContentAddressedStorage.hashKey(identityPair.publicSigningKey);
+                    SigningPrivateKeyAndPublicHash identity = new SigningPrivateKeyAndPublicHash(identityHash, identityPair.secretSigningKey);
+
+                    Optional<BoxingKeyPair> boxer = isLegacy ? Optional.empty() : Optional.of(userWithRoot.getBoxingPair());
+                    UserStaticData entryData = new UserStaticData(Collections.emptyList(), userWithRoot.getRoot(), Optional.of(identityPair), boxer);
                     progressCallback.accept("Registering username");
                     return initialNetwork.dhtClient.id()
-                            .thenApply(id -> UserPublicKeyLink.createInitial(signer, username, expiry, Arrays.asList(id)))
-                            .thenCompose(chain -> IpfsTransaction.call(signerHash, tid -> network.dhtClient.putSigningKey(
-                                    secretSigningKey.signMessage(publicSigningKey.serialize()),
-                                    signerHash,
-                                    publicSigningKey, tid).thenCompose(returnedSignerHash -> {
+                            .thenApply(id -> UserPublicKeyLink.createInitial(identity, username, expiry, Arrays.asList(id)))
+                            .thenCompose(chain -> IpfsTransaction.call(identityHash, tid -> network.dhtClient.putSigningKey(
+                                    identityPair.secretSigningKey.signMessage(identityPair.publicSigningKey.serialize()),
+                                    identityHash,
+                                    identityPair.publicSigningKey, tid).thenCompose(returnedIdentityHash -> {
                                 PublicBoxingKey publicBoxingKey = userWithRoot.getBoxingPair().publicBoxingKey;
                                 return crypto.hasher.sha256(publicBoxingKey.serialize())
-                                        .thenCompose(boxerHash -> network.dhtClient.putBoxingKey(signerHash,
-                                                secretSigningKey.signMessage(boxerHash), publicBoxingKey, tid));
+                                        .thenCompose(boxerHash -> network.dhtClient.putBoxingKey(identityHash,
+                                                identityPair.secretSigningKey.signMessage(boxerHash), publicBoxingKey, tid));
                             }).thenCompose(boxerHash -> {
                                 progressCallback.accept("Creating filesystem");
-                                return WriterData.createEmptyWithStaticData(signerHash,
-                                        signer,
+                                return WriterData.createIdentity(identityHash,
+                                        identity,
                                         Optional.of(new PublicKeyHash(boxerHash)),
-                                        userWithRoot.getRoot(),
-                                        algorithm.includesBoxerGeneration() ? Optional.empty() : Optional.of(userWithRoot.getBoxingPair()),
+                                        isLegacy ? Optional.of(entryData) : Optional.empty(),
                                         algorithm,
                                         network.dhtClient, network.hasher, tid).thenCompose(newUserData -> {
 
                                     CommittedWriterData notCommitted = new CommittedWriterData(MaybeMultihash.empty(), newUserData);
-                                    network.synchronizer.put(signer.publicKeyHash, signer.publicKeyHash, notCommitted);
-                                    return network.synchronizer.applyComplexUpdate(signerHash, signer,
-                                            (s, committer) -> newUserData.commit(signerHash, signer, MaybeMultihash.empty(), network, tid));
+                                    network.synchronizer.put(identity.publicKeyHash, identity.publicKeyHash, notCommitted);
+                                    return network.synchronizer.applyComplexUpdate(identityHash, identity,
+                                            (s, committer) -> newUserData.commit(identityHash, identity, MaybeMultihash.empty(), network, tid));
                                 });
                             }), network.dhtClient)
                                     .thenCompose(snapshot -> {
                                         LOG.info("Creating user's root directory");
                                         long t1 = System.currentTimeMillis();
-                                        return createEntryDirectory(signer, username, userWithRoot.getRoot(), network, crypto)
+                                        return createEntryDirectory(identity, username, entryData, loginPublicKey, userWithRoot.getRoot(), network, crypto)
                                                 .thenCompose(globalRoot -> {
                                                     LOG.info("Creating root directory took " + (System.currentTimeMillis() - t1) + " mS");
                                                     return createSpecialDirectory(globalRoot, username, SHARED_DIR_NAME, network, crypto);
@@ -702,8 +720,9 @@ public class UserContext {
     @JsMethod
     public CompletableFuture<UserContext> changePassword(String oldPassword, String newPassword) {
         return getKeyGenAlgorithm().thenCompose(alg -> {
-            // Use a new salt, and if this is a legacy account with generated boxer, remove it from generation
-            SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random).withoutBoxer();
+            // Use a new salt, and if this is a legacy account with generated boxer, remove it from generation and use
+            // a new generated identity independent of the password
+            SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random).withoutBoxerOrIdentity();
             // set claim expiry to two months from now
             return changePassword(oldPassword, newPassword, alg, newAlgorithm, LocalDate.now().plusMonths(2));
         });
@@ -715,28 +734,56 @@ public class UserContext {
                                                          SecretGenerationAlgorithm newAlgorithm,
                                                          LocalDate expiry) {
         LOG.info("Changing password and setting expiry to: " + expiry);
+        boolean isLegacy = existingAlgorithm.generateBoxerAndIdentity();
+        if (! isLegacy && newAlgorithm.generateBoxerAndIdentity())
+            throw new IllegalStateException("Cannot migrate from an upgraded style account to a legacy style account!");
 
         return UserUtil.generateUser(username, oldPassword, crypto.hasher, crypto.symmetricProvider, crypto.random, crypto.signer, crypto.boxer, existingAlgorithm)
-                .thenCompose(existingUser -> {
-                    if (!existingUser.getUser().secretSigningKey.equals(this.signer.secret))
+                .thenCompose(existingLogin -> {
+                    SecretSigningKey existingLoginSecret = existingLogin.getUser().secretSigningKey;
+                    if (isLegacy && !existingLoginSecret.equals(this.signer.secret))
                         throw new IllegalArgumentException("Incorrect existing password during change password attempt!");
+
                     return UserUtil.generateUser(username, newPassword, crypto.hasher, crypto.symmetricProvider,
                             crypto.random, crypto.signer, crypto.boxer, newAlgorithm)
-                            .thenCompose(updatedUser -> {
-                                PublicSigningKey newPublicSigningKey = updatedUser.getUser().publicSigningKey;
-                                PublicKeyHash existingOwner = ContentAddressedStorage.hashKey(existingUser.getUser().publicSigningKey);
-
-                                BoxingKeyPair newBoxingKeypair = newAlgorithm.includesBoxerGeneration() ? updatedUser.getBoxingPair() : boxer;
+                            .thenCompose(updatedLogin -> {
+                                PublicSigningKey newLoginPublicKey = updatedLogin.getUser().publicSigningKey;
+                                PublicKeyHash existingOwner = ContentAddressedStorage.hashKey(existingLogin.getUser().publicSigningKey);
+                                if (! isLegacy) {
+                                    // identity doesn't change here, just need to update the secret UserStaticData
+                                    byte[] auth = TimeLimitedClient.signNow(existingLoginSecret);
+                                    return network.account.getLoginData(username, existingLogin.getUser().publicSigningKey, auth).thenCompose(usd -> {
+                                        UserStaticData.EntryPoints entry = usd.getData(existingLogin.getRoot());
+                                        UserStaticData updatedEntry = new UserStaticData(entry.entries, updatedLogin.getRoot(), entry.identity, entry.boxer);
+                                        // need to commit new login algorithm too in the same call
+                                        return WriterData.getWriterData(signer.publicKeyHash, signer.publicKeyHash, network.mutable, network.dhtClient).thenCompose(cwd -> {
+                                            WriterData newIdBlock = cwd.props.withAlgorithm(newAlgorithm);
+                                            byte[] rawBlock = newIdBlock.serialize();
+                                            return crypto.hasher.sha256(rawBlock).thenCompose(blockHash -> {
+                                                OpLog.BlockWrite blockWrite = new OpLog.BlockWrite(signer.publicKeyHash, signer.secret.signMessage(blockHash), rawBlock, false);
+                                                HashCasPair pointerCas = new HashCasPair(cwd.hash, MaybeMultihash.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, blockHash)));
+                                                OpLog.PointerWrite pointerWrite = new OpLog.PointerWrite(signer.publicKeyHash, signer.secret.signMessage(pointerCas.serialize()));
+                                                LoginData updatedLoginData = new LoginData(username, updatedEntry, newLoginPublicKey, Optional.of(new Pair<>(blockWrite, pointerWrite)));
+                                                return network.account.setLoginData(updatedLoginData, TimeLimitedClient.signNow(signer.secret))
+                                                        .thenCompose(b -> UserContext.signIn(username, newPassword, network, crypto));
+                                            });
+                                        });
+                                    });
+                                }
+                                // upgrading a legacy account to new style
+                                BoxingKeyPair newBoxingKeypair = newAlgorithm.generateBoxerAndIdentity() ? updatedLogin.getBoxingPair() : boxer;
+                                SigningKeyPair newIdentityPair = SigningKeyPair.random(crypto.random, crypto.signer);
+                                PublicSigningKey newIdentityPub = newIdentityPair.publicSigningKey;
                                 return IpfsTransaction.call(existingOwner,
                                         tid -> network.dhtClient.putSigningKey(
-                                                existingUser.getUser().secretSigningKey.signMessage(newPublicSigningKey.serialize()),
+                                                existingLoginSecret.signMessage(newIdentityPub.serialize()),
                                                 existingOwner,
-                                                newPublicSigningKey,
+                                                newIdentityPub,
                                                 tid),
                                         network.dhtClient
-                                ).thenCompose(newSignerHash -> {
-                                    SigningPrivateKeyAndPublicHash newSigner =
-                                            new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey);
+                                ).thenCompose(newIdentityHash -> {
+                                    SigningPrivateKeyAndPublicHash newIdentity =
+                                            new SigningPrivateKeyAndPublicHash(newIdentityHash, newIdentityPair.secretSigningKey);
                                     Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> ownedKeys = new HashMap<>();
                                     return getUserRoot().thenCompose(homeDir -> {
                                         // If we ever implement plausibly deniable dual (N) login this will need to include all the other keys
@@ -745,22 +792,23 @@ public class UserContext {
                                         // TODO need to get the pki keypair here if were are the 'peergos' user
 
                                         // auth new key by adding to existing writer data first
-                                        OwnerProof proof = OwnerProof.build(newSigner, signer.publicKeyHash);
+                                        OwnerProof proof = OwnerProof.build(newIdentity, signer.publicKeyHash);
                                         return writeSynchronizer.applyUpdate(signer.publicKeyHash, signer, (wd, tid) ->
                                                 wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient, network.hasher))
-                                                .thenCompose(version -> version.get(signer).props.changeKeys(signer,
-                                                        newSigner,
+                                                .thenCompose(version -> version.get(signer).props.changeKeys(username,
+                                                        signer,
+                                                        newIdentity,
+                                                        newIdentityPair,
+                                                        newLoginPublicKey,
                                                         newBoxingKeypair,
-                                                        existingUser.getRoot(),
-                                                        updatedUser.getRoot(),
+                                                        existingLogin.getRoot(),
+                                                        updatedLogin.getRoot(),
                                                         newAlgorithm,
                                                         ownedKeys,
                                                         network)).thenCompose(writerData -> {
-                                                    SigningPrivateKeyAndPublicHash newUser =
-                                                            new SigningPrivateKeyAndPublicHash(newSignerHash, updatedUser.getUser().secretSigningKey);
                                                     return network.coreNode.getChain(username).thenCompose(existing -> {
                                                         List<Multihash> storage = existing.get(existing.size() - 1).claim.storageProviders;
-                                                        List<UserPublicKeyLink> claimChain = UserPublicKeyLink.createChain(signer, newUser, username, expiry, storage);
+                                                        List<UserPublicKeyLink> claimChain = UserPublicKeyLink.createChain(signer, newIdentity, username, expiry, storage);
                                                         return updateChainWithRetry(username, claimChain, "", crypto.hasher, network, x -> {})
                                                                 .thenCompose(updatedChain -> {
                                                                     if (!updatedChain)
@@ -778,6 +826,8 @@ public class UserContext {
 
     private static CompletableFuture<TrieNode> createEntryDirectory(SigningPrivateKeyAndPublicHash owner,
                                                                     String directoryName,
+                                                                    UserStaticData current,
+                                                                    PublicSigningKey loginPublic,
                                                                     SymmetricKey userRootKey,
                                                                     NetworkAccess network,
                                                                     Crypto crypto) {
@@ -789,7 +839,7 @@ public class UserContext {
         // 2. Commit authorisation for writer to owner WriterData
         // 3. Add empty WriterData for writer
         // 4. Add root directory writer's WriterData
-        // 5. Add entry point to root dir to owner WriterData
+        // 5. Add entry point to root dir to owner WriterData's UserStaticData (legacy account) or LoginData
 
         byte[] rootMapKey = crypto.random.randomBytes(32); // root will be stored under this label
         SymmetricKey rootRKey = SymmetricKey.random();
@@ -831,7 +881,7 @@ public class UserContext {
                                                                 LOG.info("Uploading root dir metadata took " + (t3 - t2) + " mS");
                                                                 return finalSnapshot;
                                                             }))
-                                                    .thenCompose(x -> addRootEntryPointAndCommit(x.merge(s2), entry, owner, userRootKey, network, tid));
+                                                    .thenCompose(x -> addRootEntryPointAndCommit(x.merge(s2), entry, current, loginPublic, owner, userRootKey, network, tid));
                                         });
                             }));
         }), network.dhtClient).thenApply(s -> TrieNodeImpl.empty().put("/" + directoryName, entry));
@@ -1716,19 +1766,23 @@ public class UserContext {
 
     private static CompletableFuture<Snapshot> addRootEntryPointAndCommit(Snapshot version,
                                                                           EntryPoint entry,
+                                                                          UserStaticData current,
+                                                                          PublicSigningKey loginPublic,
                                                                           SigningPrivateKeyAndPublicHash owner,
                                                                           SymmetricKey rootKey,
                                                                           NetworkAccess network,
                                                                           TransactionId tid) {
         CommittedWriterData cwd = version.get(owner.publicKeyHash);
         WriterData wd = cwd.props;
-        Optional<UserStaticData> updated = wd.staticData.map(sd -> {
-            UserStaticData.EntryPoints data = sd.getData(rootKey);
-            List<EntryPoint> entryPoints = data.entries;
-            entryPoints.add(entry);
-            return new UserStaticData(entryPoints, rootKey, data.boxer);
-        });
-        return wd.withStaticData(updated).commit(owner.publicKeyHash, owner, cwd.hash, network, tid);
+        if (wd.staticData.isEmpty()) {
+            UserStaticData updated = new UserStaticData(current.getData(rootKey).addEntryPoint(entry), rootKey);
+            return network.account.setLoginData(new LoginData(entry.ownerName, updated, loginPublic, Optional.empty()), owner)
+                    .thenApply(b -> version);
+        } else {
+            // legacy account
+            Optional<UserStaticData> updated = wd.staticData.map(sd -> new UserStaticData(sd.getData(rootKey).addEntryPoint(entry), rootKey));
+            return wd.withStaticData(updated).commit(owner.publicKeyHash, owner, cwd.hash, network, tid);
+        }
     }
 
     private synchronized CompletableFuture<FileWrapper> addExternalEntryPoint(EntryPoint entry) {
@@ -1913,15 +1967,11 @@ public class UserContext {
      * @return TrieNode for root of filesystem containing only our files
      */
     private static CompletableFuture<TrieNode> createOurFileTreeOnly(String ourName,
-                                                                     SymmetricKey rootKey,
+                                                                     UserStaticData.EntryPoints entry,
                                                                      WriterData userData,
-                                                                     NetworkAccess network,
-                                                                     Crypto crypto) {
+                                                                     NetworkAccess network) {
         TrieNode root = TrieNodeImpl.empty();
-        if (!userData.staticData.isPresent())
-            throw new IllegalStateException("Cannot retrieve file tree for a filesystem without entrypoints!");
-        List<EntryPoint> ourFileSystemEntries = userData.staticData.get()
-                .getData(rootKey).entries
+        List<EntryPoint> ourFileSystemEntries = entry.entries
                 .stream()
                 .filter(e -> e.ownerName.equals(ourName))
                 .map(e -> e.withOwner(userData.controller))

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -724,6 +724,8 @@ public class UserContext {
                             .thenCompose(updatedUser -> {
                                 PublicSigningKey newPublicSigningKey = updatedUser.getUser().publicSigningKey;
                                 PublicKeyHash existingOwner = ContentAddressedStorage.hashKey(existingUser.getUser().publicSigningKey);
+
+                                BoxingKeyPair newBoxingKeypair = newAlgorithm.includesBoxerGeneration() ? updatedUser.getBoxingPair() : boxer;
                                 return IpfsTransaction.call(existingOwner,
                                         tid -> network.dhtClient.putSigningKey(
                                                 existingUser.getUser().secretSigningKey.signMessage(newPublicSigningKey.serialize()),
@@ -747,7 +749,7 @@ public class UserContext {
                                                 wd.addOwnedKey(signer.publicKeyHash, signer, proof, network.dhtClient, network.hasher))
                                                 .thenCompose(version -> version.get(signer).props.changeKeys(signer,
                                                         newSigner,
-                                                        updatedUser.getBoxingPair().publicBoxingKey,
+                                                        newBoxingKeypair.publicBoxingKey,
                                                         existingUser.getRoot(),
                                                         updatedUser.getRoot(),
                                                         newAlgorithm,

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -175,7 +175,6 @@ public class UserContext {
             boolean legacyAccount = userData.staticData.isPresent();
             PublicSigningKey loginPub = generatedCredentials.getUser().publicSigningKey;
             SecretSigningKey loginSecret = generatedCredentials.getUser().secretSigningKey;
-//            PublicKeyHash loginHash = ContentAddressedStorage.hashKey(loginPub);
             return (legacyAccount ?
                     Futures.of(userData.staticData.get()) :
                     network.account.getLoginData(username, loginPub, TimeLimitedClient.signNow(loginSecret))).thenCompose(entryData -> {
@@ -764,8 +763,8 @@ public class UserContext {
                                                 HashCasPair pointerCas = new HashCasPair(cwd.hash, MaybeMultihash.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, blockHash)));
                                                 OpLog.PointerWrite pointerWrite = new OpLog.PointerWrite(signer.publicKeyHash, signer.secret.signMessage(pointerCas.serialize()));
                                                 LoginData updatedLoginData = new LoginData(username, updatedEntry, newLoginPublicKey, Optional.of(new Pair<>(blockWrite, pointerWrite)));
-                                                return network.account.setLoginData(updatedLoginData, TimeLimitedClient.signNow(signer.secret))
-                                                        .thenCompose(b -> UserContext.signIn(username, newPassword, network, crypto));
+                                                return network.account.setLoginData(updatedLoginData, signer)
+                                                        .thenCompose(b -> UserContext.signIn(username, newPassword, network.clear(), crypto));
                                             });
                                         });
                                     });

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -719,6 +719,8 @@ public class UserContext {
     @JsMethod
     public CompletableFuture<UserContext> changePassword(String oldPassword, String newPassword) {
         return getKeyGenAlgorithm().thenCompose(alg -> {
+            if (oldPassword.equals(newPassword))
+                throw new IllegalStateException("You must change to a different password.");
             // Use a new salt, and if this is a legacy account with generated boxer, remove it from generation and use
             // a new generated identity independent of the password
             SecretGenerationAlgorithm newAlgorithm = SecretGenerationAlgorithm.withNewSalt(alg, crypto.random).withoutBoxerOrIdentity();

--- a/src/peergos/shared/user/UserSnapshot.java
+++ b/src/peergos/shared/user/UserSnapshot.java
@@ -11,10 +11,14 @@ public class UserSnapshot implements Cborable {
 
     public final Map<PublicKeyHash, byte[]> pointerState;
     public final List<BlindFollowRequest> pendingFollowReqs;
+    public final Optional<LoginData> login;
 
-    public UserSnapshot(Map<PublicKeyHash, byte[]> pointerState, List<BlindFollowRequest> pendingFollowReqs) {
+    public UserSnapshot(Map<PublicKeyHash, byte[]> pointerState,
+                        List<BlindFollowRequest> pendingFollowReqs,
+                        Optional<LoginData> login) {
         this.pointerState = pointerState;
         this.pendingFollowReqs = pendingFollowReqs;
+        this.login = login;
     }
 
     @Override
@@ -30,6 +34,7 @@ public class UserSnapshot implements Cborable {
                     TreeMap::new
                 ));
         state.put("p", new CborObject.CborList(pointerMap));
+        login.ifPresent(d -> state.put("l", d));
         return CborObject.CborMap.build(state);
     }
 
@@ -40,10 +45,11 @@ public class UserSnapshot implements Cborable {
         List<BlindFollowRequest> pendingFollowReqs = m.getList("f", BlindFollowRequest::fromCbor);
         Map<PublicKeyHash, byte[]> pointerState = ((CborObject.CborList)m.get("p"))
                 .getMap(PublicKeyHash::fromCbor, c -> ((CborObject.CborByteArray)c).value);
-        return new UserSnapshot(pointerState, pendingFollowReqs);
+        Optional<LoginData> login = m.getOptional("l", LoginData::fromCbor);
+        return new UserSnapshot(pointerState, pendingFollowReqs, login);
     }
 
     public static UserSnapshot empty() {
-        return new UserSnapshot(Collections.emptyMap(), Collections.emptyList());
+        return new UserSnapshot(Collections.emptyMap(), Collections.emptyList(), Optional.empty());
     }
 }

--- a/src/peergos/shared/user/UserStaticData.java
+++ b/src/peergos/shared/user/UserStaticData.java
@@ -41,7 +41,7 @@ public class UserStaticData implements Cborable {
 
         private final long version;
         public final List<EntryPoint> entries;
-        public final Optional<BoxingKeyPair> boxer;
+        public final Optional<BoxingKeyPair> boxer; // this is only absent on legacy accounts
 
         public EntryPoints(long version, List<EntryPoint> entries, Optional<BoxingKeyPair> boxer) {
             this.version = version;

--- a/src/peergos/shared/user/UserUtil.java
+++ b/src/peergos/shared/user/UserUtil.java
@@ -25,8 +25,10 @@ public class UserUtil {
         CompletableFuture<byte[]> fut = hasher.hashToKeyBytes(username + algorithm.getExtraSalt(), password, algorithm);
         return fut.thenApply(keyBytes -> {
             byte[] signBytesSeed = Arrays.copyOfRange(keyBytes, 0, 32);
-            byte[] secretBoxBytes = Arrays.copyOfRange(keyBytes, 32, 64);
-            byte[] rootKeyBytes = Arrays.copyOfRange(keyBytes, 64, 96);
+            boolean hasBoxer = algorithm.includesBoxerGeneration();
+            byte[] secretBoxBytes = hasBoxer ? Arrays.copyOfRange(keyBytes, 32, 64) : random.randomBytes(32);
+
+            byte[] rootKeyBytes = Arrays.copyOfRange(keyBytes, hasBoxer ? 64 : 32, hasBoxer ? 96 : 64);
 	
             byte[] secretSignBytes = Arrays.copyOf(signBytesSeed, 64);
             byte[] publicSignBytes = new byte[32];

--- a/src/peergos/shared/user/UserUtil.java
+++ b/src/peergos/shared/user/UserUtil.java
@@ -25,7 +25,7 @@ public class UserUtil {
         CompletableFuture<byte[]> fut = hasher.hashToKeyBytes(username + algorithm.getExtraSalt(), password, algorithm);
         return fut.thenApply(keyBytes -> {
             byte[] signBytesSeed = Arrays.copyOfRange(keyBytes, 0, 32);
-            boolean hasBoxer = algorithm.includesBoxerGeneration();
+            boolean hasBoxer = algorithm.generateBoxerAndIdentity();
             byte[] secretBoxBytes = hasBoxer ? Arrays.copyOfRange(keyBytes, 32, 64) : random.randomBytes(32);
 
             byte[] rootKeyBytes = Arrays.copyOfRange(keyBytes, hasBoxer ? 64 : 32, hasBoxer ? 96 : 64);

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -187,6 +187,7 @@ public class WriterData implements Cborable {
                                                                           SigningPrivateKeyAndPublicHash writer,
                                                                           Optional<PublicKeyHash> followRequestReceiver,
                                                                           SymmetricKey rootKey,
+                                                                          Optional<BoxingKeyPair> boxer,
                                                                           SecretGenerationAlgorithm algorithm,
                                                                           ContentAddressedStorage ipfs,
                                                                           Hasher hasher,
@@ -198,7 +199,7 @@ public class WriterData implements Cborable {
                         followRequestReceiver,
                         Optional.of(ownedRoot),
                         Collections.emptyMap(),
-                        Optional.of(new UserStaticData(rootKey)),
+                        Optional.of(new UserStaticData(Collections.emptyList(), rootKey, boxer)),
                         Optional.empty()));
     }
 
@@ -219,7 +220,7 @@ public class WriterData implements Cborable {
         return network.synchronizer.applyUpdate(oldSigner.publicKeyHash, signer,
                 (wd, tid) -> {
                     Optional<UserStaticData> newEntryPoints = staticData
-                            .map(sd -> new UserStaticData(sd.getEntryPoints(currentKey), newKey));
+                            .map(sd -> new UserStaticData(sd.getData(currentKey).entries, newKey, sd.getData(currentKey).boxer));
                     return network.hasher.sha256(followRequestReceiver.serialize())
                             .thenCompose(boxerHash -> network.dhtClient.putBoxingKey(oldSigner.publicKeyHash,
                             oldSigner.secret.signMessage(boxerHash),

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -81,6 +81,10 @@ public class WriterData implements Cborable {
         return new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver, Optional.of(ownedRoot), namedOwnedKeys, staticData, tree);
     }
 
+    public WriterData withAlgorithm(SecretGenerationAlgorithm newAlg) {
+        return new WriterData(controller, Optional.of(newAlg), publicData, followRequestReceiver, ownedKeys, namedOwnedKeys, staticData, tree);
+    }
+
     public CompletableFuture<WriterData> addOwnedKey(PublicKeyHash owner,
                                                      SigningPrivateKeyAndPublicHash signer,
                                                      OwnerProof newOwned,
@@ -183,15 +187,14 @@ public class WriterData implements Cborable {
                         Optional.empty()));
     }
 
-    public static CompletableFuture<WriterData> createEmptyWithStaticData(PublicKeyHash owner,
-                                                                          SigningPrivateKeyAndPublicHash writer,
-                                                                          Optional<PublicKeyHash> followRequestReceiver,
-                                                                          SymmetricKey rootKey,
-                                                                          Optional<BoxingKeyPair> boxer,
-                                                                          SecretGenerationAlgorithm algorithm,
-                                                                          ContentAddressedStorage ipfs,
-                                                                          Hasher hasher,
-                                                                          TransactionId tid) {
+    public static CompletableFuture<WriterData> createIdentity(PublicKeyHash owner,
+                                                               SigningPrivateKeyAndPublicHash writer,
+                                                               Optional<PublicKeyHash> followRequestReceiver,
+                                                               Optional<UserStaticData> entryData,
+                                                               SecretGenerationAlgorithm algorithm,
+                                                               ContentAddressedStorage ipfs,
+                                                               Hasher hasher,
+                                                               TransactionId tid) {
         return OwnedKeyChamp.createEmpty(owner, writer, ipfs, hasher, tid)
                 .thenApply(ownedRoot -> new WriterData(writer.publicKeyHash,
                         Optional.of(algorithm),
@@ -199,7 +202,7 @@ public class WriterData implements Cborable {
                         followRequestReceiver,
                         Optional.of(ownedRoot),
                         Collections.emptyMap(),
-                        Optional.of(new UserStaticData(Collections.emptyList(), rootKey, boxer)),
+                        entryData,
                         Optional.empty()));
     }
 
@@ -207,15 +210,18 @@ public class WriterData implements Cborable {
         return new CommittedWriterData(hash, this);
     }
 
-    public CompletableFuture<WriterData> changeKeys(SigningPrivateKeyAndPublicHash oldSigner,
+    public CompletableFuture<WriterData> changeKeys(String username,
+                                                    SigningPrivateKeyAndPublicHash oldSigner,
                                                     SigningPrivateKeyAndPublicHash signer,
+                                                    SigningKeyPair newIdentity,
+                                                    PublicSigningKey newLogin,
                                                     BoxingKeyPair followRequestReceiver,
                                                     SymmetricKey currentKey,
                                                     SymmetricKey newKey,
                                                     SecretGenerationAlgorithm newAlgorithm,
                                                     Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> ownedKeys,
                                                     NetworkAccess network) {
-
+        // This will upgrade legacy accounts to the new structure with secret UserStaticData
         network.synchronizer.putEmpty(oldSigner.publicKeyHash, signer.publicKeyHash);
         return network.synchronizer.applyUpdate(oldSigner.publicKeyHash, signer,
                 (wd, tid) -> {
@@ -223,13 +229,15 @@ public class WriterData implements Cborable {
                             .map(sd -> {
                                 UserStaticData.EntryPoints staticData = sd.getData(currentKey);
                                 Optional<BoxingKeyPair> boxer = Optional.of(staticData.boxer.orElse(followRequestReceiver));
-                                return new UserStaticData(staticData.entries, newKey, boxer);
+                                Optional<SigningKeyPair> identity = Optional.of(staticData.identity.orElse(newIdentity));
+                                return new UserStaticData(staticData.entries, newKey, identity, boxer);
                             });
-                    return network.hasher.sha256(followRequestReceiver.serialize())
+                    return network.account.setLoginData(new LoginData(username, newEntryPoints.get(), newLogin, Optional.empty()), oldSigner)
+                            .thenCompose(b -> network.hasher.sha256(followRequestReceiver.serialize())
                             .thenCompose(boxerHash -> network.dhtClient.putBoxingKey(oldSigner.publicKeyHash,
-                            oldSigner.secret.signMessage(boxerHash),
-                            followRequestReceiver.publicBoxingKey, tid
-                    )).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner,
+                                    oldSigner.secret.signMessage(boxerHash),
+                                    followRequestReceiver.publicBoxingKey, tid
+                            ))).thenCompose(boxerHash -> OwnedKeyChamp.createEmpty(oldSigner.publicKeyHash, oldSigner,
                             network.dhtClient, network.hasher, tid)
                             .thenCompose(ownedRoot -> {
                                 Map<String, OwnerProof> newNamedOwnedKeys = namedOwnedKeys.entrySet()
@@ -244,7 +252,7 @@ public class WriterData implements Cborable {
                                         Optional.of(new PublicKeyHash(boxerHash)),
                                         Optional.of(ownedRoot),
                                         newNamedOwnedKeys,
-                                        newEntryPoints,
+                                        Optional.empty(),
                                         tree);
                                 return getOwnedKeyChamp(network.dhtClient, network.hasher)
                                         .thenCompose(okChamp -> okChamp.applyToAllMappings(base, (nwd, p) ->
@@ -291,8 +299,7 @@ public class WriterData implements Cborable {
                         return CompletableFuture.completedFuture(new Snapshot(signer.publicKeyHash, committed));
                     }
                     HashCasPair cas = new HashCasPair(currentHash, newHash);
-                    byte[] signed = signer.secret.signMessage(cas.serialize());
-                    return mutable.setPointer(owner, signer.publicKeyHash, signed)
+                    return mutable.setPointer(owner, signer, cas)
                             .thenApply(res -> {
                                 if (!res)
                                     throw new IllegalStateException("Corenode Crypto CAS failed!");

--- a/src/peergos/shared/util/Constants.java
+++ b/src/peergos/shared/util/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
     public static final String PEERGOS_API_PREFIX = "peergos/v0/";
     public static final String ADMIN_URL = PEERGOS_API_PREFIX + "admin/";
     public static final String MUTABLE_POINTERS_URL = PEERGOS_API_PREFIX + "mutable/";
+    public static final String LOGIN_URL = PEERGOS_API_PREFIX + "login/";
     public static final String CORE_URL = PEERGOS_API_PREFIX + "core/";
     public static final String SOCIAL_URL = PEERGOS_API_PREFIX + "social/";
     public static final String SPACE_USAGE_URL = PEERGOS_API_PREFIX + "storage/";


### PR DESCRIPTION
This drastically improves security in some threat models. 

Currently the boxer (the key pair used to send follow requests to) and your identity key pair are deterministically derived from your password (and username and salt) at login. This is designed to prevent brute force attempts on a good password, even by those with state level resources, by using scrypt with hard parameters. However, if someone chose a poor password, or there is an attacker who stores all their previous UserStaticData blobs (the encrypted entry point to their file system) and a previous password of theirs is leaked independently, then this user may be vulnerable to offline brute force in the former case, and exposing their data in the second. 

**Currently:**
scrypt(password, username+salt) => identity signing keypair, boxing key pair, root key (which decrypts the UserStaticData)

**After this PR:**
scrypt(password, username+salt) => auth signin keypair, root key (which decrypts the UserStaticData). Identity and boxer keypairs are stored in the UserStaticData

This PR moves the UserStaticData to a secret known only by your home server. To retrieve the secret you auth with a key pair that you generate as before from your password+username+salt. The identity key pair and boxer key pair are now stored in the UserStaticData (and are generated randomly - not from the password etc.). 

This means that offline brute force attacks are impossible, because you need to ask the server each time to try and get the UserStaticData. It also paves the way for implementing 2FA which will simply be an additional step to retrieve the UserStaticData. It also decouples your identity from your password, which means you can change your password without needing to contact the PKI, just your server. 

Even if the server is compromised, you still have the existing brute force protection.

**Key requirements**
* New sign ups are in the new scheme
* Legacy accounts can still login
* Changing your password will upgrade a legacy account, and keep the same boxing keypair

TODO
* Consider automatically upgrading legacy accounts at login, but this can be a separate PR.

**Testing**
As well as the unit tests, I've tested running a node from master, and creating users which have changed their password 0, 1, 2, 3 times. Then restarting with this version, testing each user can still login, changing their password, and testing they can still log in after, including the "peergos" user. 
