### PR TITLE
Support wildcard listener address

### DIFF
--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -221,8 +221,9 @@ public class UserService {
         if (isPublicServer && publicHostname.isEmpty())
             throw new IllegalStateException("Missing arg public-domain");
         CspHost host = tlsProps.map(p -> new CspHost("https://", p.hostname))
-                .orElse(isPublicServer ?
-                        new CspHost("https://", publicHostname.get())  :
+                .orElse(publicHostname.isPresent() ?
+                        new CspHost(CspHost.isLocal(publicHostname.get()) ?
+                                "http://" : "https://", publicHostname.get())  :
                         new CspHost("http://",  local.getHostName(), local.getPort()));
         StaticHandler handler = webroot.map(p -> (StaticHandler) new FileHandler(host, blockstoreDomains, frameDomains, appSubdomains, p, includeCsp, true, appDevTarget))
                 .orElseGet(() -> new JarHandler(host, blockstoreDomains, frameDomains, appSubdomains, includeCsp, true, PathUtil.get("/webroot"), appDevTarget));

--- a/src/peergos/server/net/CspHost.java
+++ b/src/peergos/server/net/CspHost.java
@@ -7,15 +7,19 @@ public class CspHost {
     public final Optional<String> protocol;
     public final String domain;
     public final Optional<Integer> port;
+    private final String portSuffix;
+    private final boolean isWildcard;
 
     public CspHost(Optional<String> protocol, String domain, Optional<Integer> port) {
         if (protocol.isPresent() && ! protocol.get().equals("http://") && ! protocol.get().equals("https://"))
             throw new IllegalStateException("Protocol must be http:// or https://");
         this.protocol = protocol;
         this.domain = domain;
+        this.isWildcard = domain.equals("0.0.0.0") || domain.equals("[::]");
         if (port.isPresent() && port.map(p -> p < 0 || p >= 65536).get())
             throw new IllegalStateException("Invalid port " + port.get());
         this.port = port;
+        this.portSuffix = port.map(p -> ":" + p).orElse("");
     }
 
     public CspHost(String protocol, String domain) {
@@ -26,8 +30,32 @@ public class CspHost {
         this(Optional.of(protocol), domain, Optional.of(port));
     }
 
+    public static boolean isLocal(String host) {
+        return host.startsWith("localhost");
+    }
+
     public CspHost wildcard() {
         return new CspHost(protocol, "*." + domain, port);
+    }
+
+    public boolean validSubdomain(String reqHost) {
+        if (! reqHost.contains("."))
+            return false;
+        if (! reqHost.endsWith(portSuffix))
+            return false;
+        if (isWildcard)
+            return true;
+        String reqDomain = reqHost.substring(reqHost.indexOf(".") + 1, reqHost.length() - portSuffix.length());
+        return reqDomain.equals(domain);
+    }
+
+
+    public String getSubdomain(String reqHost) {
+        if (! reqHost.contains(".") || ! reqHost.endsWith(portSuffix))
+            return "";
+        if (isWildcard)
+            return reqHost.substring(0, reqHost.lastIndexOf("."));
+        return reqHost.substring(0, reqHost.length() - (1 + domain.length() + portSuffix.length()));
     }
 
     public String host() {
@@ -36,6 +64,6 @@ public class CspHost {
 
     @Override
     public String toString() {
-        return protocol.orElse("") + domain + port.map(p -> ":" + p).orElse("");
+        return protocol.orElse("") + domain + portSuffix;
     }
 }

--- a/src/peergos/server/net/SubdomainHandler.java
+++ b/src/peergos/server/net/SubdomainHandler.java
@@ -4,27 +4,53 @@ import com.sun.net.httpserver.*;
 import peergos.server.util.*;
 
 import java.io.*;
+import java.net.*;
 import java.util.*;
 import java.util.logging.*;
+import java.util.regex.*;
+import java.util.stream.*;
 
 public class SubdomainHandler implements HttpHandler
 {
     private static final Logger LOG = Logging.LOG();
     private final List<String> domains;
     private final HttpHandler handler;
-    private final boolean allowSubdomains;
+    private final boolean allowSubdomains, allowAnyIp4, allowAnyIp6;
+    private final Optional<Pattern> IP4Wildcard;
+    private final int ipv6PortSuffixSize;
 
     public SubdomainHandler(List<String> domains, HttpHandler handler, boolean allowSubdomains) {
-        this.domains = domains;
         this.handler = handler;
         this.allowSubdomains = allowSubdomains;
+        Optional<String> allIp4s = domains.stream().filter(d -> d.startsWith("0.0.0.0")).findAny();
+        this.allowAnyIp4 = allIp4s.isPresent();
+        IP4Wildcard = allIp4s.map(d -> Pattern.compile("\\d+\\.\\d+\\.\\d+\\.\\d+"+d.substring(7)));
+        Optional<String> allIp6s = domains.stream().filter(d -> d.startsWith("[::]")).findAny();
+        this.allowAnyIp6 = allIp6s.isPresent();
+        this.ipv6PortSuffixSize = allIp6s.map(d -> d.substring(4).length()).orElse(0);
+        this.domains = allowAnyIp4 ?
+                Stream.concat(domains.stream(), Stream.of("localhost" + allIp4s.get().substring(7))).collect(Collectors.toList()) :
+                domains;
+    }
+
+    private boolean isIPv6(String ip) {
+        try {
+            if (! ip.substring(0, ip.length() - ipv6PortSuffixSize).contains(":")) // try to avoid DNS lookups
+                return false;
+            return Inet6Address.getByName(ip) instanceof Inet6Address;
+        } catch (UnknownHostException e) {
+            return false;
+        }
     }
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         List<String> hostHeaders = exchange.getRequestHeaders().get("Host");
         if (hostHeaders.isEmpty() || (hostHeaders.size() == 1 &&
-                domains.contains(hostHeaders.get(0)))) {
+                (domains.contains(hostHeaders.get(0))
+                        || (allowAnyIp4 && IP4Wildcard.get().matcher(hostHeaders.get(0)).matches())
+                        || (allowAnyIp6 && isIPv6(hostHeaders.get(0)))
+                ))) {
             handler.handle(exchange);
         } else if (allowSubdomains && hostHeaders.size() == 1 &&
                 domains.stream().anyMatch(d -> hostHeaders.get(0).endsWith(d))) {


### PR DESCRIPTION
This is mainly useful in docker where proxied connections come in on random non local ips

So you can run with -domain 0.0.0.0 -public-domain localhost:8000
if docker is set to proxy localhost:8000 to peergos.