### PR TITLE
Fix mirroring a user's data on an S3 instance

### DIFF
--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -279,7 +279,8 @@ public class Builder {
                                 return ALLOW;
                         }
                         if (! batids.isEmpty()) {
-                            Logging.LOG().info("INVALID AUTH: source: " + s + ", cid: " + b + " reason: " + BlockRequestAuthoriser.invalidReason(blockAuth, b, s, batids, hasher));
+                            String reason = BlockRequestAuthoriser.invalidReason(blockAuth, b, s, batids, hasher);
+                            Logging.LOG().info("INVALID AUTH: source: " + s + ", cid: " + b + " reason: " + reason);
                         }
                         return BLOCK;
                     } else return ALLOW; // This is a public block

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -262,7 +262,7 @@ public class Builder {
                     if (((CborObject.CborMap) block).containsKey("bats")) {
                         List<BatId> batids = ((CborObject.CborMap) block).getList("bats", BatId::fromCbor);
                         if (auth.isEmpty()) {
-                            System.out.println("INVALID AUTH: EMPTY");
+                            Logging.LOG().info("INVALID AUTH: EMPTY");
                             return BLOCK;
                         }
                         BlockAuth blockAuth = BlockAuth.fromString(auth);
@@ -279,7 +279,7 @@ public class Builder {
                                 return ALLOW;
                         }
                         if (! batids.isEmpty()) {
-                            Logging.LOG().info("INVALID AUTH: " + BlockRequestAuthoriser.invalidReason(blockAuth, b, s, batids, hasher));
+                            Logging.LOG().info("INVALID AUTH: source: " + s + ", cid: " + b + " reason: " + BlockRequestAuthoriser.invalidReason(blockAuth, b, s, batids, hasher));
                         }
                         return BLOCK;
                     } else return ALLOW; // This is a public block

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -728,6 +728,12 @@ public class Main extends Builder {
                             Optional<BatWithId> mirrorBat = a.getOptionalArg("mirror.bat").map(BatWithId::decode);
                             if (mirrorBat.isEmpty())
                                 System.out.println("WARNING: Mirroring users public blocks only, see option 'mirror.bat'");
+                            else {
+                                BatId mirrorId = mirrorBat.get().id();
+                                Optional<Bat> existingMirrorBat = batStore.getBat(mirrorId);
+                                if (existingMirrorBat.isEmpty())
+                                    batStore.addBat(username, mirrorId, mirrorBat.get().bat, new byte[0]).join();
+                            }
                             Mirror.mirrorUser(username, mirrorLoginDataPair, mirrorBat, core, p2mMutable, p2pAccount, localStorage,
                                     rawPointers, rawAccount, transactions, hasher);
                             try {

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -39,6 +39,7 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.logging.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -733,7 +734,7 @@ public class Main extends Builder {
                                 Thread.sleep(60_000);
                             } catch (InterruptedException f) {}
                         } catch (Exception e) {
-                            e.printStackTrace();
+                            Logging.LOG().log(Level.SEVERE, e, () -> e.getMessage());
                             try {
                                 Thread.sleep(5_000);
                             } catch (InterruptedException f) {}

--- a/src/peergos/server/UserCleanup.java
+++ b/src/peergos/server/UserCleanup.java
@@ -63,10 +63,10 @@ public class UserCleanup {
             reachableKeys.putIfAbsent(s, new HashMap<>());
             reachableKeys.get(s).put(p, new ByteArrayWrapper(cap.getMapKey()));
             fopt.ifPresent(f -> {
-                if (f.getPointer().capability.bat.isPresent() && f.mirrorBatId().isEmpty()) {
-                    System.out.println("Fixing file with 1 bat at " + p);
-                    f.addMirrorBat(mirrorBat.id(), c.network).join();
-                }
+                RetrievedCapability rcap = f.getPointer();
+                boolean addToFragmentsOnly = rcap.capability.bat.isEmpty();
+                if (! f.isDirectory())
+                    f.addMirrorBat(mirrorBat.id(), addToFragmentsOnly, c.network).join();
             });
             return true;
         }, c);

--- a/src/peergos/server/UserCleanup.java
+++ b/src/peergos/server/UserCleanup.java
@@ -65,7 +65,7 @@ public class UserCleanup {
             fopt.ifPresent(f -> {
                 RetrievedCapability rcap = f.getPointer();
                 boolean addToFragmentsOnly = rcap.capability.bat.isEmpty();
-                if (! f.isDirectory())
+                if (! addToFragmentsOnly || ! f.getPointer().fileAccess.bats.isEmpty())
                     f.addMirrorBat(mirrorBat.id(), addToFragmentsOnly, c.network).join();
             });
             return true;

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -34,7 +34,7 @@ import java.util.concurrent.*;
 public class UserService {
 	private static final Logger LOG = Logging.LOG();
 
-    public static final Version CURRENT_VERSION = Version.parse("0.10.0");
+    public static final Version CURRENT_VERSION = Version.parse("0.11.0");
     public static final String UI_URL = "/";
 
     private static void initTLS() {

--- a/src/peergos/server/storage/AuthedStorage.java
+++ b/src/peergos/server/storage/AuthedStorage.java
@@ -54,7 +54,8 @@ public class AuthedStorage extends DelegatingStorage implements DeletableContent
         return getRaw(hash, auth, true);
     }
 
-    private CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
         return target.getRaw(hash, auth).thenApply(bopt -> {
             if (bopt.isEmpty())
                 return Optional.empty();

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -100,13 +100,13 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
             return Futures.of(Collections.singletonList(newRoot));
         boolean isRaw = newRoot.isRaw();
 
-        Optional<CborObject> newVal = get(newRoot, mirrorBat, ourNodeId, hasher).join();
+        Optional<byte[]> newVal = getRaw(newRoot, mirrorBat, ourNodeId, hasher, false).join();
         if (newVal.isEmpty())
             throw new IllegalStateException("Couldn't retrieve block: " + newRoot);
         if (isRaw)
             return Futures.of(Collections.singletonList(newRoot));
 
-        CborObject newBlock = newVal.get();
+        CborObject newBlock = CborObject.fromByteArray(newVal.get());
         List<Multihash> newLinks = newBlock.links().stream()
                 .filter(h -> !h.isIdentity())
                 .collect(Collectors.toList());

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -107,9 +107,13 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
             return Futures.of(Collections.singletonList(newRoot));
 
         CborObject newBlock = newVal.get();
-        List<Multihash> newLinks = newBlock.links();
+        List<Multihash> newLinks = newBlock.links().stream()
+                .filter(h -> !h.isIdentity())
+                .collect(Collectors.toList());
         List<Multihash> existingLinks = existing.map(h -> get(h, mirrorBat, ourNodeId, hasher).join())
-                .flatMap(copt -> copt.map(CborObject::links))
+                .flatMap(copt -> copt.map(CborObject::links).map(links -> links.stream()
+                        .filter(h -> !h.isIdentity())
+                        .collect(Collectors.toList())))
                 .orElse(Collections.emptyList());
 
         for (int i=0; i < newLinks.size(); i++) {

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -12,7 +12,6 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.function.*;
 import java.util.stream.*;
 
 /** This interface is only used locally on a server and never exposed.
@@ -100,7 +99,7 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
             return Futures.of(Collections.singletonList(newRoot));
         boolean isRaw = newRoot.isRaw();
 
-        Optional<byte[]> newVal = getRaw(newRoot, mirrorBat, ourNodeId, hasher, false).join();
+        Optional<byte[]> newVal = RetryStorage.runWithRetry(3, () -> getRaw(newRoot, mirrorBat, ourNodeId, hasher, false)).join();
         if (newVal.isEmpty())
             throw new IllegalStateException("Couldn't retrieve block: " + newRoot);
         if (isRaw)

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -63,12 +63,20 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
      */
     CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth);
 
+    default CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
+        return getRaw(hash, auth);
+    }
+
     default CompletableFuture<Optional<byte[]>> getRaw(Cid hash, Optional<BatWithId> bat, Cid ourId, Hasher h) {
+        return getRaw(hash, bat, ourId, h, true);
+    }
+
+    default CompletableFuture<Optional<byte[]>> getRaw(Cid hash, Optional<BatWithId> bat, Cid ourId, Hasher h, boolean doAuth) {
         if (bat.isEmpty())
             return getRaw(hash, "");
         return bat.get().bat.generateAuth(hash, ourId, 300, S3Request.currentDatetime(), bat.get().id, h)
                 .thenApply(BlockAuth::encode)
-                .thenCompose(auth -> getRaw(hash, auth));
+                .thenCompose(auth -> getRaw(hash, auth, doAuth));
     }
 
     /** Ensure that local copies of all blocks in merkle tree referenced are present locally

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -156,7 +156,8 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
         return getRaw(hash, auth, true);
     }
 
-    private CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
         try {
             if (hash.isIdentity())
                 return Futures.of(Optional.of(hash.getHash()));

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -360,7 +360,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         if (newBlock.isEmpty())
             throw new IllegalStateException("Couldn't retrieve block: " + newRoot);
         if (! hasBlock(newRoot))
-            put(newBlock.get(), newRoot.isRaw(), tid, owner);
+            getWithBackoff(() -> put(newBlock.get(), newRoot.isRaw(), tid, owner));
         if (newRoot.isRaw())
             return Futures.of(Collections.singletonList(newRoot));
 

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -303,7 +303,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
             nonLocalGets.inc();
             if (p2pGetId.equals(id))
                 return p2pFallback.getRaw(hash, auth);
-            return p2pFallback.getRaw(hash, bat); // recalculate auth when the fallback node has a different node id
+            return p2pFallback.getRaw(hash, bat, p2pGetId, hasher, enforceAuth); // recalculate auth when the fallback node has a different node id
         } finally {
             readTimer.observeDuration();
         }
@@ -355,17 +355,18 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         if (existing.equals(updated))
             return Futures.of(Collections.singletonList(newRoot));
 
-        if (contains(newRoot))
-            return Futures.of(Collections.singletonList(newRoot));
-        Optional<byte[]> newBlock = p2pFallback.getRaw(newRoot, mirrorBat, p2pGetId, hasher).join();
+        // This call will not verify the auth as we might not have the mirror bat present locally
+        Optional<byte[]> newBlock = p2pFallback.getRaw(newRoot, mirrorBat, p2pGetId, hasher, false).join();
         if (newBlock.isEmpty())
             throw new IllegalStateException("Couldn't retrieve block: " + newRoot);
-        put(newBlock.get(), newRoot.isRaw(), tid, owner);
+        if (! hasBlock(newRoot))
+            put(newBlock.get(), newRoot.isRaw(), tid, owner);
         if (newRoot.isRaw())
             return Futures.of(Collections.singletonList(newRoot));
 
         List<Multihash> newLinks = CborObject.fromByteArray(newBlock.get()).links();
-        List<Multihash> existingLinks = existing.map(h -> get(h, mirrorBat, id, hasher).join())
+        List<Multihash> existingLinks = existing.map(h -> getRaw(h, Optional.empty(), "", false, mirrorBat).join())
+                .map(bopt -> bopt.map(CborObject::fromByteArray))
                 .flatMap(copt -> copt.map(CborObject::links))
                 .orElse(Collections.emptyList());
 

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -70,7 +70,8 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
         return getRaw(hash, auth, true);
     }
 
-    private CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(Cid hash, String auth, boolean doAuth) {
         return target.getRaw(hash, auth).thenApply(bopt -> {
             if (bopt.isEmpty())
                 return Optional.empty();

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -1861,7 +1861,7 @@ public abstract class UserTests {
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         long initialUsage = context.getSpaceUsage().join();
 
-        UserGC.checkRawUsage(context);
+        UserCleanup.checkRawUsage(context);
         String filename = "test.bin";
         context.getUserRoot().join().uploadFileJS(filename, AsyncReader.build(new byte[10*1024*1024]),
                 0, 10*1024*1024, true, context.mirrorBatId(), network, crypto, x-> {},
@@ -1869,7 +1869,7 @@ public abstract class UserTests {
         String dirName = "subdir";
         context.getUserRoot().join().mkdir(dirName, network, false, context.mirrorBatId(), crypto).join();
         Thread.sleep(5_000); // Allow time for space usage recalculation
-        UserGC.checkRawUsage(context);
+        UserCleanup.checkRawUsage(context);
 
         // now delete the file and dir
         Path filePath = PathUtil.get(username, filename);
@@ -1877,7 +1877,7 @@ public abstract class UserTests {
         Path dirPath = PathUtil.get(username, dirName);
         context.getByPath(dirPath).join().get().remove(context.getUserRoot().join(), dirPath, context).join();
         try {Thread.sleep(2000);} catch (InterruptedException e) {}
-        UserGC.checkRawUsage(context);
+        UserCleanup.checkRawUsage(context);
 
         long finalUsage = context.getSpaceUsage().join();
         long diff = finalUsage - initialUsage;

--- a/src/peergos/server/util/JavaPoster.java
+++ b/src/peergos/server/util/JavaPoster.java
@@ -71,6 +71,8 @@ public class JavaPoster implements HttpPoster {
             byte[] resp = Serialize.readFully(din);
             din.close();
             res.complete(resp);
+        } catch (SocketTimeoutException e) {
+            res.completeExceptionally(new SocketTimeoutException("Socket timeout on: " + url));
         } catch (IOException e) {
             if (conn != null){
                 String trailer = conn.getHeaderField("Trailer");

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -49,6 +49,10 @@ public class FragmentedPaddedCipherText implements Cborable {
         return cipherTextFragments;
     }
 
+    public List<BatWithId> getBats() {
+        return bats;
+    }
+
     public FragmentedPaddedCipherText withFragments(List<Cid> fragments) {
         return new FragmentedPaddedCipherText(nonce, header, fragments, bats, inlinedCipherText);
     }

--- a/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
+++ b/src/peergos/shared/crypto/FragmentedPaddedCipherText.java
@@ -41,6 +41,18 @@ public class FragmentedPaddedCipherText implements Cborable {
             throw new IllegalStateException("Cannot have an inlined block and merkle linked blocks!");
     }
 
+    public boolean isInline() {
+        return inlinedCipherText.isPresent();
+    }
+
+    public List<Cid> getFragments() {
+        return cipherTextFragments;
+    }
+
+    public FragmentedPaddedCipherText withFragments(List<Cid> fragments) {
+        return new FragmentedPaddedCipherText(nonce, header, fragments, bats, inlinedCipherText);
+    }
+
     @Override
     public CborObject toCbor() {
         SortedMap<String, Cborable> state = new TreeMap<>();

--- a/src/peergos/shared/messaging/Messenger.java
+++ b/src/peergos/shared/messaging/Messenger.java
@@ -65,7 +65,7 @@ public class Messenger {
         PrivateChatState privateChatState = Chat.generateChatIdentity(crypto);
         byte[] rawPrivateChatState = privateChatState.serialize();
         return createChatRoot(chatId)
-                .thenCompose(chatRoot -> chatRoot.getOrMkdirs(PathUtil.get("shared"), context.network, false, chatRoot.mirrorBatId(), crypto)
+                .thenCompose(chatRoot -> chatRoot.getOrMkdirs(PathUtil.get("shared"), context.network, false, context.mirrorBatId(), crypto)
                         .thenCompose(chatSharedDir -> chatRoot.getUpdated(network)
                                 .thenCompose(updatedChatRoot -> chatSharedDir.setProperties(chatSharedDir.getFileProperties(), hasher,
                                         network, Optional.of(updatedChatRoot)).thenCompose(b -> chatSharedDir.getUpdated(network))))
@@ -91,7 +91,7 @@ public class Messenger {
 
     private CompletableFuture<FileWrapper> createChatRoot(String chatId) {
         return context.getUserRoot()
-                .thenCompose(home -> home.getOrMkdirs(PathUtil.get(MESSAGING_BASE_DIR), context.network, true, home.mirrorBatId(), context.crypto))
+                .thenCompose(home -> home.getOrMkdirs(PathUtil.get(MESSAGING_BASE_DIR), context.network, true, context.mirrorBatId(), context.crypto))
                 .thenCompose(chatsRoot -> chatsRoot.mkdir(chatId, context.network, false, chatsRoot.mirrorBatId(), crypto))
                 .thenCompose(updated -> updated.getChild(chatId, hasher, network))
                 .thenApply(Optional::get);
@@ -125,7 +125,7 @@ public class Messenger {
                 .thenApply(Optional::get)
                 .thenApply(parent -> parent.getName())
                 .thenCompose(chatId -> createChatRoot(chatId) // This will error if a chat with this chatId already exists
-                        .thenCompose(chatRoot -> chatRoot.getOrMkdirs(PathUtil.get("shared"), network, false, chatRoot.mirrorBatId(), crypto)
+                        .thenCompose(chatRoot -> chatRoot.getOrMkdirs(PathUtil.get("shared"), network, false, context.mirrorBatId(), crypto)
                                 .thenCompose(shared -> ChatController.getChatState(sourceChatSharedDir, network, crypto)
                                         .thenCompose(mirrorState -> {
                                             Chat ourVersion = mirrorState.copy(new Member(context.username,
@@ -260,7 +260,7 @@ public class Messenger {
                 Integer.toString(postTime.getYear()),
                 Integer.toString(postTime.getMonthValue())));
         return context.getUserRoot()
-                .thenCompose(home -> home.getOrMkdirs(dirFromHome, network, true, home.mirrorBatId(), crypto)
+                .thenCompose(home -> home.getOrMkdirs(dirFromHome, network, true, context.mirrorBatId(), crypto)
                 .thenApply(dir -> new Pair<>(PathUtil.get("/" + context.username).resolve(dirFromHome), dir)));
     }
 
@@ -289,7 +289,7 @@ public class Messenger {
     @JsMethod
     public CompletableFuture<Set<ChatController>> listChats() {
         return context.getUserRoot()
-                .thenCompose(home -> home.getOrMkdirs(PathUtil.get(MESSAGING_BASE_DIR), network, true, home.mirrorBatId(), crypto))
+                .thenCompose(home -> home.getOrMkdirs(PathUtil.get(MESSAGING_BASE_DIR), network, true, context.mirrorBatId(), crypto))
                 .thenCompose(chatsRoot -> chatsRoot.getChildren(hasher, network))
                 .thenCompose(chatDirs -> Futures.combineAll(chatDirs.stream()
                         .map(d -> ChatController.getChatController(d, context, cache))

--- a/src/peergos/shared/social/SocialFeed.java
+++ b/src/peergos/shared/social/SocialFeed.java
@@ -68,7 +68,7 @@ public class SocialFeed {
         byte[] raw = post.serialize();
         AsyncReader reader = AsyncReader.build(raw);
         return context.getUserRoot()
-                .thenCompose(home -> home.getOrMkdirs(dir, network, true, home.mirrorBatId(), crypto))
+                .thenCompose(home -> home.getOrMkdirs(dir, network, true, context.mirrorBatId(), crypto))
                 .thenCompose(postDir -> postDir.uploadAndReturnFile(postFilename, reader, raw.length, false,
                         postDir.mirrorBatId(), network, crypto)
                         .thenApply(f -> new Pair<>(PathUtil.get(post.author).resolve(dir).resolve(postFilename), f)))
@@ -109,7 +109,7 @@ public class SocialFeed {
                 Integer.toString(postTime.getYear()),
                 mediaType);
         return context.getUserRoot()
-                .thenCompose(home -> home.getOrMkdirs(dirFromHome, network, true, home.mirrorBatId(), crypto)
+                .thenCompose(home -> home.getOrMkdirs(dirFromHome, network, true, context.mirrorBatId(), crypto)
                 .thenApply(dir -> new Pair<>(PathUtil.get("/" + context.username).resolve(dirFromHome), dir)));
     }
 
@@ -398,7 +398,7 @@ public class SocialFeed {
 
     public static CompletableFuture<SocialFeed> create(UserContext c) {
         return c.getUserRoot()
-                .thenCompose(home -> home.getOrMkdirs(PathUtil.get(UserContext.FEED_DIR_NAME), c.network, true, home.mirrorBatId(), c.crypto))
+                .thenCompose(home -> home.getOrMkdirs(PathUtil.get(UserContext.FEED_DIR_NAME), c.network, true, c.mirrorBatId(), c.crypto))
                 .thenCompose(feedDir -> {
                     FeedState empty = new FeedState(0, 0, 0L, Collections.emptyMap());
                     byte[] rawEmpty = empty.serialize();

--- a/src/peergos/shared/user/App.java
+++ b/src/peergos/shared/user/App.java
@@ -68,7 +68,7 @@ public class App implements StoreAppData {
         App app = new App(ctx, appDataDir);
         return ctx.username == null ? Futures.of(app) :
                 ctx.getUserRoot()
-                .thenCompose(root -> root.getOrMkdirs(appDataDir, ctx.network, true, root.mirrorBatId(), ctx.crypto))
+                .thenCompose(root -> root.getOrMkdirs(appDataDir, ctx.network, true, ctx.mirrorBatId(), ctx.crypto))
                 .thenApply(appDir -> app);
     }
 
@@ -100,7 +100,7 @@ public class App implements StoreAppData {
 
     private CompletableFuture<Boolean> appendFileContents(Path path, byte[] data) {
         Path pathWithoutUsername = path.subpath(1, path.getNameCount());
-        return ctx.getByPath(ctx.username).thenCompose(userRoot -> userRoot.get().getOrMkdirs(pathWithoutUsername.getParent(), ctx.network, false, userRoot.get().mirrorBatId(), ctx.crypto)
+        return ctx.getByPath(ctx.username).thenCompose(userRoot -> userRoot.get().getOrMkdirs(pathWithoutUsername.getParent(), ctx.network, false, ctx.mirrorBatId(), ctx.crypto)
                 .thenCompose(dir -> dir.appendFileJS(path.getFileName().toString(), AsyncReader.build(data),
                                 0,data.length, ctx.network, ctx.crypto, x -> {})
                         .thenApply(fw -> true)
@@ -109,7 +109,7 @@ public class App implements StoreAppData {
 
     private CompletableFuture<Boolean> writeFileContents(Path path, byte[] data) {
         Path pathWithoutUsername = path.subpath(1, path.getNameCount());
-        return ctx.getByPath(ctx.username).thenCompose(userRoot -> userRoot.get().getOrMkdirs(pathWithoutUsername.getParent(), ctx.network, false, userRoot.get().mirrorBatId(), ctx.crypto)
+        return ctx.getByPath(ctx.username).thenCompose(userRoot -> userRoot.get().getOrMkdirs(pathWithoutUsername.getParent(), ctx.network, false, ctx.mirrorBatId(), ctx.crypto)
                 .thenCompose(dir -> dir.uploadOrReplaceFile(path.getFileName().toString(), AsyncReader.build(data),
                         data.length, ctx.network, ctx.crypto, x -> {})
                         .thenApply(fw -> true)
@@ -187,7 +187,7 @@ public class App implements StoreAppData {
     public CompletableFuture<Boolean> createDirectoryInternal(Path relativePath, String username) {
         Path base = PathUtil.get(username == null ? ctx.username : username).resolve(appDataDirectoryWithoutUser);
         return ctx.getByPath(base)
-                .thenCompose(baseOpt -> baseOpt.get().getOrMkdirs(normalisePath(relativePath), ctx.network, false, baseOpt.get().mirrorBatId(), ctx.crypto)
+                .thenCompose(baseOpt -> baseOpt.get().getOrMkdirs(normalisePath(relativePath), ctx.network, false, ctx.mirrorBatId(), ctx.crypto)
                 .thenApply(fw -> true));
     }
     /*

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -45,8 +45,8 @@ public class IncomingCapCache {
         this.pointerCache = new HashMap<>();
     }
 
-    public static CompletableFuture<IncomingCapCache> build(FileWrapper cacheRoot, Crypto crypto, NetworkAccess network) {
-        return cacheRoot.getOrMkdirs(PathUtil.get(WORLD_ROOT_NAME), network, true, cacheRoot.getPointer().fileAccess.mirrorBatId(), crypto)
+    public static CompletableFuture<IncomingCapCache> build(FileWrapper cacheRoot, Optional<BatId> mirrorBatId, Crypto crypto, NetworkAccess network) {
+        return cacheRoot.getOrMkdirs(PathUtil.get(WORLD_ROOT_NAME), network, true, mirrorBatId, crypto)
                 .thenApply(worldRoot -> new IncomingCapCache(cacheRoot, worldRoot, crypto));
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -124,7 +124,7 @@ public class UserContext {
         return root.getByPath(username, crypto.hasher, network)
                 .thenApply(Optional::get)
                 .thenCompose(home -> home.getOrMkdirs(PathUtil.get(CapabilityStore.CAPABILITY_CACHE_DIR), network, true, mirrorBatId, crypto))
-                .thenCompose(cacheRoot -> IncomingCapCache.build(cacheRoot, crypto, network));
+                .thenCompose(cacheRoot -> IncomingCapCache.build(cacheRoot, mirrorBatId, crypto, network));
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1032,9 +1032,10 @@ public class FileWrapper {
                                                         LocalDateTime.now(), props.created, props.isHidden,
                                                         props.thumbnail, props.streamSecret);
 
+                                                Optional<BatId> mirrorBat = mirrorBatId();
                                                 CompletableFuture<Snapshot> chunkUploaded = FileUploader.uploadChunk(version, committer, us.signingPair(),
                                                         newProps, parentLocation, parentBat, parentParentKey, baseKey, located,
-                                                        nextChunkLocation, nextChunkBat, writerLink, mirrorBatId(),
+                                                        nextChunkLocation, nextChunkBat, writerLink, mirrorBat,
                                                         crypto.random, crypto.hasher, network, monitor);
 
                                                 return chunkUploaded.thenCompose(updatedBase -> {
@@ -1658,10 +1659,10 @@ public class FileWrapper {
                 });
     }
 
-    public CompletableFuture<Snapshot> addMirrorBat(BatId mirrorBat, NetworkAccess network) {
+    public CompletableFuture<Snapshot> addMirrorBat(BatId mirrorBat, boolean addToFragmentsOnly, NetworkAccess network) {
         return network.synchronizer.applyComplexUpdate(owner(), signingPair(),
                 (s, committer) -> getPointer().fileAccess.addMirrorBat(s, committer, writableFilePointer(),
-                        entryWriter, getFileProperties().streamSecret, mirrorBat, network));
+                        entryWriter, getFileProperties().streamSecret, mirrorBat, ! addToFragmentsOnly, network));
     }
 
     public CompletableFuture<Boolean> setProperties(FileProperties updatedProperties,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1658,6 +1658,12 @@ public class FileWrapper {
                 });
     }
 
+    public CompletableFuture<Snapshot> addMirrorBat(BatId mirrorBat, NetworkAccess network) {
+        return network.synchronizer.applyComplexUpdate(owner(), signingPair(),
+                (s, committer) -> getPointer().fileAccess.addMirrorBat(s, committer, writableFilePointer(),
+                        entryWriter, getFileProperties().streamSecret, mirrorBat, network));
+    }
+
     public CompletableFuture<Boolean> setProperties(FileProperties updatedProperties,
                                                     Hasher hasher,
                                                     NetworkAccess network,


### PR DESCRIPTION
Errors were not being logged.

Give DeletableCAS an explicit option to not check auth in internal calls as all implementations had this anyway. Use this to not enforce the auth during mirroring as we might not have the mirror bat committed locally.

Bump version.