### PR TITLE
Clear source write synchronizer pointers after buffered network commit.

### DIFF
--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -61,12 +61,16 @@ public abstract class UserTests {
             Path peergosDir = Files.createTempDirectory("peergos");
             Random r = new Random();
             int port = 9000 + r.nextInt(8000);
+            int allowPort = 9000 + r.nextInt(8000);
+            int proxyPort = 9000 + r.nextInt(8000);
             int gatewayPort = 9000 + r.nextInt(8000);
             int ipfsApiPort = 9000 + r.nextInt(50_000);
             int ipfsGatewayPort = 9000 + r.nextInt(50_000);
             int ipfsSwarmPort = 9000 + r.nextInt(50_000);
             return Args.parse(new String[]{
                     "-port", Integer.toString(port),
+                    "-allow-target", "/ip4/127.0.0.1/tcp/" + allowPort,
+                    "-proxy-target", "/ip4/127.0.0.1/tcp/" + proxyPort,
                     "-gateway-port", Integer.toString(gatewayPort),
                     "-ipfs-api-address", "/ip4/127.0.0.1/tcp/" + ipfsApiPort,
                     "-ipfs-gateway-address", "/ip4/127.0.0.1/tcp/" + ipfsGatewayPort,

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -30,6 +30,7 @@ public class BufferedNetworkAccess extends NetworkAccess {
     private Committer targetCommitter;
     private final PublicKeyHash owner;
     private final Supplier<Boolean> commitWatcher;
+    private final WriteSynchronizer source;
     private final ContentAddressedStorage blocks;
     private boolean safeToCommit = true;
 
@@ -52,7 +53,8 @@ public class BufferedNetworkAccess extends NetworkAccess {
                                   Hasher hasher,
                                   List<String> usernames,
                                   CryptreeCache cache,
-                                  boolean isJavascript) {
+                                  boolean isJavascript,
+                                  WriteSynchronizer source) {
         super(coreNode, account, social, blockBuffer, batCave, mutable, tree, synchronizer, instanceAdmin, spaceUsage,
                 serverMessager, hasher, usernames, cache, isJavascript);
         this.blockBuffer = blockBuffer;
@@ -60,6 +62,7 @@ public class BufferedNetworkAccess extends NetworkAccess {
         this.bufferSize = bufferSize;
         this.owner = owner;
         this.commitWatcher = commitWatcher;
+        this.source = source;
         this.blocks = dhtClient;
     }
 
@@ -147,6 +150,7 @@ public class BufferedNetworkAccess extends NetworkAccess {
                             pointerBuffer.clear();
                             writers.clear();
                             writerUpdates.clear();
+                            source.clear();
                             return commitWatcher.get();
                         }));
     }
@@ -162,6 +166,6 @@ public class BufferedNetworkAccess extends NetworkAccess {
         MutableTree tree = new MutableTreeImpl(mutableBuffer, blockBuffer, h, synchronizer);
         return new BufferedNetworkAccess(blockBuffer, mutableBuffer, bufferSize, owner, commitWatcher, base.coreNode, base.account, base.social,
                 base.dhtClient, base.batCave, mutableBuffer, tree, synchronizer, base.instanceAdmin,
-                base.spaceUsage, base.serverMessager, base.hasher, base.usernames, base.cache, base.isJavascript());
+                base.spaceUsage, base.serverMessager, base.hasher, base.usernames, base.cache, base.isJavascript(), base.synchronizer);
     }
 }

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -30,6 +30,10 @@ public class WriteSynchronizer {
         this.hasher = hasher;
     }
 
+    public void clear() {
+        pending.clear();
+    }
+
     public void put(PublicKeyHash owner, PublicKeyHash writer, CommittedWriterData val) {
         pending.put(new Pair<>(owner, writer),
                 new AsyncLock<>(CompletableFuture.completedFuture(new Snapshot(writer, val))));


### PR DESCRIPTION
This fixes a CAS exception trying to write immediately after committing through a buffered network