### PR TITLE
Only update progress monitor during upload when buffered storage is flushed, not written to.

### DIFF
--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -137,7 +137,7 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
         byte[] hash = Arrays.copyOfRange(signedHash, ED25519_SIGNATURE_SIZE, signedHash.length);
         Cid h = new Cid(1, isRaw ? Cid.Codec.Raw : Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
         storage.put(h, block);
-        operations.add(Either.b(new BlockWrite(writer, signedHash, block, isRaw)));
+        operations.add(Either.b(new BlockWrite(writer, signedHash, block, isRaw, Optional.empty())));
         return Futures.of(h);
     }
 
@@ -160,12 +160,14 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
         public final PublicKeyHash writer;
         public final byte[] signature, block;
         public final boolean isRaw;
+        public final Optional<ProgressConsumer<Long>> progressMonitor;
 
-        public BlockWrite(PublicKeyHash writer, byte[] signature, byte[] block, boolean isRaw) {
+        public BlockWrite(PublicKeyHash writer, byte[] signature, byte[] block, boolean isRaw, Optional<ProgressConsumer<Long>> progressMonitor) {
             this.writer = writer;
             this.signature = signature;
             this.block = block;
             this.isRaw = isRaw;
+            this.progressMonitor = progressMonitor;
         }
 
         @Override
@@ -187,7 +189,7 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
             byte[] signature = m.getByteArray("s");
             byte[] block = m.getByteArray("b");
             boolean isRaw = m.getBoolean("r");
-            return new BlockWrite(writer, signature, block, isRaw);
+            return new BlockWrite(writer, signature, block, isRaw, Optional.empty());
         }
 
         @Override

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -794,7 +794,7 @@ public class UserContext {
                                             WriterData newIdBlock = cwd.props.withAlgorithm(newAlgorithm);
                                             byte[] rawBlock = newIdBlock.serialize();
                                             return crypto.hasher.sha256(rawBlock).thenCompose(blockHash -> {
-                                                OpLog.BlockWrite blockWrite = new OpLog.BlockWrite(signer.publicKeyHash, signer.secret.signMessage(blockHash), rawBlock, false);
+                                                OpLog.BlockWrite blockWrite = new OpLog.BlockWrite(signer.publicKeyHash, signer.secret.signMessage(blockHash), rawBlock, false, Optional.empty());
                                                 MaybeMultihash newHash = MaybeMultihash.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, blockHash));
                                                 PointerUpdate pointerCas = new PointerUpdate(cwd.hash, newHash, PointerUpdate.increment(cwd.sequence));
                                                 OpLog.PointerWrite pointerWrite = new OpLog.PointerWrite(signer.publicKeyHash, signer.secret.signMessage(pointerCas.serialize()));


### PR DESCRIPTION
This stops the progress bar from closing before the file has been fully uploaded.