### PR TITLE
Resumable uploads

### DIFF
--- a/src/peergos/server/apps/email/EmailBridgeClient.java
+++ b/src/peergos/server/apps/email/EmailBridgeClient.java
@@ -114,7 +114,7 @@ public class EmailBridgeClient {
             byte[] rawCipherText = encryptEmail(m).serialize();
             return inbox.getUpdated(s, context.network).join()
                     .uploadFileSection(s, c, m.id + ".cbor", AsyncReader.build(rawCipherText), false, 0,
-                            rawCipherText.length, Optional.empty(), true, true,
+                            rawCipherText.length, Optional.empty(), false, true, true,
                             context.network, context.crypto, x -> {}, context.crypto.random.randomBytes(32),
                             Optional.empty(), Optional.of(Bat.random(context.crypto.random)), inbox.mirrorBatId());
         }).join();

--- a/src/peergos/server/cli/Command.java
+++ b/src/peergos/server/cli/Command.java
@@ -8,7 +8,7 @@ public enum Command {
     help("Show this help."),
     exit("Disconnect."),
     get("Download a file.", "get remote-path <local path>", Argument.REMOTE_FILE, Argument.LOCAL_FILE),
-    put("Upload a file.", "put local-path <remote-path>", Argument.LOCAL_FILE, Argument.REMOTE_FILE),
+    put("Upload a file or folder.", "put local-path <remote-path> <skip-existing=true/false>", Argument.LOCAL_FILE, Argument.REMOTE_FILE, Argument.SKIP_EXISTING),
     ls("List contents of a remote directory.", "ls <path>", Argument.REMOTE_FILE),
     rm("Remove a remote-file.", "rm remote-path", Argument.REMOTE_FILE),
     space("Show used remote space."),
@@ -24,24 +24,31 @@ public enum Command {
     bye("Disconnect.");
 
     public final String description, example;
-    public final Argument firstArg, secondArg;
+    public final Argument firstArg, secondArg, thirdArg;
 
-    Command(String description, String example, Argument firstArg, Argument secondArg) {
+    Command(String description, String example, Argument firstArg, Argument secondArg, Argument thirdArg) {
         if (firstArg == null && secondArg != null)
+            throw new IllegalArgumentException();
+        if (secondArg == null && thirdArg != null)
             throw new IllegalArgumentException();
 
         this.description = description;
         this.example = example;
         this.firstArg = firstArg;
         this.secondArg = secondArg;
+        this.thirdArg = thirdArg;
+    }
+
+    Command(String description, String example, Argument firstArg, Argument secondArg) {
+        this(description, example, firstArg, secondArg, null);
     }
 
     Command(String description, String example, Argument firstArg) {
-        this(description, example, firstArg,null);
+        this(description, example, firstArg,null, null);
     }
 
     Command(String description, String example) {
-        this(description, example, null,null);
+        this(description, example, null,null, null);
     }
 
     Command(String description) {
@@ -69,17 +76,18 @@ public enum Command {
         }
     }
 
-    public static enum Argument {
+    public enum Argument {
         REMOTE_FILE,
         REMOTE_DIR,
         LOCAL_FILE,
+        SKIP_EXISTING,
         USERNAME,
         FOLLOWER,
         PENDING_FOLLOW_REQUEST,
         PROCESS_FOLLOW_REQUEST;
     }
 
-    public static enum ProcessFollowRequestAction  {
+    public enum ProcessFollowRequestAction  {
         accept,
         accept_and_reciprocate("accept-and-reciprocate"),
         reject;
@@ -110,6 +118,4 @@ public enum Command {
             return alternative == null ? name() : alternative;
         }
     }
-
-
 }

--- a/src/peergos/server/cli/ParsedCommand.java
+++ b/src/peergos/server/cli/ParsedCommand.java
@@ -22,6 +22,10 @@ class ParsedCommand {
         return arguments.size() > 1;
     }
 
+    public boolean hasThirdArgument() {
+        return arguments.size() > 2;
+    }
+
     public String firstArgument() {
         if (arguments.size() < 1)
             throw new IllegalStateException("Specifed command " + line + " requires an argument");
@@ -32,6 +36,12 @@ class ParsedCommand {
         if (arguments.size() < 2)
             throw new IllegalStateException("Specifed command " + line + " requires a second argument");
         return arguments.get(1);
+    }
+
+    public String thirdArgument() {
+        if (arguments.size() < 3)
+            throw new IllegalStateException("Specifed command " + line + " requires a third argument");
+        return arguments.get(2);
     }
 
     @Override

--- a/src/peergos/server/simulation/FileSystem.java
+++ b/src/peergos/server/simulation/FileSystem.java
@@ -2,13 +2,14 @@ package peergos.server.simulation;
 
 
 import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.transaction.*;
 import peergos.shared.util.*;
 
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Random;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public interface FileSystem {
@@ -34,7 +35,7 @@ public interface FileSystem {
 
     void write(Path path, byte[] data, Consumer<Long> progressConsumer);
 
-    void writeSubtree(Path path, Stream<FileWrapper.FolderUploadProperties> folders);
+    void writeSubtree(Path path, Stream<FileWrapper.FolderUploadProperties> folders, Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile);
 
     void modify(Path path, byte[] data, Consumer<Long> progressConsumer);
 

--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -56,7 +56,7 @@ public class PeergosFileSystemImpl implements FileSystem {
         String fileName = path.getFileName().toString();
         ProgressConsumer<Long> pc  = l -> progressConsumer.accept(l);
         FileWrapper fileWrapper = directory.uploadFileJS(fileName, resetableFileInputStream, (int)(data.length >> 32), (int) data.length,
-                true, true, userContext.mirrorBatId(), userContext.network, userContext.crypto, pc, userContext.getTransactionService(), f -> Futures.of(false)).join();
+                true, userContext.mirrorBatId(), userContext.network, userContext.crypto, pc, userContext.getTransactionService(), f -> Futures.of(false)).join();
     }
 
     @Override

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -863,7 +863,7 @@ public class PeergosNetworkUtils {
         FileWrapper sharedDir = shareeUploader.getByPath(path).join().get();
         String shareeFilename = "a-new-file.png";
         sharedDir.uploadFileJS(shareeFilename, AsyncReader.build(data), 0, data.length,
-                false, false, shareeUploader.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
+                false, shareeUploader.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
         FileWrapper newFile = shareeUploader.getByPath(path + "/" + shareeFilename).join().get();
         Assert.assertTrue(newFile.mirrorBatId().equals(sharer.mirrorBatId()));
 
@@ -991,7 +991,7 @@ public class PeergosNetworkUtils {
         UserContext shareeUploader = shareeUsers.get(0);
         FileWrapper sharedDir = shareeUploader.getByPath(subdirPath).join().get();
         sharedDir.uploadFileJS("a-new-file.png", AsyncReader.build(data), 0, data.length,
-                false, false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
+                false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
 
         Set<String> childNames = sharer.getByPath(dirPath).join().get().getChildren(crypto.hasher, sharer.network).join()
                 .stream()
@@ -1317,7 +1317,7 @@ public class PeergosNetworkUtils {
         UserContext shareeUploader = shareeUsers.get(0);
         FileWrapper sharedDir = shareeUploader.getByPath(subdirPath).join().get();
         sharedDir.uploadFileJS("a-new-file.png", AsyncReader.build(data), 0, data.length,
-                false, false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
+                false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
 
         // check 'a' can see the shared directory
         FileWrapper sharedFolder = a.getByPath(sharer.username + "/" + folderName).join()

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -863,7 +863,7 @@ public class PeergosNetworkUtils {
         FileWrapper sharedDir = shareeUploader.getByPath(path).join().get();
         String shareeFilename = "a-new-file.png";
         sharedDir.uploadFileJS(shareeFilename, AsyncReader.build(data), 0, data.length,
-                false, false, shareeUploader.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService()).join();
+                false, false, shareeUploader.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
         FileWrapper newFile = shareeUploader.getByPath(path + "/" + shareeFilename).join().get();
         Assert.assertTrue(newFile.mirrorBatId().equals(sharer.mirrorBatId()));
 
@@ -991,7 +991,7 @@ public class PeergosNetworkUtils {
         UserContext shareeUploader = shareeUsers.get(0);
         FileWrapper sharedDir = shareeUploader.getByPath(subdirPath).join().get();
         sharedDir.uploadFileJS("a-new-file.png", AsyncReader.build(data), 0, data.length,
-                false, false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService()).join();
+                false, false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
 
         Set<String> childNames = sharer.getByPath(dirPath).join().get().getChildren(crypto.hasher, sharer.network).join()
                 .stream()
@@ -1317,7 +1317,7 @@ public class PeergosNetworkUtils {
         UserContext shareeUploader = shareeUsers.get(0);
         FileWrapper sharedDir = shareeUploader.getByPath(subdirPath).join().get();
         sharedDir.uploadFileJS("a-new-file.png", AsyncReader.build(data), 0, data.length,
-                false, false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService()).join();
+                false, false, sharedDir.mirrorBatId(), shareeUploader.network, crypto, x -> {}, shareeUploader.getTransactionService(), f -> Futures.of(false)).join();
 
         // check 'a' can see the shared directory
         FileWrapper sharedFolder = a.getByPath(sharer.username + "/" + folderName).join()

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -113,7 +113,7 @@ public class RamUserTests extends UserTests {
             userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
         } catch (Exception e) {}
         try {
-            context.getUserRoot().join().uploadFileJS("anotherfile", thrower, 0, size, false, false,
+            context.getUserRoot().join().uploadFileJS("anotherfile", thrower, 0, size, false,
                     context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(false)).join();
         } catch (Exception e) {}
         long usageAfterFail = context.getSpaceUsage().join();

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -108,13 +108,13 @@ public class RamUserTests extends UserTests {
         FileWrapper txnDir = context.getByPath(Paths.get(username, UserContext.TRANSACTIONS_DIR_NAME)).join().get();
         TransactionService txns = new NonClosingTransactionService(network, crypto, txnDir);
         try {
-            FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties("somefile", thrower, 0, size, false, x -> {});
+            FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties("somefile", thrower, 0, size, false, false, x -> {});
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(username), Arrays.asList(fileUpload));
-            userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, () -> true).join();
+            userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
         } catch (Exception e) {}
         try {
             context.getUserRoot().join().uploadFileJS("anotherfile", thrower, 0, size, false, false,
-                    context.mirrorBatId(), network, crypto, x -> {}, txns).join();
+                    context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(false)).join();
         } catch (Exception e) {}
         long usageAfterFail = context.getSpaceUsage().join();
         if (usageAfterFail <= size / 2) { // give server a chance to recalculate usage

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -4,6 +4,7 @@ import org.junit.*;
 import org.junit.runner.*;
 import org.junit.runners.*;
 import peergos.server.*;
+import peergos.server.tests.util.*;
 import peergos.server.util.*;
 import peergos.shared.*;
 import peergos.shared.social.*;
@@ -92,20 +93,6 @@ public class RamUserTests extends UserTests {
         Assert.assertTrue(Arrays.equals(retrieved, data));
 
         publicGateway.shutdown();
-    }
-
-    private static class NonClosingTransactionService extends TransactionServiceImpl {
-
-        public NonClosingTransactionService(NetworkAccess network,
-                                            Crypto crypto,
-                                            FileWrapper transactionsDir) {
-            super(network, crypto, transactionsDir);
-        }
-
-        @Override
-        public CompletableFuture<Snapshot> close(Snapshot version, Committer committer, Transaction transaction) {
-            return Futures.of(version);
-        }
     }
 
     @Test

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -582,6 +582,7 @@ public abstract class UserTests {
         }
     }
 
+    @Ignore
     @Test
     public void resumeFailedUploads() {
         String username = generateUsername();

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -563,12 +563,12 @@ public abstract class UserTests {
                         e.getValue()
                                 .stream()
                                 .map(f -> new FileWrapper.FileUploadProperties(f.getKey().get(f.getKey().size() - 1),
-                                        AsyncReader.build(f.getValue()), 0, f.getValue().length, false, x -> {}))
+                                        AsyncReader.build(f.getValue()), 0, f.getValue().length, false, false, x -> {}))
                                 .collect(Collectors.toList())));
 
         int priorChildren = userRoot.getChildren(crypto.hasher, network).join().size();
 
-        userRoot.uploadSubtree(byFolder, Optional.empty(), network, crypto, context.getTransactionService(), () -> true).join();
+        userRoot.uploadSubtree(byFolder, Optional.empty(), network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
 
         userRoot = context.getUserRoot().join();
         int postChildren = userRoot.getChildren(crypto.hasher, network).join().size();
@@ -597,9 +597,9 @@ public abstract class UserTests {
         TransactionService txns = new NonClosingTransactionService(network, crypto, txnDir);
         String subdir = "dir";
         try {
-            FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties(filename, thrower, 0, size, false, x -> {});
+            FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties(filename, thrower, 0, size, false, false, x -> {});
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(subdir), Arrays.asList(fileUpload));
-            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, () -> true).join();
+            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
         } catch (Exception e) {}
         FileWrapper home = context.getUserRoot().join();
         Set<Transaction> open = context.getTransactionService().getOpenTransactions(home.version).join();
@@ -607,7 +607,7 @@ public abstract class UserTests {
         // Now try again, with confirmation from the user to resume upload
         context.getByPath(Paths.get(username, subdir)).join().get()
                 .uploadFileJS(filename, AsyncReader.build(data), 0, size, false, false,
-                        context.mirrorBatId(), network, crypto, x -> {}, txns).join();
+                        context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(true)).join();
         checkFileContents(data, context.getByPath(Paths.get(username, subdir, filename)).join().get(), context);
     }
 
@@ -622,13 +622,13 @@ public abstract class UserTests {
         String filename = "file1.bin";
         byte[] data = randomData(6*1024*1024);
         userRoot.uploadFileJS(filename, new AsyncReader.ArrayBacked(data), 0,data.length, false, false,
-                userRoot.mirrorBatId(), network, crypto, l -> {}, context.getTransactionService()).join();
+                userRoot.mirrorBatId(), network, crypto, l -> {}, context.getTransactionService(), f -> Futures.of(false)).join();
         checkFileContents(data, context.getUserRoot().join().getDescendentByPath(filename, crypto.hasher, context.network).join().get(), context);
 
         String file2name = "file2.bin";
         byte[] data2 = randomData(6*1024*1024);
         userRootCopy.uploadFileJS(file2name, new AsyncReader.ArrayBacked(data2), 0,data2.length, false, false,
-                userRootCopy.mirrorBatId(), network, crypto, l -> {}, context.getTransactionService()).join();
+                userRootCopy.mirrorBatId(), network, crypto, l -> {}, context.getTransactionService(), f -> Futures.of(false)).join();
         checkFileContents(data2, context.getUserRoot().join().getDescendentByPath(file2name, crypto.hasher, context.network).join().get(), context);
     }
 
@@ -922,11 +922,11 @@ public abstract class UserTests {
         TransactionService transactions = context.getTransactionService();
         try {
             userRoot.uploadFileJS(filename, throwingReader, 0, data.length, false, false,
-                    userRoot.mirrorBatId(), context.network, context.crypto, l -> {}, transactions).join();
+                    userRoot.mirrorBatId(), context.network, context.crypto, l -> {}, transactions, f -> Futures.of(false)).join();
         } catch (Exception e) {}
 
         userRoot.uploadFileJS(filename, AsyncReader.build(data), 0, data.length, false, false,
-                userRoot.mirrorBatId(), context.network, context.crypto, l -> {}, transactions).join();
+                userRoot.mirrorBatId(), context.network, context.crypto, l -> {}, transactions, f -> Futures.of(true)).join();
     }
 
     @Test
@@ -1369,7 +1369,7 @@ public abstract class UserTests {
 
         byte[] newData = "Some dataaa".getBytes();
         dirThroughLink.get().uploadFileJS("anoterfile", AsyncReader.build(newData), 0, newData.length,
-                false, false, dirThroughLink.get().mirrorBatId(), linkContext.network, linkContext.crypto, x -> {}, null).join();
+                false, false, dirThroughLink.get().mirrorBatId(), linkContext.network, linkContext.crypto, x -> {}, null, f -> Futures.of(false)).join();
     }
 
     @Test

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -582,7 +582,6 @@ public abstract class UserTests {
         }
     }
 
-    @Ignore
     @Test
     public void resumeFailedUploads() {
         String username = generateUsername();
@@ -606,8 +605,8 @@ public abstract class UserTests {
         Set<Transaction> open = context.getTransactionService().getOpenTransactions(home.version).join();
         Assert.assertTrue(open.size() > 0);
         // Now try again, with confirmation from the user to resume upload
-        context.getByPath(Paths.get(username, subdir)).join().get()
-                .uploadFileJS(filename, AsyncReader.build(data), 0, size, false, context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(true)).join();
+        FileWrapper parent = context.getByPath(Paths.get(username, subdir)).join().get();
+        parent.uploadFileJS(filename, AsyncReader.build(data), 0, size, false, context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(true)).join();
         checkFileContents(data, context.getByPath(Paths.get(username, subdir, filename)).join().get(), context);
     }
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -582,7 +582,6 @@ public abstract class UserTests {
         }
     }
 
-    @Ignore
     @Test
     public void resumeFailedUploads() {
         String username = generateUsername();

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -607,8 +607,7 @@ public abstract class UserTests {
         Assert.assertTrue(open.size() > 0);
         // Now try again, with confirmation from the user to resume upload
         context.getByPath(Paths.get(username, subdir)).join().get()
-                .uploadFileJS(filename, AsyncReader.build(data), 0, size, false, false,
-                        context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(true)).join();
+                .uploadFileJS(filename, AsyncReader.build(data), 0, size, false, context.mirrorBatId(), network, crypto, x -> {}, txns, f -> Futures.of(true)).join();
         checkFileContents(data, context.getByPath(Paths.get(username, subdir, filename)).join().get(), context);
     }
 
@@ -622,13 +621,13 @@ public abstract class UserTests {
 
         String filename = "file1.bin";
         byte[] data = randomData(6*1024*1024);
-        userRoot.uploadFileJS(filename, new AsyncReader.ArrayBacked(data), 0,data.length, false, false,
+        userRoot.uploadFileJS(filename, new AsyncReader.ArrayBacked(data), 0,data.length, false,
                 userRoot.mirrorBatId(), network, crypto, l -> {}, context.getTransactionService(), f -> Futures.of(false)).join();
         checkFileContents(data, context.getUserRoot().join().getDescendentByPath(filename, crypto.hasher, context.network).join().get(), context);
 
         String file2name = "file2.bin";
         byte[] data2 = randomData(6*1024*1024);
-        userRootCopy.uploadFileJS(file2name, new AsyncReader.ArrayBacked(data2), 0,data2.length, false, false,
+        userRootCopy.uploadFileJS(file2name, new AsyncReader.ArrayBacked(data2), 0,data2.length, false,
                 userRootCopy.mirrorBatId(), network, crypto, l -> {}, context.getTransactionService(), f -> Futures.of(false)).join();
         checkFileContents(data2, context.getUserRoot().join().getDescendentByPath(file2name, crypto.hasher, context.network).join().get(), context);
     }
@@ -922,11 +921,11 @@ public abstract class UserTests {
 
         TransactionService transactions = context.getTransactionService();
         try {
-            userRoot.uploadFileJS(filename, throwingReader, 0, data.length, false, false,
+            userRoot.uploadFileJS(filename, throwingReader, 0, data.length, false,
                     userRoot.mirrorBatId(), context.network, context.crypto, l -> {}, transactions, f -> Futures.of(false)).join();
         } catch (Exception e) {}
 
-        userRoot.uploadFileJS(filename, AsyncReader.build(data), 0, data.length, false, false,
+        userRoot.uploadFileJS(filename, AsyncReader.build(data), 0, data.length, false,
                 userRoot.mirrorBatId(), context.network, context.crypto, l -> {}, transactions, f -> Futures.of(true)).join();
     }
 
@@ -1370,7 +1369,7 @@ public abstract class UserTests {
 
         byte[] newData = "Some dataaa".getBytes();
         dirThroughLink.get().uploadFileJS("anoterfile", AsyncReader.build(newData), 0, newData.length,
-                false, false, dirThroughLink.get().mirrorBatId(), linkContext.network, linkContext.crypto, x -> {}, null, f -> Futures.of(false)).join();
+                false, dirThroughLink.get().mirrorBatId(), linkContext.network, linkContext.crypto, x -> {}, null, f -> Futures.of(false)).join();
     }
 
     @Test

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -589,21 +589,26 @@ public abstract class UserTests {
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
 
         String filename = "somefile";
-        int size = 20*1024*1024;
+        int size = 30*1024*1024;
         byte[] data = new byte[size];
         random.nextBytes(data);
         AsyncReader thrower = new ThrowingStream(data, size/2);
         FileWrapper txnDir = context.getByPath(Paths.get(username, UserContext.TRANSACTIONS_DIR_NAME)).join().get();
         TransactionService txns = new NonClosingTransactionService(network, crypto, txnDir);
+        String subdir = "dir";
         try {
             FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties(filename, thrower, 0, size, false, x -> {});
-            FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(username), Arrays.asList(fileUpload));
+            FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(subdir), Arrays.asList(fileUpload));
             context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, () -> true).join();
         } catch (Exception e) {}
+        FileWrapper home = context.getUserRoot().join();
+        Set<Transaction> open = context.getTransactionService().getOpenTransactions(home.version).join();
+        Assert.assertTrue(open.size() > 0);
         // Now try again, with confirmation from the user to resume upload
-        context.getUserRoot().join().uploadFileJS(filename, AsyncReader.build(data), 0, size, false, false,
-                context.mirrorBatId(), network, crypto, x -> {}, txns).join();
-        checkFileContents(data, context.getByPath(Paths.get(username, filename)).join().get(), context);
+        context.getByPath(Paths.get(username, subdir)).join().get()
+                .uploadFileJS(filename, AsyncReader.build(data), 0, size, false, false,
+                        context.mirrorBatId(), network, crypto, x -> {}, txns).join();
+        checkFileContents(data, context.getByPath(Paths.get(username, subdir, filename)).join().get(), context);
     }
 
     @Test

--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -4,6 +4,7 @@ import peergos.server.simulation.AccessControl;
 import peergos.server.simulation.FileSystem;
 import peergos.server.simulation.Stat;
 import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.transaction.*;
 import peergos.shared.util.*;
 
 import java.io.File;
@@ -18,8 +19,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class NativeFileSystemImpl implements FileSystem {
@@ -91,7 +92,7 @@ public class NativeFileSystemImpl implements FileSystem {
     }
 
     @Override
-    public void writeSubtree(Path path, Stream<FileWrapper.FolderUploadProperties> folders) {
+    public void writeSubtree(Path path, Stream<FileWrapper.FolderUploadProperties> folders, Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile) {
         throw new IllegalStateException("Unimplemented!");
     }
 

--- a/src/peergos/server/tests/slow/DeleteBenchmark.java
+++ b/src/peergos/server/tests/slow/DeleteBenchmark.java
@@ -67,11 +67,11 @@ public class DeleteBenchmark {
         random.nextBytes(data);
 
         List<FileWrapper.FileUploadProperties> files = names.stream()
-                .map(n -> new FileWrapper.FileUploadProperties(n, AsyncReader.build(data), 0, data.length, false, x -> {}))
+                .map(n -> new FileWrapper.FileUploadProperties(n, AsyncReader.build(data), 0, data.length, false, false, x -> {}))
                 .collect(Collectors.toList());
         String dirName = "folder";
         userRoot.uploadSubtree(Stream.of(new FileWrapper.FolderUploadProperties(Arrays.asList(dirName), files)),
-                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), () -> true).join();
+                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
         Path dirPath = PathUtil.get(username, dirName);
         FileWrapper folder = context.getByPath(dirPath).join().get();
 

--- a/src/peergos/server/tests/slow/SmallFileBenchmark.java
+++ b/src/peergos/server/tests/slow/SmallFileBenchmark.java
@@ -72,10 +72,10 @@ public class SmallFileBenchmark {
             progressReceived.add(num);
         };
         List<FileWrapper.FileUploadProperties> files = names.stream()
-                .map(n -> new FileWrapper.FileUploadProperties(n, AsyncReader.build(data), 0, data.length, false, progressCounter))
+                .map(n -> new FileWrapper.FileUploadProperties(n, AsyncReader.build(data), 0, data.length, false, false, progressCounter))
                 .collect(Collectors.toList());
         userRoot.uploadSubtree(Stream.of(new FileWrapper.FolderUploadProperties(Collections.emptyList(), files)),
-                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), () -> true).join();
+                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
         long duration = System.currentTimeMillis() - start;
         System.err.printf("UPLOAD("+names.size()+") duration: %d mS, av: %d mS\n", duration, (duration) / names.size());
         Assert.assertTrue("Correct progress", progressReceived.stream().mapToLong(i -> i).sum() == data.length * names.size());

--- a/src/peergos/server/tests/util/NonClosingTransactionService.java
+++ b/src/peergos/server/tests/util/NonClosingTransactionService.java
@@ -1,0 +1,23 @@
+package peergos.server.tests.util;
+
+import peergos.shared.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.transaction.*;
+import peergos.shared.util.*;
+
+import java.util.concurrent.*;
+
+public class NonClosingTransactionService extends TransactionServiceImpl {
+
+    public NonClosingTransactionService(NetworkAccess network,
+                                        Crypto crypto,
+                                        FileWrapper transactionsDir) {
+        super(network, crypto, transactionsDir);
+    }
+
+    @Override
+    public CompletableFuture<Snapshot> close(Snapshot version, Committer committer, Transaction transaction) {
+        return Futures.of(version);
+    }
+}

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -31,6 +31,7 @@ public class BufferedNetworkAccess extends NetworkAccess {
     private final PublicKeyHash owner;
     private final Supplier<Boolean> commitWatcher;
     private final ContentAddressedStorage blocks;
+    private boolean safeToCommit = true;
 
     private BufferedNetworkAccess(BufferedStorage blockBuffer,
                                   BufferedPointers mutableBuffer,
@@ -98,8 +99,22 @@ public class BufferedNetworkAccess extends NetworkAccess {
         return blockBuffer.totalSize();
     }
 
+    public BufferedNetworkAccess disableCommits() {
+        safeToCommit = false;
+        return this;
+    }
+
+    public BufferedNetworkAccess enableCommits() {
+        safeToCommit = true;
+        return this;
+    }
+
+    public boolean isFull() {
+        return bufferedSize() >= bufferSize;
+    }
+
     private CompletableFuture<Boolean> maybeCommit() {
-        if (bufferedSize() >= bufferSize)
+        if (safeToCommit && isFull())
             return commit();
         return Futures.of(true);
     }

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -580,6 +580,15 @@ public class NetworkAccess {
                 .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
     }
 
+    public CompletableFuture<Boolean> chunkIsPresent(Snapshot current,
+                                                     PublicKeyHash owner,
+                                                     PublicKeyHash writer,
+                                                     byte[] mapKey) {
+        CommittedWriterData version = current.get(writer);
+        return tree.get(version.props, owner, writer, mapKey)
+                .thenApply(valueHash -> valueHash.isPresent());
+    }
+
     public static CompletableFuture<List<FragmentWithHash>> downloadFragments(List<Cid> hashes,
                                                                               List<BatWithId> bats,
                                                                               ContentAddressedStorage dhtClient,

--- a/src/peergos/shared/messaging/ChatController.java
+++ b/src/peergos/shared/messaging/ChatController.java
@@ -215,7 +215,7 @@ public class ChatController {
                         .thenApply(Optional::get))
                 .thenCompose(f -> f.getInputStream(f.version.get(f.writer()).props, context.network, context.crypto, x -> {})
                         .thenCompose(r -> dir.uploadFileSection(v, c, f.getName(), r, false, 0, f.getSize(),
-                                Optional.empty(), false, false, context.network, context.crypto, x -> {},
+                                Optional.empty(), false, false, false, context.network, context.crypto, x -> {},
                                 context.crypto.random.randomBytes(RelativeCapability.MAP_KEY_LENGTH), Optional.empty(),
                                 Optional.of(Bat.random(context.crypto.random)), dir.mirrorBatId())));
     }
@@ -297,7 +297,7 @@ public class ChatController {
         byte[] rawPrivateChatState = priv.get().serialize();
         return chatRoot.uploadFileSection(in, c, ChatController.PRIVATE_CHAT_STATE,
                 AsyncReader.build(rawPrivateChatState), false, 0, rawPrivateChatState.length,
-                Optional.empty(), true, true, network, crypto, x -> {},
+                Optional.empty(), false, true, true, network, crypto, x -> {},
                 crypto.random.randomBytes(32), Optional.empty(), Optional.of(Bat.random(crypto.random)), chatRoot.mirrorBatId());
     }
 

--- a/src/peergos/shared/social/SocialFeed.java
+++ b/src/peergos/shared/social/SocialFeed.java
@@ -325,7 +325,7 @@ public class SocialFeed {
                             updated.getChild(FEED_FILE, crypto.hasher, network).thenCompose(feedOpt -> {
                                 if (feedOpt.isEmpty())
                                     return updated.uploadFileSection(updated.version, c, FEED_FILE, AsyncReader.build(data),
-                                            false, 0, data.length, Optional.empty(), false,
+                                            false, 0, data.length, Optional.empty(), false, false,
                                             false, network, crypto, x -> {},
                                             crypto.random.randomBytes(RelativeCapability.MAP_KEY_LENGTH),
                                             Optional.empty(),  Optional.of(Bat.random(crypto.random)), updated.mirrorBatId());

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -199,7 +199,7 @@ public class SharedWithCache {
                             byte[] raw = empty.serialize();
                             // upload or replace file
                             return parent.uploadFileSection(parent.version, committer, DIR_CACHE_FILENAME, AsyncReader.build(raw), false, 0, raw.length,
-                                    Optional.empty(), true, true, network, crypto, x -> {},
+                                    Optional.empty(), false, true, true, network, crypto, x -> {},
                                     crypto.random.randomBytes(32), Optional.empty(), Optional.of(Bat.random(crypto.random)), parent.mirrorBatId())
                                     .thenCompose(s -> parent.getUpdated(s, network)
                                             .thenCompose(updatedParent -> updatedParent.getChild(DIR_CACHE_FILENAME, crypto.hasher, network)))

--- a/src/peergos/shared/user/fs/AsyncReader.java
+++ b/src/peergos/shared/user/fs/AsyncReader.java
@@ -156,7 +156,7 @@ public interface AsyncReader extends AutoCloseable {
         public CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
             if (high32 != 0)
                 throw new IllegalArgumentException("Cannot have arrays larger than 4GiB!");
-            index += low32;
+            index = low32;
             return CompletableFuture.completedFuture(this);
         }
 

--- a/src/peergos/shared/user/fs/CapabilityStore.java
+++ b/src/peergos/shared/user/fs/CapabilityStore.java
@@ -57,7 +57,7 @@ public class CapabilityStore {
                     AsyncReader.ArrayBacked newCapability = new AsyncReader.ArrayBacked(serializedCapability);
                     long startIndex = capStore.map(f -> f.getSize()).orElse(0L);
                     return sharedDir.uploadFileSection(sharedDir.version, c, capStoreFilename, newCapability, false,
-                            startIndex, startIndex + serializedCapability.length, Optional.empty(), true,
+                            startIndex, startIndex + serializedCapability.length, Optional.empty(), false, true,
                             false, network, crypto, x -> {}, crypto.random.randomBytes(32),
                             Optional.empty(), Optional.of(Bat.random(crypto.random)), sharedDir.mirrorBatId());
                 });

--- a/src/peergos/shared/user/fs/FileExistsException.java
+++ b/src/peergos/shared/user/fs/FileExistsException.java
@@ -1,0 +1,8 @@
+package peergos.shared.user.fs;
+
+public class FileExistsException extends RuntimeException {
+
+    public FileExistsException(String filename){
+        super("File already exists with name " + filename);
+    }
+}

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -558,7 +558,6 @@ public class FileWrapper {
                                                        int lengthHi,
                                                        int lengthLow,
                                                        boolean overwriteExisting,
-                                                       boolean truncateExisting,
                                                        Optional<BatId> mirrorBat,
                                                        NetworkAccess network,
                                                        Crypto crypto,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -796,7 +796,7 @@ public class FileWrapper {
                             network.enableCommits();
                             List<FileUploadTransaction> toClose = new ArrayList<>();
                             return Transaction.buildFileUploadTransaction(toParent.resolve(f.filename).toString(), f.length, crypto.random.randomBytes(32), f.fileData, parent.signingPair(),
-                                            new Location(parent.owner(), parent.writer(), crypto.random.randomBytes(32)))
+                                            new Location(parent.owner(), parent.writer(), crypto.random.randomBytes(32)), crypto.hasher)
                                     .thenCompose(txn -> transactions.open(p.left, c, txn)
                                             .thenCompose(r -> {
                                                 if (r.isB())

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -815,8 +815,8 @@ public class FileWrapper {
                                                 crypto.random.randomBytes(32)), Optional.of(Bat.random(crypto.random)), crypto.hasher);
                             }).thenCompose(txn -> transactions.open(p.left, c, txn)
                                             .thenCompose(r -> {
-                                                if (r.isB()) // we must clear legacy transactions which can't be resumed
-                                                    return (r.b().isLegacy() ? Futures.of(false) : resumeFile.apply(r.b()))
+                                                if (r.isB()) // we must clear legacy transactions which can't be resumed or ones whose parent has rotated writer
+                                                    return (r.b().isLegacy() || ! parent.writer().equals(r.b().writer()) ? Futures.of(false) : resumeFile.apply(r.b()))
                                                             .thenCompose(resume -> {
                                                                 if (resume) {
                                                                     toClose.add(r.b());

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -581,6 +581,7 @@ public class FileWrapper {
         // first find how many chunks were already uploaded, then seek reader to that offset and continue
         return findFirstAbsentChunkIndex(0, txn.streamSecret(), txn.getFirstLocation(), s, network, crypto)
                 .thenCompose(startChunkIndex -> {
+                    monitor.accept(startChunkIndex * Chunk.MAX_SIZE);
                     FileUploader uploader = new FileUploader(txn.targetFilename(), data, startChunkIndex*Chunk.MAX_SIZE,
                             txn.size(), txn.baseKey, txn.dataKey, getLocation(), getPointer().capability.bat, getParentKey(),
                             monitor, props, txn.getFirstLocation().getMapKey(), txn.firstBat);

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -847,7 +847,7 @@ public class FileWrapper {
                 .thenCompose(latest -> latest.addChildPointers(in, c, childLinks, network.disableCommits(), crypto))
                 .thenCompose(res -> Futures.reduceAll(toClose, res, (v, f) -> transactions.close(v, c, f), (a, b) -> b))
                 .thenCompose(s -> network.enableCommits().commit().thenApply(b -> s))
-                .thenApply(s -> new Pair<>(s, Collections.emptyList()));
+                .thenApply(s -> new Pair<>(s, Collections.<NamedRelativeCapability>emptyList()));
     }
 
     public Optional<BatId> mirrorBatId() {

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -845,6 +845,8 @@ public class CryptreeNode implements Cborable {
                                                             Optional<BatId> mirrorBat,
                                                             NetworkAccess network,
                                                             Crypto crypto) {
+        if (targetCAPs.isEmpty())
+            return Futures.of(current);
         // Make sure subsequent blobs use a different transaction to obscure linkage of different parts of this dir
         return getDirectChildren(us, current, network).thenCompose(children -> {
             if (children.size() + targetCAPs.size() > getMaxChildLinksPerBlob()) {

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -1,5 +1,6 @@
 package peergos.shared.user.fs.transaction;
 
+import jsinterop.annotations.JsMethod;
 import peergos.shared.NetworkAccess;
 import peergos.shared.cbor.CborObject;
 import peergos.shared.cbor.Cborable;
@@ -61,6 +62,11 @@ public class FileUploadTransaction implements Transaction {
                                         .thenApply(mapKey -> new Pair<>(s, firstChunk.withMapKey(mapKey.left)))),
                         (a, b) -> b)
                 .thenApply(p -> p.left);
+    }
+
+    @JsMethod
+    public String getPath() {
+        return path;
     }
 
     @Override

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -37,6 +37,10 @@ public class FileUploadTransaction implements Transaction {
         this.owner = firstChunk.owner;
     }
 
+    public long size() {
+        return size;
+    }
+
     public byte[] streamSecret() {
         return streamSecret;
     }

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -16,7 +16,7 @@ import java.util.stream.*;
 
 public class FileUploadTransaction implements Transaction {
     private final long startTimeEpochMillis;
-    private final String path;
+    private final String path, name;
     private final PublicKeyHash owner;
     private final SigningPrivateKeyAndPublicHash writer;
     private final Location firstChunk;
@@ -25,12 +25,14 @@ public class FileUploadTransaction implements Transaction {
 
     public FileUploadTransaction(long startTimeEpochMillis,
                                  String path,
+                                 String name,
                                  SigningPrivateKeyAndPublicHash writer,
                                  Location firstChunk,
                                  long size,
                                  byte[] streamSecret) {
         this.startTimeEpochMillis = startTimeEpochMillis;
         this.path = path;
+        this.name = name;
         this.writer = writer;
         this.firstChunk = firstChunk;
         this.size = size;
@@ -84,6 +86,7 @@ public class FileUploadTransaction implements Transaction {
         Map<String, Cborable> map = new HashMap<>();
         map.put("type", new CborObject.CborString(Type.FILE_UPLOAD.name()));
         map.put("path", new CborObject.CborString(path));
+        map.put("name", new CborObject.CborString(name));
         map.put("startTimeEpochMs", new CborObject.CborLong(startTimeEpochMillis()));
         map.put("owner", owner);
         map.put("writer", writer);
@@ -109,6 +112,7 @@ public class FileUploadTransaction implements Transaction {
         return new FileUploadTransaction(
                 map.getLong("startTimeEpochMs"),
                 map.getString("path"),
+                map.getString("name"),
                 writer,
                 new Location(owner, writer.publicKeyHash, map.getByteArray("mapKey")),
                 map.getLong("size"),

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -10,6 +10,7 @@ import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.*;
@@ -74,6 +75,12 @@ public class FileUploadTransaction implements Transaction {
     @Override
     public String name() {
         return "" + path.hashCode();
+    }
+
+    @JsMethod
+    public String targetFilename() {
+        Path path = PathUtil.get(this.path);
+        return path.getFileName().toString();
     }
 
     @Override

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -93,7 +93,6 @@ public class FileUploadTransaction implements Transaction {
         Map<String, Cborable> map = new HashMap<>();
         map.put("type", new CborObject.CborString(Type.FILE_UPLOAD.name()));
         map.put("path", new CborObject.CborString(path));
-        map.put("name", new CborObject.CborString(name));
         map.put("startTimeEpochMs", new CborObject.CborLong(startTimeEpochMillis()));
         map.put("owner", owner);
         map.put("writer", writer);
@@ -104,7 +103,7 @@ public class FileUploadTransaction implements Transaction {
         return CborObject.CborMap.build(map);
     }
 
-    static Transaction fromCbor(CborObject.CborMap map) {
+    static Transaction fromCbor(CborObject.CborMap map, String filename) {
         Type type = Type.valueOf(map.getString("type"));
         boolean isFileUpload = type.equals(Type.FILE_UPLOAD);
         if (!isFileUpload)
@@ -119,7 +118,7 @@ public class FileUploadTransaction implements Transaction {
         return new FileUploadTransaction(
                 map.getLong("startTimeEpochMs"),
                 map.getString("path"),
-                map.getString("name"),
+                filename,
                 writer,
                 new Location(owner, writer.publicKeyHash, map.getByteArray("mapKey")),
                 map.getLong("size"),

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -117,7 +117,7 @@ public class FileUploadTransaction implements Transaction {
     }
 
     public LocalDateTime startTime() {
-        return LocalDateTime.ofEpochSecond(startTimeEpochMillis / 1000, (int)(startTimeEpochMillis % 1000)* 1_0000_000, ZoneOffset.UTC);
+        return LocalDateTime.ofEpochSecond(startTimeEpochMillis / 1000, (int)(startTimeEpochMillis % 1000)* 1_000_000, ZoneOffset.UTC);
     }
 
     public WritableAbsoluteCapability writeCap() {

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -73,6 +73,10 @@ public class FileUploadTransaction implements Transaction {
         return firstChunk;
     }
 
+    public PublicKeyHash writer() {
+        return writer.publicKeyHash;
+    }
+
     public byte[] firstMapKey() {
         return firstChunk.getMapKey();
     }

--- a/src/peergos/shared/user/fs/transaction/Transaction.java
+++ b/src/peergos/shared/user/fs/transaction/Transaction.java
@@ -20,13 +20,13 @@ public interface Transaction extends Cborable {
      */
     CompletableFuture<Snapshot> clear(Snapshot version, Committer committer, NetworkAccess network, Hasher h);
 
-    static Transaction deserialize(byte[] data) {
+    static Transaction deserialize(byte[] data, String filename) {
         CborObject cborObject = CborObject.fromByteArray(data);
         CborObject.CborMap map =  (CborObject.CborMap) cborObject;
         Type type = Type.valueOf(map.getString("type"));
         switch (type)  {
             case FILE_UPLOAD:
-                return FileUploadTransaction.fromCbor(map);
+                return FileUploadTransaction.fromCbor(map, filename);
             default:
                 throw new IllegalStateException("Unimplemented type "+ type);
         }

--- a/src/peergos/shared/user/fs/transaction/Transaction.java
+++ b/src/peergos/shared/user/fs/transaction/Transaction.java
@@ -4,9 +4,12 @@ import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.symmetric.*;
+import peergos.shared.storage.auth.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public interface Transaction extends Cborable {
@@ -38,12 +41,16 @@ public interface Transaction extends Cborable {
 
     static CompletableFuture<FileUploadTransaction> buildFileUploadTransaction(String path,
                                                                                long fileSize,
+                                                                               FileProperties props,
                                                                                byte[] streamSecret,
-                                                                               AsyncReader fileData,
+                                                                               SymmetricKey baseKey,
+                                                                               SymmetricKey dataKey,
                                                                                SigningPrivateKeyAndPublicHash writer,
                                                                                Location firstChunkLocation,
+                                                                               Optional<Bat> firstBat,
                                                                                Hasher h) {
         return h.hash(path.getBytes(), true)
-                .thenApply(cid -> new FileUploadTransaction(System.currentTimeMillis(), path, cid.toString(), writer, firstChunkLocation, fileSize, streamSecret));
+                .thenApply(cid -> new FileUploadTransaction(System.currentTimeMillis(), path, cid.toString(), props, writer,
+                        firstChunkLocation, firstBat, fileSize, baseKey, dataKey, streamSecret));
     }
 }

--- a/src/peergos/shared/user/fs/transaction/Transaction.java
+++ b/src/peergos/shared/user/fs/transaction/Transaction.java
@@ -45,12 +45,13 @@ public interface Transaction extends Cborable {
                                                                                byte[] streamSecret,
                                                                                SymmetricKey baseKey,
                                                                                SymmetricKey dataKey,
+                                                                               SymmetricKey writeKey,
                                                                                SigningPrivateKeyAndPublicHash writer,
                                                                                Location firstChunkLocation,
                                                                                Optional<Bat> firstBat,
                                                                                Hasher h) {
         return h.hash(path.getBytes(), true)
                 .thenApply(cid -> new FileUploadTransaction(System.currentTimeMillis(), path, cid.toString(), props, writer,
-                        firstChunkLocation, firstBat, fileSize, baseKey, dataKey, streamSecret));
+                        firstChunkLocation, firstBat, fileSize, baseKey, dataKey, writeKey, streamSecret));
     }
 }

--- a/src/peergos/shared/user/fs/transaction/Transaction.java
+++ b/src/peergos/shared/user/fs/transaction/Transaction.java
@@ -41,7 +41,9 @@ public interface Transaction extends Cborable {
                                                                                byte[] streamSecret,
                                                                                AsyncReader fileData,
                                                                                SigningPrivateKeyAndPublicHash writer,
-                                                                               Location firstChunkLocation) {
-        return CompletableFuture.completedFuture(new FileUploadTransaction(System.currentTimeMillis(), path, writer, firstChunkLocation, fileSize, streamSecret));
+                                                                               Location firstChunkLocation,
+                                                                               Hasher h) {
+        return h.hash(path.getBytes(), true)
+                .thenApply(cid -> new FileUploadTransaction(System.currentTimeMillis(), path, cid.toString(), writer, firstChunkLocation, fileSize, streamSecret));
     }
 }

--- a/src/peergos/shared/user/fs/transaction/TransactionService.java
+++ b/src/peergos/shared/user/fs/transaction/TransactionService.java
@@ -4,7 +4,7 @@ import jsinterop.annotations.JsMethod;
 import peergos.shared.*;
 import peergos.shared.crypto.*;
 import peergos.shared.user.*;
-import peergos.shared.util.Futures;
+import peergos.shared.util.*;
 
 import java.util.List;
 import java.util.Set;
@@ -17,7 +17,12 @@ public interface TransactionService {
     SigningPrivateKeyAndPublicHash getSigner();
 
     @JsMethod
-    CompletableFuture<Snapshot> open(Snapshot version, Committer committer, Transaction transaction);
+    /**
+     *  Open a transaction or return an existing matching transaction
+     */
+    CompletableFuture<Either<Snapshot, FileUploadTransaction>> open(Snapshot version,
+                                                                    Committer committer,
+                                                                    Transaction transaction);
 
     @JsMethod
     CompletableFuture<Snapshot> close(Snapshot version, Committer committer, Transaction transaction);

--- a/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
+++ b/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
@@ -54,7 +54,7 @@ public class TransactionServiceImpl implements TransactionService {
                                 crypto, VOID_PROGRESS, crypto.random.randomBytes(32), Optional.empty(), Optional.of(Bat.random(crypto.random)), dir.mirrorBatId())
                                 .thenApply(Either::a),
                         t -> {
-                            if (!(t instanceof FileExistsException))
+                            if (!(Exceptions.getRootCause(t) instanceof FileExistsException))
                                 throw new RuntimeException(t);
                             return dir.getChild(transaction.name(), crypto.hasher, networkAccess)
                                     .thenCompose(fopt -> read(version, fopt.get()))
@@ -63,7 +63,7 @@ public class TransactionServiceImpl implements TransactionService {
                                         if (txn instanceof FileUploadTransaction) {
                                             return Either.b((FileUploadTransaction) txn);
                                         }
-                                        throw new RuntimeException(t);
+                                        throw new RuntimeException(Exceptions.getRootCause(t));
                                     });
                         }));
     }

--- a/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
+++ b/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
@@ -93,7 +93,7 @@ public class TransactionServiceImpl implements TransactionService {
         CommittedWriterData cwd = version.get(txnFile.writer());
         return txnFile.getInputStream(cwd.props, networkAccess, crypto, VOID_PROGRESS)
                 .thenApply(reader -> Serialize.readFullArray(reader, data))
-                .thenApply(done -> Optional.of(Transaction.deserialize(data)))
+                .thenApply(done -> Optional.of(Transaction.deserialize(data, txnFile.getName())))
                 .exceptionally(t -> Optional.empty());
     }
 

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -9,6 +9,7 @@ import java.util.stream.*;
 
 public class Futures {
 
+    @JsMethod
     public static final <T> CompletableFuture<T> of(T val) {
         return CompletableFuture.completedFuture(val);
     }


### PR DESCRIPTION
This expands the information stored in a FileUploadTransaction to enable continuing the upload from where it failed. Also allow skipping file uploads if the file already exists in bulk uploads. 

This also updates parent directories after each multi-chunk file, or after the buffered network is full. 

CLI put command has an extra option which is to skip existing. 