### PR TITLE
Optimise usage updater

### DIFF
--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -126,7 +126,7 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
         return getLinks(block, "").thenCompose(links -> {
             List<CompletableFuture<Long>> subtrees = links.stream()
                     .filter(m -> ! m.isIdentity())
-                    .map(this::getRecursiveBlockSize)
+                    .map(c -> Futures.runAsync(() -> getRecursiveBlockSize(c)))
                     .collect(Collectors.toList());
             return getSize(block)
                     .thenCompose(sizeOpt -> {
@@ -164,24 +164,32 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
 
                     List<Cid> extraBefore = onlyBefore.subList(nPairs, onlyBefore.size());
                     List<Cid> extraAfter = onlyAfter.subList(nPairs, onlyAfter.size());
-                    Function<List<Cid>, CompletableFuture<Long>> getAllRecursiveSizes =
-                            extra -> Futures.reduceAll(extra,
-                                    0L,
-                                    (s, h) -> getRecursiveBlockSize(h).thenApply(size -> size + s),
-                                    (a, b) -> a + b);
 
-                    CompletableFuture<Long> beforeRes = Futures.runAsync(() -> getAllRecursiveSizes.apply(extraBefore));
-                    CompletableFuture<Long> afterRes = Futures.runAsync(() -> getAllRecursiveSizes.apply(extraAfter));
+                    CompletableFuture<Long> beforeRes = Futures.runAsync(() -> getAllRecursiveSizes(extraBefore));
+                    CompletableFuture<Long> afterRes = Futures.runAsync(() -> getAllRecursiveSizes(extraAfter));
                     CompletableFuture<Long> pairsRes = Futures.runAsync(() -> getSizeDiff(pairs));
                     return beforeRes.thenCompose(priorSize -> afterRes.thenApply(postSize -> postSize - priorSize + objectDelta))
                             .thenCompose(total -> pairsRes.thenApply(res -> res + total));
                 }));
     }
 
-    private CompletableFuture<Long> getSizeDiff(List<Pair<Cid, Cid>> pairs) {
-        return Futures.reduceAll(pairs,
+    private CompletableFuture<Long> getAllRecursiveSizes(List<Cid> roots) {
+        List<CompletableFuture<Long>> allSizes = roots.stream()
+                .map(c -> Futures.runAsync(() -> getRecursiveBlockSize(c)))
+                .collect(Collectors.toList());
+        return Futures.reduceAll(allSizes,
                 0L,
-                (s, p) -> Futures.runAsync(() -> getChangeInContainedSize(p.left, p.right).thenApply(size -> size + s)),
+                (s, f) -> f.thenApply(size -> size + s),
+                (a, b) -> a + b);
+    }
+
+    private CompletableFuture<Long> getSizeDiff(List<Pair<Cid, Cid>> pairs) {
+        List<CompletableFuture<Long>> pairDiffs = pairs.stream()
+                .map(p -> Futures.runAsync(() -> getChangeInContainedSize(p.left, p.right)))
+                .collect(Collectors.toList());
+        return Futures.reduceAll(pairDiffs,
+                0L,
+                (s, f) -> f.thenApply(size -> size + s),
                 (a, b) -> a + b);
     }
 

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -123,8 +123,11 @@ public class RamUserTests extends UserTests {
         }
         Assert.assertTrue(usageAfterFail > size / 2);
         context.cleanPartialUploads(t -> true).join();
-        Thread.sleep(20_000);
         long usageAfterCleanup = context.getSpaceUsage().join();
+        while (usageAfterCleanup >= initialUsage + 16000) {
+            Thread.sleep(1_000);
+            usageAfterCleanup = context.getSpaceUsage().join();
+        }
         Assert.assertTrue(usageAfterCleanup < initialUsage + 16000); // TODO: investigate why 16000 more (open transactions in db referencing blocks?)
     }
 

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -1215,8 +1215,11 @@ public abstract class UserTests {
         checkFileContents(data5, file, context);
 
         // check used space
-        PublicKeyHash signer = context.signer.publicKeyHash;
         long totalSpaceUsed = context.getSpaceUsage().get();
+        while (totalSpaceUsed < 10*1024*1024) {
+            Thread.sleep(1_000);
+            totalSpaceUsed = context.getSpaceUsage().get();
+        }
         Assert.assertTrue("Correct used space", totalSpaceUsed > 10*1024*1024);
 
         // check second chunk BAT is different from first

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -128,6 +128,20 @@ public class Futures {
                 });
     }
 
+    public static <V> CompletableFuture<V> runAsync(Supplier<CompletableFuture<V>> work) {
+        CompletableFuture<V> res = new CompletableFuture<>();
+        ForkJoinPool.commonPool().execute(() -> {
+            try {
+                work.get()
+                        .thenApply(res::complete)
+                        .exceptionally(res::completeExceptionally);
+            } catch (Throwable t) {
+                res.completeExceptionally(t);
+            }
+        });
+        return res;
+    }
+
     public static <T> CompletableFuture<T> asyncExceptionally(Supplier<CompletableFuture<T>> normal,
                                                               Function<Throwable, CompletableFuture<T>> exceptional) {
         CompletableFuture<T> result = new CompletableFuture<>();

--- a/src/peergos/shared/util/Futures.java
+++ b/src/peergos/shared/util/Futures.java
@@ -129,8 +129,12 @@ public class Futures {
     }
 
     public static <V> CompletableFuture<V> runAsync(Supplier<CompletableFuture<V>> work) {
+        return runAsync(work, ForkJoinPool.commonPool());
+    }
+
+    public static <V> CompletableFuture<V> runAsync(Supplier<CompletableFuture<V>> work, ForkJoinPool pool) {
         CompletableFuture<V> res = new CompletableFuture<>();
-        ForkJoinPool.commonPool().execute(() -> {
+        pool.execute(() -> {
             try {
                 work.get()
                         .thenApply(res::complete)


### PR DESCRIPTION
This makes the usage recalculator parallel. On test this makes the update time consistently ~600ms, compared to 1000-2000ms before on an account using 5-15 GiB. The large update after a large multi gigabyte delete has dropped from 5 minutes to 37s.