### PR TITLE
Make file deletion 9x faster

### DIFF
--- a/src/peergos/server/tests/slow/DeleteBenchmark.java
+++ b/src/peergos/server/tests/slow/DeleteBenchmark.java
@@ -81,8 +81,9 @@ public class DeleteBenchmark {
         System.err.printf("DELETE("+names.size()+") duration: %d mS\n", duration);
     }
 
-    // DELETE_FILE(200) duration: 7445 mS
-    // DELETE_FILE(200) duration: 3058 mS
+    // DELETE_FILE(200) duration: 7445 mS old
+    // DELETE_FILE(200) duration: 3058 mS new
+    // DELETE_FILE(200) duration: 4058 mS parallel new
     @Test
     public void deleteLargeFile() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/slow/DeleteBenchmark.java
+++ b/src/peergos/server/tests/slow/DeleteBenchmark.java
@@ -81,6 +81,30 @@ public class DeleteBenchmark {
         System.err.printf("DELETE("+names.size()+") duration: %d mS\n", duration);
     }
 
+    // DELETE_FILE(200) duration: 7445 mS
+    // DELETE_FILE(200) duration: 3058 mS
+    @Test
+    public void deleteLargeFile() throws Exception {
+        String username = generateUsername();
+        String password = "test01";
+        UserContext context = ensureSignedUp(username, password, network, crypto);
+        FileWrapper userRoot = context.getUserRoot().get();
+        int size = 200*1024*1024;
+        byte[] data = new byte[size];
+        random.nextBytes(data);
+
+        String filename = "file.bin";
+        userRoot.uploadFileJS(filename, AsyncReader.build(data), 0, size, false,
+                userRoot.mirrorBatId(), context.network, crypto, x -> {}, context.getTransactionService(), f -> Futures.of(false)).join();
+        Path filePath = PathUtil.get(username, filename);
+        FileWrapper file = context.getByPath(filePath).join().get();
+
+        long start = System.currentTimeMillis();
+        file.remove(context.getUserRoot().join(), filePath, context).join();
+        long duration = System.currentTimeMillis() - start;
+        System.err.printf("DELETE_FILE("+(size/1024/1024)+") duration: %d mS\n", duration);
+    }
+
     private static String randomString() {
         return UUID.randomUUID().toString();
     }

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -579,6 +579,27 @@ public class NetworkAccess {
                 .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
     }
 
+    public CompletableFuture<Snapshot> deleteAllChunksIfPresent(Snapshot current,
+                                                                Committer committer,
+                                                                PublicKeyHash owner,
+                                                                SigningPrivateKeyAndPublicHash writer,
+                                                                List<byte[]> mapKeys,
+                                                                TransactionId tid) {
+        CommittedWriterData version = current.get(writer);
+        List<CompletableFuture<Pair<byte[], MaybeMultihash>>> withValues = mapKeys.stream()
+                .parallel()
+                .map(mapKey -> tree.get(version.props, owner, writer.publicKeyHash, mapKey)
+                        .thenApply(valueHash -> new Pair<>(mapKey, valueHash)))
+                .collect(Collectors.toList());
+        return Futures.reduceAll(withValues, version.props,
+                        (wd, f) -> f.thenCompose(p -> p.right.isPresent() ?
+                                tree.remove(wd, owner, writer, p.left, p.right, tid) :
+                                Futures.of(wd)),
+                        (a, b) -> b)
+                .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid))
+                .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
+    }
+
     public CompletableFuture<Boolean> chunkIsPresent(Snapshot current,
                                                      PublicKeyHash owner,
                                                      PublicKeyHash writer,

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -568,15 +568,14 @@ public class NetworkAccess {
                                                             Committer committer,
                                                             PublicKeyHash owner,
                                                             SigningPrivateKeyAndPublicHash writer,
-                                                            byte[] mapKey) {
+                                                            byte[] mapKey,
+                                                            TransactionId tid) {
         CommittedWriterData version = current.get(writer);
         return tree.get(version.props, owner, writer.publicKeyHash, mapKey)
                 .thenCompose(valueHash ->
                         ! valueHash.isPresent() ? CompletableFuture.completedFuture(current) :
-                                IpfsTransaction.call(owner,
-                                        tid -> tree.remove(version.props, owner, writer, mapKey, valueHash, tid)
-                                                .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid)),
-                                        dhtClient))
+                                tree.remove(version.props, owner, writer, mapKey, valueHash, tid)
+                                        .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid)))
                 .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1495,7 +1495,7 @@ public class UserContext {
                                                 tid -> FileWrapper.deleteAllChunks(
                                                         file.writableFilePointer(),
                                                         file.signingPair(),
-                                                        true, tid, crypto.hasher, network, s, c), network.dhtClient))
+                                                        tid, crypto.hasher, network, s, c), network.dhtClient))
                                         .thenCompose(s -> rotateSigners ?
                                                 CryptreeNode.deAuthoriseSigner(owner, parentSigner, file.writer(),
                                                         network, s, c) :

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1495,7 +1495,7 @@ public class UserContext {
                                                 tid -> FileWrapper.deleteAllChunks(
                                                         file.writableFilePointer(),
                                                         file.signingPair(),
-                                                        tid, crypto.hasher, network, s, c), network.dhtClient))
+                                                        true, tid, crypto.hasher, network, s, c), network.dhtClient))
                                         .thenCompose(s -> rotateSigners ?
                                                 CryptreeNode.deAuthoriseSigner(owner, parentSigner, file.writer(),
                                                         network, s, c) :

--- a/src/peergos/shared/user/fs/FileProperties.java
+++ b/src/peergos/shared/user/fs/FileProperties.java
@@ -126,7 +126,7 @@ public class FileProperties implements Cborable {
         return (int) (size >> 32);
     }
 
-    public int getNumberOfChunks() {
+    public int chunkCount() {
         return FileWrapper.getNumberOfChunks(size);
     }
 

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1820,23 +1820,28 @@ public class FileWrapper {
                             if (! mOpt.isPresent()) {
                                 return CompletableFuture.completedFuture(current);
                             }
-                            SigningPrivateKeyAndPublicHash ourSigner = mOpt.get()
+                            CryptreeNode chunk = mOpt.get();
+                            SigningPrivateKeyAndPublicHash ourSigner = chunk
                                     .getSigner(currentCap.rBaseKey, currentCap.wBaseKey.get(), Optional.of(signer));
-                            return network.deleteChunk(current, committer, mOpt.get(), currentCap.owner,
-                                    currentCap.getMapKey(), ourSigner, tid)
-                                    .thenCompose(deletedVersion -> {
-                                        CryptreeNode chunk = mOpt.get();
-                                        Optional<byte[]> streamSecret = chunk.getProperties(chunk
-                                                .getParentKey(currentCap.rBaseKey)).streamSecret;
-                                        return chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
-                                                currentCap.getMapKey(), currentCap.bat, hasher).thenCompose(nextChunkMapKeyAndBat ->
-                                                deleteAllChunks(currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right), signer, tid, hasher,
-                                                        network, deletedVersion, committer));
-                                    })
+                            FileProperties props = chunk.getProperties(chunk
+                                    .getParentKey(currentCap.rBaseKey));
+                            Optional<byte[]> streamSecret = props.streamSecret;
+
+                            boolean normalFile = ! chunk.isDirectory() && streamSecret.isPresent();
+                            return (normalFile ?
+                                    deleteFile(chunk, props, currentCap, ourSigner, tid, hasher, network, current, committer) :
+                                    network.deleteChunk(current, committer, chunk, currentCap.owner,
+                                                    currentCap.getMapKey(), ourSigner, tid)
+                                            .thenCompose(deletedVersion -> {
+                                                return chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
+                                                        currentCap.getMapKey(), currentCap.bat, hasher).thenCompose(nextChunkMapKeyAndBat ->
+                                                        deleteAllChunks(currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right), signer, tid, hasher,
+                                                                network, deletedVersion, committer));
+                                            }))
                                     .thenCompose(updatedVersion -> {
-                                        if (! mOpt.get().isDirectory())
+                                        if (! chunk.isDirectory())
                                             return CompletableFuture.completedFuture(updatedVersion);
-                                        return mOpt.get().getDirectChildrenCapabilities(currentCap, updatedVersion, network).thenCompose(childCaps ->
+                                        return chunk.getDirectChildrenCapabilities(currentCap, updatedVersion, network).thenCompose(childCaps ->
                                                 Futures.reduceAll(childCaps,
                                                         updatedVersion,
                                                         (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, signer,
@@ -1845,6 +1850,33 @@ public class FileWrapper {
                                     })
                                     .thenCompose(s -> removeSigningKey(currentCap.writer, signer, currentCap.owner, network, s, committer));
                         }));
+    }
+
+    private static CompletableFuture<Snapshot> deleteFile(CryptreeNode meta,
+                                                          FileProperties props,
+                                                          WritableAbsoluteCapability currentCap,
+                                                          SigningPrivateKeyAndPublicHash ourSigner,
+                                                          TransactionId tid,
+                                                          Hasher hasher,
+                                                          NetworkAccess network,
+                                                          Snapshot current,
+                                                          Committer c) {
+        return getAllChunkLocations(currentCap.getMapKey(), props.streamSecret.get(), props.chunkCount(), hasher)
+                .thenCompose(labels -> Futures.reduceAll(labels.stream(), current,
+                        (v, m) -> network.deleteChunkIfPresent(v, c, currentCap.owner, ourSigner, m, tid),
+                        (a,b) -> b));
+    }
+
+    private static CompletableFuture<List<byte[]>> getAllChunkLocations(byte[] first, byte[] streamSecret, int nChunks, Hasher h) {
+        List<byte[]> res = new ArrayList<>(nChunks);
+        res.add(first);
+        return Futures.reduceAll(IntStream.range(1, nChunks).mapToObj(i -> i), res,
+                (labels, i) -> FileProperties.calculateNextMapKey(streamSecret, labels.get(labels.size() - 1), Optional.empty(), h)
+                        .thenApply(next -> {
+                            labels.add(next.left);
+                            return labels;
+                        }),
+                (a, b) -> b);
     }
 
     /**
@@ -1860,10 +1892,11 @@ public class FileWrapper {
         if (! pointer.capability.isWritable())
             return Futures.errored(new IllegalStateException("Cannot delete file without write access to it"));
 
-        BufferedNetworkAccess buffered = BufferedNetworkAccess.build(network, 5 * 1024 * 1024, owner(), () -> true, network.hasher);
+        BufferedNetworkAccess buffered = BufferedNetworkAccess.build(network, 50 * 1024 * 1024, owner(), () -> true, network.hasher);
 
         boolean writableParent = parent.isWritable();
         parent.setModified();
+        buffered.disableCommits();
         return buffered.synchronizer.applyComplexUpdate(owner(), signingPair(),
                 (version, c) -> {
                     Committer condenser = buffered.buildCommitter(c);

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1862,9 +1862,7 @@ public class FileWrapper {
                                                           Snapshot current,
                                                           Committer c) {
         return getAllChunkLocations(currentCap.getMapKey(), props.streamSecret.get(), props.chunkCount(), hasher)
-                .thenCompose(labels -> Futures.reduceAll(labels.stream(), current,
-                        (v, m) -> network.deleteChunkIfPresent(v, c, currentCap.owner, ourSigner, m, tid),
-                        (a,b) -> b));
+                .thenCompose(labels -> network.deleteAllChunksIfPresent(current, c, currentCap.owner, ourSigner, labels, tid));
     }
 
     private static CompletableFuture<List<byte[]>> getAllChunkLocations(byte[] first, byte[] streamSecret, int nChunks, Hasher h) {

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -7,6 +7,7 @@ import peergos.shared.cbor.Cborable;
 import peergos.shared.crypto.SigningPrivateKeyAndPublicHash;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.*;
+import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
@@ -82,7 +83,8 @@ public class FileUploadTransaction implements Transaction {
     }
 
     private CompletableFuture<Snapshot> clear(Snapshot version, Committer committer, NetworkAccess networkAccess, Location location) {
-        return networkAccess.deleteChunkIfPresent(version, committer, location.owner, writer, location.getMapKey());
+        return IpfsTransaction.call(owner,
+                tid -> networkAccess.deleteChunkIfPresent(version, committer, location.owner, writer, location.getMapKey(), tid), networkAccess.dhtClient);
     }
 
     public CompletableFuture<Snapshot> clear(Snapshot version, Committer committer, NetworkAccess network, Hasher h) {


### PR DESCRIPTION
add a benchmark for deleting a large file

increase delete buffer siz to 50 MiB

disable commits during delete. (It will end up as a single commit per signing keypair)