### PR TITLE
Further optimise BufferedNetworkAccess to remove superfluous signatures

### DIFF
--- a/src/peergos/server/tests/slow/DeleteBenchmark.java
+++ b/src/peergos/server/tests/slow/DeleteBenchmark.java
@@ -54,7 +54,7 @@ public class DeleteBenchmark {
         return PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
     }
 
-    // DELETE(100) duration: 16028 mS
+    // DELETE(100) duration: 15552 mS
     @Test
     public void deleteFolderOfSmallFiles() throws Exception {
         String username = generateUsername();

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -129,6 +129,7 @@ public class BufferedNetworkAccess extends NetworkAccess {
                         .thenCompose(x -> blocks.closeTransaction(owner, tid))
                         .thenApply(x -> {
                             blockBuffer.clear();
+                            pointerBuffer.clear();
                             writers.clear();
                             writerUpdates.clear();
                             return commitWatcher.get();

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -3,6 +3,7 @@ package peergos.shared;
 import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.mutable.*;
 import peergos.shared.social.*;
 import peergos.shared.storage.*;
@@ -14,6 +15,7 @@ import peergos.shared.util.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.stream.*;
 
 /** This will buffer block writes, and mutable pointer updates and commit in bulk
  *
@@ -24,6 +26,8 @@ public class BufferedNetworkAccess extends NetworkAccess {
     private final BufferedPointers pointerBuffer;
     private final int bufferSize;
     private Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> writers = new HashMap<>();
+    private final List<WriterUpdate> writerUpdates = new ArrayList<>();
+    private Committer targetCommitter;
     private final PublicKeyHash owner;
     private final Supplier<Boolean> commitWatcher;
     private final ContentAddressedStorage blocks;
@@ -58,8 +62,37 @@ public class BufferedNetworkAccess extends NetworkAccess {
         pointerBuffer.watchUpdates(() -> maybeCommit());
     }
 
-    public void addWriter(SigningPrivateKeyAndPublicHash writer) {
-        writers.put(writer.publicKeyHash, writer);
+    private static class WriterUpdate {
+        public final PublicKeyHash writer;
+        public final CommittedWriterData prev;
+        public final CommittedWriterData current;
+
+        public WriterUpdate(PublicKeyHash writer, CommittedWriterData prev, CommittedWriterData current) {
+            this.writer = writer;
+            this.prev = prev;
+            this.current = current;
+        }
+    }
+
+    public Committer buildCommitter(Committer c) {
+        targetCommitter = c;
+        return (o, w, wd, e, tid) -> blockBuffer.put(owner, w.publicKeyHash, new byte[0], wd.serialize(), tid)
+                .thenApply(newHash -> {
+                    CommittedWriterData updated = new CommittedWriterData(MaybeMultihash.of(newHash), wd);
+                    PublicKeyHash writer = w.publicKeyHash;
+                    writers.put(writer, w);
+                    if (writerUpdates.isEmpty())
+                        writerUpdates.add(new WriterUpdate(writer, e, updated));
+                    else {
+                        WriterUpdate last = writerUpdates.get(writerUpdates.size() - 1);
+                        if (last.writer.equals(writer))
+                            writerUpdates.set(writerUpdates.size() - 1, new WriterUpdate(writer, last.prev, updated));
+                        else {
+                            writerUpdates.add(new WriterUpdate(writer, e, updated));
+                        }
+                    }
+                    return new Snapshot(writer, updated);
+                });
     }
 
     public int bufferedSize() {
@@ -72,18 +105,32 @@ public class BufferedNetworkAccess extends NetworkAccess {
         return Futures.of(true);
     }
 
+    private List<Cid> getRoots() {
+        return writerUpdates.stream()
+                .flatMap(u -> u.current.hash.toOptional().stream())
+                .map(c -> (Cid)c)
+                .collect(Collectors.toList());
+    }
+
+    private CompletableFuture<List<Snapshot>> commitPointers(TransactionId tid) {
+        return Futures.combineAllInOrder(writerUpdates.stream()
+                .map(u -> targetCommitter.commit(owner, writers.get(u.writer), u.current.props, u.prev, tid))
+                .collect(Collectors.toList()));
+    }
+
     public synchronized CompletableFuture<Boolean> commit() {
         // Condense pointers and do a mini GC to remove superfluous work
-        pointerBuffer.condense(writers);
-        blockBuffer.gc(pointerBuffer.getRoots());
-        return blocks.startTransaction(owner)
+        blockBuffer.gc(getRoots());
+        return blockBuffer.signBlocks(writers)
+                .thenCompose(b -> blocks.startTransaction(owner))
                 .thenCompose(tid -> blockBuffer.commit(owner, tid)
+                        .thenCompose(b -> commitPointers(tid))
                         .thenCompose(b -> pointerBuffer.commit())
                         .thenCompose(x -> blocks.closeTransaction(owner, tid))
                         .thenApply(x -> {
                             blockBuffer.clear();
-                            pointerBuffer.clear();
                             writers.clear();
+                            writerUpdates.clear();
                             return commitWatcher.get();
                         }));
     }

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -189,6 +189,13 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
             boolean isRaw = m.getBoolean("r");
             return new BlockWrite(writer, signature, block, isRaw);
         }
+
+        @Override
+        public String toString() {
+            return "BlockWrite{block[" + block.length +
+                    "], " + (isRaw ? "raw" : "cbor") +
+                    '}';
+        }
     }
 
     public static final class PointerWrite implements Cborable {

--- a/src/peergos/shared/mutable/BufferedPointers.java
+++ b/src/peergos/shared/mutable/BufferedPointers.java
@@ -29,14 +29,9 @@ public class BufferedPointers implements MutablePointers {
     private final MutablePointers target;
     private final Map<PublicKeyHash, PointerUpdate> buffer = new HashMap<>();
     private final List<PointerUpdate> order = new ArrayList<>();
-    private Supplier<CompletableFuture<Boolean>> watcher;
 
     public BufferedPointers(MutablePointers target) {
         this.target = target;
-    }
-
-    public void watchUpdates(Supplier<CompletableFuture<Boolean>> watcher) {
-        this.watcher = watcher;
     }
 
     @Override
@@ -56,7 +51,7 @@ public class BufferedPointers implements MutablePointers {
             buffer.put(writer, update);
             order.add(update);
         }
-        return watcher.get();
+        return Futures.of(true);
     }
 
     /**

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -761,10 +761,7 @@ public class FileWrapper {
         return getPath(network).thenCompose(path ->
                 buffered.synchronizer.applyComplexUpdate(owner(), signingPair(),
                         (s, c) -> {
-                    Committer condenser = (o, w, wd, e, tid) -> {
-                        buffered.addWriter(w);
-                        return c.commit(o, w, wd, e, tid);
-                    };
+                            Committer condenser = buffered.buildCommitter(c);
                             return getUpdated(s, buffered).thenCompose(us -> Futures.reduceAll(directories, us,
                                     (dir, children) -> dir.getOrMkdirs(children.relativePath, false, mirror, buffered, crypto, dir.version, condenser)
                                             .thenCompose(p -> uploadFolder(Paths.get(path).resolve(children.path()), p.right,
@@ -1783,10 +1780,7 @@ public class FileWrapper {
         parent.setModified();
         return buffered.synchronizer.applyComplexUpdate(owner(), signingPair(),
                 (version, c) -> {
-                    Committer condenser = (o, w, wd, e, tid) -> {
-                        buffered.addWriter(w);
-                        return c.commit(o, w, wd, e, tid);
-                    };
+                    Committer condenser = buffered.buildCommitter(c);
                     return (writableParent ? version.withWriter(owner(), parent.writer(), network)
                             .thenCompose(v2 -> parent.pointer.fileAccess
                                     .removeChildren(v2, condenser, Arrays.asList(getPointer().capability), parent.writableFilePointer(),


### PR DESCRIPTION
This applies to both pointers and blocks that will not be committed.
Signing was 50% of time in the browser so this gives a further 2X to bulk upload in browser.