### PR TITLE
Fix replace file - add monitor update for thumbnail progress

### DIFF
--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1201,7 +1201,10 @@ public class FileWrapper {
                                                 } else {
                                                     return updateExistingChild(current, committer, child, fileData,
                                                             startIndex, endIndex, network, crypto, monitor)
-                                                            .thenApply(s -> new Pair<>(s, Optional.<NamedRelativeCapability>empty()));
+                                                            .thenApply(s -> {
+                                                                monitor.accept(THUMBNAIL_PROGRESS_OFFSET);
+                                                                return new Pair<>(s, Optional.<NamedRelativeCapability>empty());
+                                                            });
                                                 }
                                             }
                                             if (startIndex > 0) {


### PR DESCRIPTION
I originally thought I would need to handle thumbnail re-creation - but if that is desired then the client should call the @JsMethod to do it.