### PR TITLE
Switch to using query parameters for S3 gets now that we use a block …

### DIFF
--- a/src/peergos/shared/storage/auth/S3Request.java
+++ b/src/peergos/shared/storage/auth/S3Request.java
@@ -157,7 +157,7 @@ public class S3Request {
         Map<String, String> extraHeaders = range
                 .map(p -> Stream.of(p).collect(Collectors.toMap(r -> "Range", r -> "bytes="+r.left+"-"+r.right)))
                 .orElse(Collections.emptyMap());
-        S3Request policy = new S3Request(verb, host, key, UNSIGNED, expiresSeconds, false, true,
+        S3Request policy = new S3Request(verb, host, key, UNSIGNED, expiresSeconds, false, false,
                 Collections.emptyMap(), extraHeaders, accessKeyId, region, datetime);
         return preSignRequest(policy, key, host, s3SecretKey, useHttps, h);
     }


### PR DESCRIPTION
…cache in the browser.

The reason for using headers was so the browser would cache the result for subsequent reads.