### PR TITLE
Add a bloom add api call  to ipfs-nucleus

### DIFF
--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -136,6 +136,24 @@ public class Builder {
         return new JavaPoster(ipfsGatewayAddress, false);
     }
 
+    /** A number representing the size in bytes of the blockstore's bloom filter. A value of zero represents the feature is disabled.
+
+     This site generates useful graphs for various bloom filter values: https://hur.st/bloomfilter/?n=1e6&p=0.01&m=&k=7
+     You may use it to find a preferred optimal value, where m is BloomFilterSize in bits. Remember to convert the value
+     m from bits, into bytes for use as BloomFilterSize in the config file. For example, for 1,000,000 blocks, expecting
+     a 1% false-positive rate, you'd end up with a filter size of 9592955 bits, so for BloomFilterSize we'd want to use
+     1199120 bytes. As of writing, 7 hash functions are used, so the constant k is 7 in the formula.
+     *
+     * @param falsePositivesProbability
+     * @param numberOfBlocks
+     * @return
+     */
+    public static int bloomfilterSizeBytes(double falsePositivesProbability, long numberOfBlocks) {
+        int numberOfHashfunctions = 7;
+        return (int)Math.ceil((numberOfBlocks * Math.log(falsePositivesProbability)) / Math.log(1 / Math.pow(2, Math.log(2))))/8;
+
+    }
+
     /**
      *
      * @param a

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -364,7 +364,8 @@ public class Main extends Builder {
                             S3Config.useS3(args) ?
                                     new S3BlockStorage(S3Config.build(args), Cid.decode(args.getArg("ipfs.id")),
                                             BlockStoreProperties.empty(), transactions, authoriser,
-                                            crypto.hasher, new DeletableContentAddressedStorage.HTTP(Builder.buildIpfsApi(args), false, crypto.hasher)) :
+                                            crypto.hasher, new DeletableContentAddressedStorage.HTTP(Builder.buildIpfsApi(args), false, crypto.hasher),
+                                            new DeletableContentAddressedStorage.HTTP(Builder.buildIpfsApi(args), false, crypto.hasher)) :
                                     new FileContentAddressedStorage(blockstorePath(args),
                                             transactions, authoriser, crypto.hasher);
                     Multihash pkiIpfsNodeId = storage.id().get();

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -33,6 +33,8 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
 
     void delete(Multihash hash);
 
+    default void bloomAdd(Multihash hash) {}
+
     default void bulkDelete(List<Multihash> blocks) {
         for (Multihash block : blocks) {
             delete(block);
@@ -219,6 +221,11 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
         @Override
         public void delete(Multihash hash) {
             poster.get(apiPrefix + BLOCK_RM + "?stream-channels=true&arg=" + hash.toString()).join();
+        }
+
+        @Override
+        public void bloomAdd(Multihash hash) {
+            poster.get(apiPrefix + BLOOM_ADD + "?stream-channels=true&arg=" + hash.toString()).join();
         }
 
         @Override

--- a/src/peergos/server/storage/IpfsInstaller.java
+++ b/src/peergos/server/storage/IpfsInstaller.java
@@ -22,17 +22,17 @@ public class IpfsInstaller {
 
     public enum DownloadTarget {
         DARWIN_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/darwin-amd64/ipfs?raw=true",
-                Cid.decode("QmU44ozuxEfc13EJCkVvwHvY1h8sZtVC52Z4ENjYtiKpAf")),
+                Cid.decode("QmbXyFJnwcZpRiC1kYxbKx5qc4AhQRJGLX9JJw2jL3M3kV")),
         DARWIN_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/darwin-arm64/ipfs?raw=true",
-                Cid.decode("QmRssvnt4tfT8brRYR7AQ3fVVirCkCo3jaoyG7KSAXK9Xg")),
+                Cid.decode("QmUKNBkNjTDjKDHuoLyds2P4qTgpvcELqni4EcsAQzWnfe")),
         LINUX_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-amd64/ipfs?raw=true",
-                Cid.decode("QmbG2fZ5wymogCPVJtzt7mRaDFT7jAmyEw2vkW4gikYMTF")),
+                Cid.decode("QmZmfHMnVJJg5ioZeWKJn8G2oa7FA8Z2X3ixskN5zjMfJP")),
         LINUX_ARM("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-arm/ipfs?raw=true",
-                Cid.decode("QmeiEqS1gcg4crDko7QGEofsPaJTgdrYVDmSq2j3Sb4Vxk")),
+                Cid.decode("QmbHMuxksFM9VuoWoZPph3EQ8PMz74mUH5w8eSx13GuQMm")),
         LINUX_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-arm64/ipfs?raw=true",
-                Cid.decode("QmYFnJ17DdQSQErk4fP6QE7PFEYYLZQwfNro65wzMzU8eJ")),
+                Cid.decode("QmajkzzxdoWFfmTVsXLE2eCYC8CkMmQrq9upLxRkwH7GJv")),
         WINDOWS_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/windows-amd64/ipfs.exe?raw=true",
-                Cid.decode("QmY53kzWog6QFL8ioZyYwVWUNRR2Kvt6DTMt3jLrTXNZd7")),;
+                Cid.decode("QmRQtC5ehMPY7cXv7TvB5kSwoeZ5qkq1vjiwn7HoxkEE5P")),;
 
         public final String url;
         public final Multihash multihash;

--- a/src/peergos/server/storage/IpfsInstaller.java
+++ b/src/peergos/server/storage/IpfsInstaller.java
@@ -22,17 +22,17 @@ public class IpfsInstaller {
 
     public enum DownloadTarget {
         DARWIN_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/darwin-amd64/ipfs?raw=true",
-                Cid.decode("QmbXyFJnwcZpRiC1kYxbKx5qc4AhQRJGLX9JJw2jL3M3kV")),
+                Cid.decode("QmUJkqgCoQXmkTFFUJDnyUWuxKU9qHxFWsWxEPpzJKJYnH")),
         DARWIN_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/darwin-arm64/ipfs?raw=true",
-                Cid.decode("QmUKNBkNjTDjKDHuoLyds2P4qTgpvcELqni4EcsAQzWnfe")),
+                Cid.decode("QmbRwUdyMRuQNTQD5DEWS26qvhiZNfpEFR9McRGQcG8Ubh")),
         LINUX_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-amd64/ipfs?raw=true",
-                Cid.decode("QmZmfHMnVJJg5ioZeWKJn8G2oa7FA8Z2X3ixskN5zjMfJP")),
+                Cid.decode("QmWatcxqg31TvBeXpJMBZwraiaRwYnfvqEGZAw9ueo94Hu")),
         LINUX_ARM("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-arm/ipfs?raw=true",
-                Cid.decode("QmbHMuxksFM9VuoWoZPph3EQ8PMz74mUH5w8eSx13GuQMm")),
+                Cid.decode("QmZZRnbdZGTn9tGNghAeh4UndaAUh6mNEGodnz8YzDjZde")),
         LINUX_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-arm64/ipfs?raw=true",
-                Cid.decode("QmajkzzxdoWFfmTVsXLE2eCYC8CkMmQrq9upLxRkwH7GJv")),
+                Cid.decode("QmPh531hDfbBGSuF5VuqW5eDP4oFCPXaV6vAhzZqyh4yQN")),
         WINDOWS_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/windows-amd64/ipfs.exe?raw=true",
-                Cid.decode("QmRQtC5ehMPY7cXv7TvB5kSwoeZ5qkq1vjiwn7HoxkEE5P")),;
+                Cid.decode("QmRU6SEK8cnqjUvJAjHyxraMGV56vLjsvQFa4m1LB4VNax")),;
 
         public final String url;
         public final Multihash multihash;

--- a/src/peergos/server/storage/IpfsInstaller.java
+++ b/src/peergos/server/storage/IpfsInstaller.java
@@ -21,18 +21,18 @@ import java.util.stream.*;
 public class IpfsInstaller {
 
     public enum DownloadTarget {
-        DARWIN_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.4/darwin-amd64/ipfs?raw=true",
-                Cid.decode("QmQRi6e262WDzxFYPGFXWSc7MoqkYcpu771CEhmQizQv7n")),
-        DARWIN_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.4/darwin-arm64/ipfs?raw=true",
-                Cid.decode("QmQ8KE3fibfnDRWyACHPiiD8SRKZh9nvGKUVEc9FoUcJzJ")),
-        LINUX_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.4/linux-amd64/ipfs?raw=true",
-                Cid.decode("QmR2hZXeUTVTwi2TpnXTCLrTGiCyhNpHPaMsqeoQxXdPLq")),
-        LINUX_ARM("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.4/linux-arm/ipfs?raw=true",
-                Cid.decode("Qmd3g6HCaiYSyK95zUBdpQvp4NHj22iqbtYsC61i9jRvnL")),
-        LINUX_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.4/linux-arm64/ipfs?raw=true",
-                Cid.decode("QmVRXWTM8vDksbGmAjZruwjTAWpVQsqxZ5NsAGtkwZqxMY")),
-        WINDOWS_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.4/windows-amd64/ipfs.exe?raw=true",
-                Cid.decode("QmZ3GfqW6s4mD45DsR5Z2Behp6a9zGMDmwUYovM29xb1gf")),;
+        DARWIN_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/darwin-amd64/ipfs?raw=true",
+                Cid.decode("QmU44ozuxEfc13EJCkVvwHvY1h8sZtVC52Z4ENjYtiKpAf")),
+        DARWIN_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/darwin-arm64/ipfs?raw=true",
+                Cid.decode("QmRssvnt4tfT8brRYR7AQ3fVVirCkCo3jaoyG7KSAXK9Xg")),
+        LINUX_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-amd64/ipfs?raw=true",
+                Cid.decode("QmbG2fZ5wymogCPVJtzt7mRaDFT7jAmyEw2vkW4gikYMTF")),
+        LINUX_ARM("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-arm/ipfs?raw=true",
+                Cid.decode("QmeiEqS1gcg4crDko7QGEofsPaJTgdrYVDmSq2j3Sb4Vxk")),
+        LINUX_ARM64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/linux-arm64/ipfs?raw=true",
+                Cid.decode("QmYFnJ17DdQSQErk4fP6QE7PFEYYLZQwfNro65wzMzU8eJ")),
+        WINDOWS_AMD64("https://github.com/peergos/ipfs-nucleus-releases/blob/main/v0.2.5/windows-amd64/ipfs.exe?raw=true",
+                Cid.decode("QmY53kzWog6QFL8ioZyYwVWUNRR2Kvt6DTMt3jLrTXNZd7")),;
 
         public final String url;
         public final Multihash multihash;
@@ -324,7 +324,7 @@ public class IpfsInstaller {
     }
 
     public static void main(String[] args) throws Exception {
-        String version = "v0.2.4";
+        String version = "v0.2.5";
         codegen(Paths.get("/home/ian/ipfs-nucleus-releases/" + version));
     }
 

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -252,6 +252,7 @@ public interface ContentAddressedStorage {
         public static final String BLOCK_PUT = "block/put";
         public static final String BLOCK_GET = "block/get";
         public static final String BLOCK_RM = "block/rm";
+        public static final String BLOOM_ADD = "bloom/add";
         public static final String BLOCK_PRESENT = "block/has";
         public static final String BLOCK_STAT = "block/stat";
         public static final String REFS_LOCAL = "refs/local";


### PR DESCRIPTION
This allows us to maintain an accurate bloom filter in ipfs to reduce dht induced block.gets by 1000x.

We call  it whenever we externally add or authorise adding a new block.