### PR TITLE
block p2p http get calls

### DIFF
--- a/src/peergos/server/storage/GetBlockingStorage.java
+++ b/src/peergos/server/storage/GetBlockingStorage.java
@@ -1,0 +1,43 @@
+package peergos.server.storage;
+
+import peergos.shared.cbor.*;
+import peergos.shared.io.ipfs.cid.*;
+import peergos.shared.storage.*;
+import peergos.shared.storage.auth.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+public class GetBlockingStorage extends DelegatingStorage {
+    private final ContentAddressedStorage target;
+
+    public GetBlockingStorage(ContentAddressedStorage target) {
+        super(target);
+        this.target = target;
+    }
+
+    @Override
+    public CompletableFuture<BlockStoreProperties> blockStoreProperties() {
+        return target.blockStoreProperties();
+    }
+
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return new GetBlockingStorage(target.directToOrigin());
+    }
+
+    @Override
+    public void clearBlockCache() {
+        target.clearBlockCache();
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(Cid key, Optional<BatWithId> bat) {
+        throw new IllegalStateException("P2P block gets are not allowed, use bitswap!");
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Cid key, Optional<BatWithId> bat) {
+        throw new IllegalStateException("P2P block gets are not allowed, use bitswap!");
+    }
+}

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -111,6 +111,7 @@ public class MultiNodeNetworkTests {
             int ipfsGatewayPort = 9000 + random.nextInt(8000);
             int ipfsSwarmPort = 9000 + random.nextInt(8000);
             int peergosPort = 9000 + random.nextInt(8000);
+            int proxyTargetPort = 9000 + random.nextInt(8000);
             int allowPort = 9000 + random.nextInt(8000);
             Args normalNode = UserTests.buildArgs()
                     .with("useIPFS", "true")
@@ -122,7 +123,7 @@ public class MultiNodeNetworkTests {
                     .with("allow-target", "/ip4/127.0.0.1/tcp/" + allowPort)
                     .with("ipfs-swarm-port", "" + ipfsSwarmPort)
                     .with(IpfsWrapper.IPFS_BOOTSTRAP_NODES, "" + Main.getLocalBootstrapAddress(bootstrapSwarmPort, pkiNodeId))
-                    .with("proxy-target", Main.getLocalMultiAddress(peergosPort).toString())
+                    .with("proxy-target", Main.getLocalMultiAddress(proxyTargetPort).toString())
                     .with("ipfs-api-address", Main.getLocalMultiAddress(ipfsApiPort).toString());
             argsToCleanUp.add(normalNode);
             UserService service = Main.PEERGOS.main(normalNode);


### PR DESCRIPTION
We do this by listening on an additional port which the p2p http requests are proxied to. This can then ignore block.get calls. 