### PR TITLE
Fix migrate timeout

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -860,6 +860,7 @@ public class Main extends Builder {
                     QuotaCLI.QUOTA,
                     ServerMessages.SERVER_MESSAGES,
                     GATEWAY,
+                    Mirror.MIRROR,
                     MIGRATE,
                     IDENTITY,
                     INSTALL_AND_RUN_IPFS,

--- a/src/peergos/server/util/JavaPoster.java
+++ b/src/peergos/server/util/JavaPoster.java
@@ -35,22 +35,23 @@ public class JavaPoster implements HttpPoster {
     }
 
     @Override
-    public CompletableFuture<byte[]> postUnzip(String url, byte[] payload) {
+    public CompletableFuture<byte[]> postUnzip(String url, byte[] payload, int timeoutMillis) {
         return post(url, payload, true);
     }
 
     @Override
-    public CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip) {
-        return post(url, payload, unzip, Collections.emptyMap());
+    public CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip, int timeoutMillis) {
+        return post(url, payload, unzip, Collections.emptyMap(), timeoutMillis);
     }
 
-    private CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip, Map<String, String> headers) {
+    private CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip, Map<String, String> headers, int timeoutMillis) {
         HttpURLConnection conn = null;
         CompletableFuture<byte[]> res = new CompletableFuture<>();
         try
         {
             conn = (HttpURLConnection) buildURL(url).openConnection();
-            conn.setReadTimeout(15000);
+            if (timeoutMillis >= 0)
+                conn.setReadTimeout(timeoutMillis);
             conn.setDoInput(true);
             conn.setDoOutput(true);
             for (Map.Entry<String, String> e : headers.entrySet()) {

--- a/src/peergos/shared/corenode/HTTPCoreNode.java
+++ b/src/peergos/shared/corenode/HTTPCoreNode.java
@@ -213,7 +213,7 @@ public class HTTPCoreNode implements CoreNode {
                 Serialize.serialize(mirrorBat.get().serialize(), dout);
             dout.flush();
 
-            return poster.postUnzip(modifiedPrefix + Constants.CORE_URL + "migrateUser", bout.toByteArray())
+            return poster.postUnzip(modifiedPrefix + Constants.CORE_URL + "migrateUser", bout.toByteArray(), -1)
                     .thenApply(res -> UserSnapshot.fromCbor(CborObject.fromByteArray(res)));
         } catch (IOException ioe) {
             LOG.log(Level.WARNING, ioe.getMessage(), ioe);

--- a/src/peergos/shared/user/HttpPoster.java
+++ b/src/peergos/shared/user/HttpPoster.java
@@ -5,9 +5,17 @@ import java.util.concurrent.*;
 
 public interface HttpPoster {
 
-    CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip);
+    CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip, int timeoutMillis);
 
-    CompletableFuture<byte[]> postUnzip(String url, byte[] payload);
+    default CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip) {
+        return post(url, payload, unzip, 15_000);
+    }
+
+    CompletableFuture<byte[]> postUnzip(String url, byte[] payload, int timeoutMillis);
+
+    default CompletableFuture<byte[]> postUnzip(String url, byte[] payload) {
+        return postUnzip(url, payload, 15_000);
+    }
 
     CompletableFuture<byte[]> postMultipart(String url, List<byte[]> files);
 

--- a/src/peergos/shared/user/JavaScriptPoster.java
+++ b/src/peergos/shared/user/JavaScriptPoster.java
@@ -22,13 +22,13 @@ public class JavaScriptPoster implements HttpPoster {
     }
 
     @Override
-    public CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip) {
-        return http.post(canonicalise(url), payload);
+    public CompletableFuture<byte[]> post(String url, byte[] payload, boolean unzip, int timeoutMillis) {
+        return http.post(canonicalise(url), payload, timeoutMillis);
     }
 
     @Override
-    public CompletableFuture<byte[]> postUnzip(String url, byte[] payload) {
-        return post(canonicalise(url), payload, true);
+    public CompletableFuture<byte[]> postUnzip(String url, byte[] payload, int timeoutMillis) {
+        return post(canonicalise(url), payload, true, timeoutMillis);
     }
 
     @Override

--- a/src/peergos/shared/user/NativeJSHttp.java
+++ b/src/peergos/shared/user/NativeJSHttp.java
@@ -12,7 +12,7 @@ public class NativeJSHttp {
 //        return new CompletableFuture<>();
 //    }
 
-    public native CompletableFuture<byte[]> post(String url, byte[] payload) ;/*-{
+    public native CompletableFuture<byte[]> post(String url, byte[] payload, int timeoutMillis) ;/*-{
         console.log("postProm");
         var future = this.incomplete();
         new Promise(function(resolve, reject) {


### PR DESCRIPTION
Allow HttpPoster timeout to be configured for each call.

Use this to disable timeout for migrate calls which can take arbitrarily long.