### PR TITLE
Protect against malicious p2p champ.get calls

### DIFF
--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -120,7 +120,7 @@ public class DHTHandler implements HttpHandler {
                 case CHAMP_GET: {
                     AggregatedMetrics.DHT_CHAMP_GET.inc();
                     PublicKeyHash ownerHash = PublicKeyHash.fromString(last.apply("owner"));
-                    Multihash root = Cid.decode(args.get(0));
+                    Cid root = Cid.decode(args.get(0));
                     byte[] champKey = ArrayOps.hexToBytes(args.get(1));
                     Optional<BatWithId> bat = params.containsKey("bat") ?
                             Optional.of(BatWithId.decode(last.apply("bat"))) :

--- a/src/peergos/server/storage/AuthedStorage.java
+++ b/src/peergos/server/storage/AuthedStorage.java
@@ -83,6 +83,13 @@ public class AuthedStorage extends DelegatingStorage implements DeletableContent
     }
 
     @Override
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+        if (! hasBlock(root))
+            return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
+        return getChampLookup(root, champKey, bat, h);
+    }
+
+    @Override
     public Stream<Cid> getAllBlockHashes() {
         return target.getAllBlockHashes();
     }

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -90,7 +90,7 @@ public class DelayingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         sleep(readDelay);
         return source.getChampLookup(owner, root, champKey, bat);
     }

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -69,7 +69,9 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+        if (! hasBlock(root))
+            return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
         return getChampLookup(root, champKey, bat, hasher);
     }
 

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -41,7 +41,7 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return modifications.getChampLookup(owner, root, champKey, bat);
     }
 

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -49,7 +49,7 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return getChampLookup(root, champKey, bat, hasher);
     }
 

--- a/src/peergos/server/storage/RequestCountingStorage.java
+++ b/src/peergos/server/storage/RequestCountingStorage.java
@@ -64,7 +64,7 @@ public class RequestCountingStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return target.getChampLookup(owner, root, champKey, bat)
                 .thenApply(blocks -> {
                     champGet.incrementAndGet();

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -267,7 +267,9 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+        if (! hasBlock(root))
+            return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
         return getChampLookup(root, champKey, bat, hasher);
     }
 

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -100,9 +100,11 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
 
     @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
-                                                          Multihash root,
+                                                          Cid root,
                                                           byte[] champKey,
                                                           Optional<BatWithId> bat) {
+        if (! hasBlock(root))
+            return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
         return getChampLookup(root, champKey, bat, hasher);
     }
 

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -111,7 +111,7 @@ public class RetryStorageTests {
         }
 
         @Override
-        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
             if(counter++ % retryLimit != 0) {
                 return CompletableFuture.failedFuture(new Error("failure!"));
             }else {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -455,8 +455,8 @@ public class NetworkAccess {
             return Futures.of(cache.get(cacheKey));
         return cap.bat.map(b -> b.calculateId(hasher).thenApply(id -> Optional.of(new BatWithId(b, id.id)))).orElse(Futures.of(Optional.empty()))
                 .thenCompose(bat -> Futures.asyncExceptionally(
-                        () -> dhtClient.getChampLookup(cap.owner, base.tree.get(), cap.getMapKey(), bat),
-                        t -> dhtClient.getChampLookup(base.tree.get(), cap.getMapKey(), bat, hasher)
+                        () -> dhtClient.getChampLookup(cap.owner, (Cid) base.tree.get(), cap.getMapKey(), bat),
+                        t -> dhtClient.getChampLookup((Cid) base.tree.get(), cap.getMapKey(), bat, hasher)
                 ).thenCompose(blocks -> ChampWrapper.create((Cid)base.tree.get(), x -> Futures.of(x.data), dhtClient, hasher, c -> (CborObject.CborMerkleLink) c)
                         .thenCompose(tree -> tree.get(cap.getMapKey()))
                         .thenApply(c -> c.map(x -> x.target))

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -147,7 +147,7 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return Futures.of(new ArrayList<>(storage.values()));
     }
 

--- a/src/peergos/shared/storage/CachingVerifyingStorage.java
+++ b/src/peergos/shared/storage/CachingVerifyingStorage.java
@@ -77,7 +77,7 @@ public class CachingVerifyingStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return target.getChampLookup(owner, root, champKey, bat)
                 .thenCompose(blocks -> Futures.combineAllInOrder(blocks.stream()
                         .map(b -> hasher.hash(b, false)

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -158,9 +158,9 @@ public interface ContentAddressedStorage {
      */
     CompletableFuture<Optional<byte[]>> getRaw(Cid hash, Optional<BatWithId> bat);
 
-    CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat);
+    CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat);
 
-    default CompletableFuture<List<byte[]>> getChampLookup(Multihash root, byte[] champKey, Optional<BatWithId> bat, Hasher hasher) {
+    default CompletableFuture<List<byte[]>> getChampLookup(Cid root, byte[] champKey, Optional<BatWithId> bat, Hasher hasher) {
         CachingStorage cache = new CachingStorage(this, 100, 100 * 1024);
         return ChampWrapper.create((Cid)root, x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
                 .thenCompose(tree -> tree.get(champKey))
@@ -361,7 +361,7 @@ public interface ContentAddressedStorage {
         }
 
         @Override
-        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
             if (! isPeergosServer) {
                 return getChampLookup(root, champKey, bat, hasher);
             }
@@ -560,7 +560,7 @@ public interface ContentAddressedStorage {
         }
 
         @Override
-        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
             return Proxy.redirectCall(core,
                     ourNodeId,
                     owner,

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -75,7 +75,7 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return target.getChampLookup(owner, root, champKey, bat);
     }
 

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -308,7 +308,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return Futures.asyncExceptionally(
                 () -> fallback.getChampLookup(owner, root, champKey, bat),
                 t -> {

--- a/src/peergos/shared/storage/PeergosBackedStorage.java
+++ b/src/peergos/shared/storage/PeergosBackedStorage.java
@@ -131,7 +131,7 @@ public class PeergosBackedStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return Futures.of(Collections.emptyList());
     }
 

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -118,7 +118,7 @@ public class RetryStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Multihash root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
         return runWithRetry(() -> target.getChampLookup(owner, root, champKey, bat));
     }
 


### PR DESCRIPTION
Make sure a malicious champ.get call via a p2p http request, with a faked owner will not result in retrieving blocks.