### PR TITLE
give sandbox allow-modals permission

### DIFF
--- a/src/peergos/server/net/StaticHandler.java
+++ b/src/peergos/server/net/StaticHandler.java
@@ -143,7 +143,7 @@ public abstract class StaticHandler implements HttpHandler
                         " " + this.host +
                         (isSubdomain ? " 'unsafe-inline' https://" + reqHost : "") + // calendar, editor, todoboard, pdfviewer
                         ";" +
-                        (isSubdomain ? "sandbox allow-same-origin allow-scripts allow-forms;" : "") +
+                        (isSubdomain ? "sandbox allow-same-origin allow-scripts allow-forms allow-modals;" : "") +
                         "frame-src 'self' " + frameDomains.stream().collect(Collectors.joining(" ")) + " " + (isSubdomain ? "" : this.host.wildcard()) + ";" +
                         "frame-ancestors 'self' " + this.host + ";" +
                         "prefetch-src 'self' " + this.host + ";" + // prefetch can be used to leak data via DNS


### PR DESCRIPTION
This is required for apps that want to use print preview (apps create an iframe)