### PR TITLE
Optimise large file upload

### DIFF
--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1355,53 +1355,53 @@ public class MultiUserTests {
     }
 
     @Test
-    public void unfollow() throws Exception {
+    public void unfollow() {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
         UserContext u2 = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
-        u2.sendFollowRequest(u1.username, SymmetricKey.random());
-        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().get();
-        u1.sendReplyFollowRequest(u1Requests.get(0), true, true);
-        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().get();
+        u2.sendFollowRequest(u1.username, SymmetricKey.random()).join();
+        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().join();
+        u1.sendReplyFollowRequest(u1Requests.get(0), true, true).join();
+        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().join();
 
-        Set<String> u1Following = u1.getFollowing().get();
+        Set<String> u1Following = u1.getFollowing().join();
         Assert.assertTrue("u1 following u2", u1Following.contains(u2.username));
 
-        u1.unfollow(u2.username).get();
+        u1.unfollow(u2.username).join();
 
-        Set<String> newU1Following = u1.getFollowing().get();
+        Set<String> newU1Following = u1.getFollowing().join();
         Assert.assertTrue("u1 no longer following u2", !newU1Following.contains(u2.username));
 
-        Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).get();
-        assertTrue("u1 can no longer see u2's root", !u2Tou1.isPresent());
+        Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).join();
+        assertTrue("u1 can no longer see u2's root", u2Tou1.isEmpty());
 
-        Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).get();
+        Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).join();
         assertTrue("u2 can still see u1's root", u1Tou2.isPresent());
     }
 
     @Test
-    public void removeFollower() throws Exception {
+    public void removeFollower() {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
         UserContext u2 = PeergosNetworkUtils.ensureSignedUp(random(), random(), network, crypto);
-        u2.sendFollowRequest(u1.username, SymmetricKey.random());
-        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().get();
-        u1.sendReplyFollowRequest(u1Requests.get(0), true, true);
-        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().get();
+        u2.sendFollowRequest(u1.username, SymmetricKey.random()).join();
+        List<FollowRequestWithCipherText> u1Requests = u1.processFollowRequests().join();
+        u1.sendReplyFollowRequest(u1Requests.get(0), true, true).join();
+        List<FollowRequestWithCipherText> u2FollowRequests = u2.processFollowRequests().join();
 
-        Set<String> u1Followers = u1.getFollowerNames().get();
+        Set<String> u1Followers = u1.getFollowerNames().join();
         Assert.assertTrue("u1 following u2", u1Followers.contains(u2.username));
 
-        u1.removeFollower(u2.username).get();
+        u1.removeFollower(u2.username).join();
 
-        Set<String> newU1Followers = u1.getFollowerNames().get();
+        Set<String> newU1Followers = u1.getFollowerNames().join();
         Assert.assertTrue("u1 no longer has u2 as follower", !newU1Followers.contains(u2.username));
 
-        Set<String> u2Following = u2.getFollowing().get();
+        Set<String> u2Following = u2.getFollowing().join();
         Assert.assertTrue("u2 is no longer following u1", !u2Following.contains(u1.username));
 
-        Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).get();
+        Optional<FileWrapper> u2Tou1 = u1.getByPath("/" + u2.username).join();
         assertTrue("u1 can still see u2's root", u2Tou1.isPresent());
 
-        Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).get();
-        assertTrue("u2 can no longer see u1's root", !u1Tou2.isPresent());
+        Optional<FileWrapper> u1Tou2 = u2.getByPath("/" + u1.username).join();
+        assertTrue("u2 can no longer see u1's root", u1Tou2.isEmpty());
     }
 }

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1443,7 +1443,8 @@ public class PeergosNetworkUtils {
                 Arrays.asList(new Text("G'day, skip!")), LocalDateTime.now(),
                 SocialPost.Resharing.Friends, Optional.empty(),
                 Collections.emptyList(), Collections.emptyList());
-        Pair<Path, FileWrapper> p = a.getSocialFeed().join().createNewPost(post).join();
+        SocialFeed feed = a.getSocialFeed().join();
+        Pair<Path, FileWrapper> p = feed.createNewPost(post).join();
         String aFriendsUid = a.getGroupUid(SocialState.FRIENDS_GROUP_NAME).join().get();
         a.shareReadAccessWith(p.left, Set.of(aFriendsUid)).join();
 

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -323,6 +323,11 @@ public interface CborObject extends Cborable {
         public int hashCode() {
             return target != null ? target.hashCode() : 0;
         }
+
+        @Override
+        public String toString() {
+            return target.toString();
+        }
     }
 
     final class CborList implements CborObject, Cborable {

--- a/src/peergos/shared/social/SocialFeed.java
+++ b/src/peergos/shared/social/SocialFeed.java
@@ -234,8 +234,7 @@ public class SocialFeed {
     @JsMethod
     public synchronized CompletableFuture<SocialFeed> update() {
         return context.getFollowingNodes()
-                .thenCompose(friends -> Futures.combineAll(friends.stream()
-                        .parallel()
+                .thenCompose(friends -> Futures.combineAllInOrder(friends.stream()
                         .map(this::getFriendUpdate)
                         .collect(Collectors.toList())))
                 .thenCompose(updates -> mergeUpdates(updates.stream()

--- a/src/peergos/shared/social/SocialFeed.java
+++ b/src/peergos/shared/social/SocialFeed.java
@@ -234,7 +234,8 @@ public class SocialFeed {
     @JsMethod
     public synchronized CompletableFuture<SocialFeed> update() {
         return context.getFollowingNodes()
-                .thenCompose(friends -> Futures.combineAllInOrder(friends.stream()
+                .thenCompose(friends -> Futures.combineAll(friends.stream()
+                        .parallel()
                         .map(this::getFriendUpdate)
                         .collect(Collectors.toList())))
                 .thenCompose(updates -> mergeUpdates(updates.stream()

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -523,7 +523,8 @@ public class IncomingCapCache {
         Path parentPath = fullPath.getParent();
         String owner = fullPath.getName(0).toString();
         String filename = fullPath.getFileName().toString();
-        return root.getOrMkdirs(parentPath, network, false, root.mirrorBatId(), crypto)
+        return root.getUpdated(network)
+                .thenCompose(freshRoot -> freshRoot.getOrMkdirs(parentPath, network, false, root.mirrorBatId(), crypto))
                 .thenCompose(parent -> parent.getChild(DIR_STATE, crypto.hasher, network)
                         .thenCompose(capsOpt -> {
                             if (capsOpt.isEmpty()) {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -756,7 +756,7 @@ public class FileWrapper {
                                                         Supplier<Boolean> commitWatcher) {
 
         Optional<BatId> mirror = mirrorBatId().or(() -> mirrorBat);
-        BufferedNetworkAccess buffered = BufferedNetworkAccess.build(network, 5 * 1024 * 1024, owner(), commitWatcher, network.hasher);
+        BufferedNetworkAccess buffered = BufferedNetworkAccess.build(network, 10 * 1024 * 1024, owner(), commitWatcher, network.hasher);
         TransactionServiceImpl txns = transactions.withNetwork(buffered);
         return getPath(network).thenCompose(path ->
                 buffered.synchronizer.applyComplexUpdate(owner(), signingPair(),


### PR DESCRIPTION
Optimise large file upload by doing encryption and upload concurrently - 50% faster to demo server.

This is achieved with a Queue which encryptors add to and uploaders poll from. The queue is limited to 10 chunks (50 MiB).

This could be improved further if the encryption was actually in another thread (web worker)
Currently large file upload is 25% signing and 25% encryption.

We could probably also separate out the fragment uploads from the champ puts in the upload for more speed too.