### PR TITLE
Speed up non local fragment gets when using DirectS3Storage

### DIFF
--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -698,7 +698,7 @@ public abstract class UserTests {
         SymmetricKey baseKey = pointer.capability.rBaseKey;
         SymmetricKey dataKey = pointer.fileAccess.getDataKey(baseKey);
         Assert.assertTrue("data key different from base key", ! dataKey.equals(baseKey));
-        pointer.fileAccess.getLinkedData(dataKey, c -> ((CborObject.CborByteArray)c).value, crypto.hasher, network, x -> {}).join();
+        pointer.fileAccess.getLinkedData(file.owner(), dataKey, c -> ((CborObject.CborByteArray)c).value, crypto.hasher, network, x -> {}).join();
     }
 
     @Test

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -143,7 +143,8 @@ public class FragmentedPaddedCipherText implements Cborable {
                 });
     }
 
-    public <T> CompletableFuture<T> getAndDecrypt(SymmetricKey from,
+    public <T> CompletableFuture<T> getAndDecrypt(PublicKeyHash owner,
+                                                  SymmetricKey from,
                                                   Function<CborObject, T> fromCbor,
                                                   Hasher h,
                                                   NetworkAccess network,
@@ -153,7 +154,7 @@ public class FragmentedPaddedCipherText implements Cborable {
                 return Futures.of(new CipherText(nonce, ArrayOps.concat(header.get(), inlinedCipherText.get())).decrypt(from, fromCbor, monitor));
             return Futures.of(new CipherText(nonce, inlinedCipherText.get()).decrypt(from, fromCbor, monitor));
         }
-        return network.dhtClient.downloadFragments(cipherTextFragments, bats, h, monitor, 1.0)
+        return network.dhtClient.downloadFragments(owner, cipherTextFragments, bats, h, monitor, 1.0)
                 .thenApply(frags -> frags.stream()
                         .map(f -> new FragmentWithHash(new Fragment(Bat.removeRawBlockBatPrefix(f.fragment.data)), f.hash))
                         .collect(Collectors.toList()))

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -85,7 +85,8 @@ public class BufferedStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Cid> hashes,
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(PublicKeyHash owner,
+                                                                       List<Cid> hashes,
                                                                        List<BatWithId> bats,
                                                                        Hasher h,
                                                                        ProgressConsumer<Long> monitor,

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -189,7 +189,8 @@ public interface ContentAddressedStorage {
         return new Cid(Cid.V1, isRaw ? Cid.Codec.Raw : Cid.Codec.DagCbor, Multihash.Type.sha2_256, sha256);
     }
 
-    default CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Cid> hashes,
+    default CompletableFuture<List<FragmentWithHash>> downloadFragments(PublicKeyHash owner,
+                                                                        List<Cid> hashes,
                                                                         List<BatWithId> bats,
                                                                         Hasher h,
                                                                         ProgressConsumer<Long> monitor,

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -85,12 +85,13 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Cid> hashes,
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(PublicKeyHash owner,
+                                                                       List<Cid> hashes,
                                                                        List<BatWithId> bats,
                                                                        Hasher h,
                                                                        ProgressConsumer<Long> monitor,
                                                                        double spaceIncreaseFactor) {
-        return target.downloadFragments(hashes, bats, h, monitor, spaceIncreaseFactor);
+        return target.downloadFragments(owner, hashes, bats, h, monitor, spaceIncreaseFactor);
     }
 
     @Override

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -128,12 +128,13 @@ public class RetryStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Cid> hashes,
+    public CompletableFuture<List<FragmentWithHash>> downloadFragments(PublicKeyHash owner,
+                                                                       List<Cid> hashes,
                                                                        List<BatWithId> bats,
                                                                        Hasher h,
                                                                        ProgressConsumer<Long> monitor,
                                                                        double spaceIncreaseFactor) {
-        return runWithRetry(() -> target.downloadFragments(hashes, bats, h, monitor, spaceIncreaseFactor));
+        return runWithRetry(() -> target.downloadFragments(owner, hashes, bats, h, monitor, spaceIncreaseFactor));
     }
 
     @Override

--- a/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
+++ b/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
@@ -103,7 +103,7 @@ public class EncryptedChunkRetriever implements FileRetriever {
                         return CompletableFuture.completedFuture(Optional.of(withLocation));
                     });
         }
-        return linksToData.getAndDecrypt(dataKey, c -> ((CborObject.CborByteArray)c).value, crypto.hasher, network, monitor)
+        return linksToData.getAndDecrypt(ourCap.owner, dataKey, c -> ((CborObject.CborByteArray)c).value, crypto.hasher, network, monitor)
                 .thenApply(data ->  Optional.of(new LocatedChunk(ourCap.getLocation(), ourCap.bat, ourExistingHash,
                         new Chunk(truncate(data, (int) Math.min(Chunk.MAX_SIZE, truncateTo)),
                                 dataKey, ourCap.getMapKey(), ourCap.rBaseKey.createNonce()))));

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -309,7 +309,7 @@ public class CryptreeNode implements Cborable {
                                                                               NetworkAccess network) {
         if (! isDirectory)
             return CompletableFuture.completedFuture(Collections.emptyList());
-        return getLinkedData(us.rBaseKey, ChildrenLinks::fromCbor, network.hasher, network, x -> {})
+        return getLinkedData(us.owner, us.rBaseKey, ChildrenLinks::fromCbor, network.hasher, network, x -> {})
                 .thenCompose(c -> {
                     if (c.children.isB())
                         return Futures.of(c.children.b());
@@ -483,12 +483,13 @@ public class CryptreeNode implements Cborable {
         return FragmentedPaddedCipherText.build(rBaseKey, children, MIN_FRAGMENT_SIZE, Fragment.MAX_LENGTH, mirrorBat, random, hasher, false);
     }
 
-    public <T> CompletableFuture<T> getLinkedData(SymmetricKey baseOrDataKey,
+    public <T> CompletableFuture<T> getLinkedData(PublicKeyHash owner,
+                                                  SymmetricKey baseOrDataKey,
                                                   Function<CborObject, T> fromCbor,
                                                   Hasher h,
                                                   NetworkAccess network,
                                                   ProgressConsumer<Long> progress) {
-        return childrenOrData.getAndDecrypt(baseOrDataKey, fromCbor, h, network, progress);
+        return childrenOrData.getAndDecrypt(owner, baseOrDataKey, fromCbor, h, network, progress);
     }
 
     public CryptreeNode withParentLink(SymmetricKey parentKey, RelativeCapability newParentLink) {


### PR DESCRIPTION
This avoids repeatedly doing the authReads call for such fragments which will always fail.