### PR TITLE
Optimise cacheless delete

### DIFF
--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -129,7 +129,7 @@ public class DHTHandler implements HttpHandler {
                             Optional.of(BatWithId.decode(last.apply("bat"))) :
                             Optional.empty();
                     try {
-                        dht.getChampLookup(ownerHash, root, champKey, bat).thenAccept(blocks -> {
+                        dht.getChampLookup(ownerHash, root, champKey, bat, Optional.empty()).thenAccept(blocks -> {
                             replyBytes(httpExchange, new CborObject.CborList(blocks.stream()
                                     .map(CborObject.CborByteArray::new).collect(Collectors.toList())).serialize(), Optional.of(root));
                         }).exceptionally(Futures::logAndThrow).get();

--- a/src/peergos/server/storage/AuthedStorage.java
+++ b/src/peergos/server/storage/AuthedStorage.java
@@ -84,10 +84,10 @@ public class AuthedStorage extends DelegatingStorage implements DeletableContent
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(root, champKey, bat, h);
+        return getChampLookup(root, champKey, bat, committedRoot, h);
     }
 
     @Override

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -92,9 +92,9 @@ public class DelayingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         sleep(4*readDelay);
-        return source.getChampLookup(owner, root, champKey, bat);
+        return source.getChampLookup(owner, root, champKey, bat, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -146,8 +146,8 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return target.getChampLookup(owner, root, champKey, bat);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, champKey, bat, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -69,10 +69,10 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(root, champKey, bat, hasher);
+        return getChampLookup(root, champKey, bat, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/storage/MetadataCachingStorage.java
+++ b/src/peergos/server/storage/MetadataCachingStorage.java
@@ -60,8 +60,8 @@ public class MetadataCachingStorage extends DelegatingDeletableStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return target.getChampLookup(owner, root, champKey, bat).thenApply(blocks -> {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, champKey, bat,committedRoot).thenApply(blocks -> {
             for (byte[] block : blocks) {
                 cacheBlockMetadata(block, false);
             }

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -41,8 +41,8 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return modifications.getChampLookup(owner, root, champKey, bat);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat,Optional<Cid> committedRoot) {
+        return modifications.getChampLookup(owner, root, champKey, bat, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -49,8 +49,8 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return getChampLookup(root, champKey, bat, hasher);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return getChampLookup(root, champKey, bat, committedRoot,hasher);
     }
 
     @Override

--- a/src/peergos/server/storage/RequestCountingStorage.java
+++ b/src/peergos/server/storage/RequestCountingStorage.java
@@ -64,8 +64,8 @@ public class RequestCountingStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return target.getChampLookup(owner, root, champKey, bat)
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, champKey, bat, committedRoot)
                 .thenApply(blocks -> {
                     champGet.incrementAndGet();
                     return blocks;

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -424,10 +424,10 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat,Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(root, champKey, bat, hasher);
+        return getChampLookup(root, champKey, bat, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -103,10 +103,11 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
                                                           Cid root,
                                                           byte[] champKey,
-                                                          Optional<BatWithId> bat) {
+                                                          Optional<BatWithId> bat,
+                                                          Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(root, champKey, bat, hasher);
+        return getChampLookup(root, champKey, bat, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/tests/RequestCountTests.java
+++ b/src/peergos/server/tests/RequestCountTests.java
@@ -87,7 +87,7 @@ public class RequestCountTests {
             boolean reciprocate = true;
             a.sendReplyFollowRequest(u1Request, accept, reciprocate).join();
         }
-        Assert.assertTrue("send reply follow request: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 22);
+        Assert.assertTrue("send reply follow request: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 23);
 
         // complete the friendship connection
         storageCounter.reset();
@@ -103,7 +103,7 @@ public class RequestCountTests {
         // check 'a' can see the shared file in their social feed
         storageCounter.reset();
         SocialFeed feed = a.getSocialFeed().join();
-        Assert.assertTrue("initialise social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 20);
+        Assert.assertTrue("initialise social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 30);
         int feedSize = 2;
 
         storageCounter.reset();
@@ -130,7 +130,7 @@ public class RequestCountTests {
             Pair<Path, FileWrapper> p = sharerFeed.createNewPost(post).join();
             sharer.shareReadAccessWith(p.left, Set.of(friends)).join();
         }
-        Assert.assertTrue("Adding a post to social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 20);
+        Assert.assertTrue("Adding a post to social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 5);
         a.getSocialFeed().join().update().join();
 
         // share more items
@@ -142,7 +142,7 @@ public class RequestCountTests {
 
         storageCounter.reset();
         SocialFeed feed2 = a.getSocialFeed().join().update().join();
-        Assert.assertTrue("load 5 items in social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 18);
+        Assert.assertTrue("load 5 items in social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 22);
 
         storageCounter.reset();
         List<SharedItem> items2 = feed2.getShared(feedSize + 1, feedSize + 6, a.crypto, a.network).join();

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -111,7 +111,7 @@ public class RetryStorageTests {
         }
 
         @Override
-        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
             if(counter++ % retryLimit != 0) {
                 return CompletableFuture.failedFuture(new Error("failure!"));
             }else {

--- a/src/peergos/server/util/JavaPoster.java
+++ b/src/peergos/server/util/JavaPoster.java
@@ -97,8 +97,9 @@ public class JavaPoster implements HttpPoster {
             if (basicAuth.isPresent())
                 headers.put("Authorization", basicAuth.get());
             Multipart mPost = new Multipart(buildURL(url).toString(), "UTF-8", headers);
+            int i = 0;
             for (byte[] file : files)
-                mPost.addFilePart("file", new NamedStreamable.ByteArrayWrapper(file));
+                mPost.addFilePart("file" + i++, new NamedStreamable.ByteArrayWrapper(file));
             return CompletableFuture.completedFuture(mPost.finish().getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/peergos/server/util/JavaPoster.java
+++ b/src/peergos/server/util/JavaPoster.java
@@ -98,8 +98,10 @@ public class JavaPoster implements HttpPoster {
                 headers.put("Authorization", basicAuth.get());
             Multipart mPost = new Multipart(buildURL(url).toString(), "UTF-8", headers);
             int i = 0;
-            for (byte[] file : files)
-                mPost.addFilePart("file" + i++, new NamedStreamable.ByteArrayWrapper(file));
+            for (byte[] file : files) {
+                String fieldName = "file" + i++;
+                mPost.addFilePart(fieldName, new NamedStreamable.ByteArrayWrapper(Optional.of(fieldName), file));
+            }
             return CompletableFuture.completedFuture(mPost.finish().getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -4,12 +4,15 @@ import peergos.shared.corenode.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.cid.*;
+import peergos.shared.io.ipfs.multihash.*;
 import peergos.shared.mutable.*;
 import peergos.shared.social.*;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.storage.controller.*;
 import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.user.fs.cryptree.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -130,6 +133,14 @@ public class BufferedNetworkAccess extends NetworkAccess {
     public NetworkAccess withCorenode(CoreNode newCore) {
         return new BufferedNetworkAccess(blockBuffer, pointerBuffer, bufferSize, newCore, account, social, dhtClient,
                 mutable, batCave, batCache, tree, synchronizer, instanceAdmin, spaceUsage, serverMessager, hasher, usernames, isJavascript());
+    }
+
+    public CompletableFuture<Optional<CryptreeNode>> getMetadata(WriterData base, AbsoluteCapability cap) {
+        return (pointerBuffer.isEmpty() ?
+                hasher.sha256(base.serialize())
+                        .thenApply(h ->  Optional.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, h))) :
+                Futures.of(pointerBuffer.getCommittedPointerTarget(cap.writer)))
+                .thenCompose(committed -> super.getMetadata(base, cap, committed));
     }
 
     public boolean isFull() {

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -554,7 +554,6 @@ public class NetworkAccess {
                         .thenApply(c -> c.map(x -> x.target))
                         .thenCompose(btreeValue -> {
                             if (btreeValue.isPresent()) {
-                                System.out.println("Getting champ value " + DirectS3BlockStore.hashToKey(btreeValue.get()));
                                 return dhtClient.get((Cid) btreeValue.get(), bat)
                                         .thenApply(value -> value.map(cbor -> CryptreeNode.fromCbor(cbor, cap.rBaseKey, btreeValue.get())))
                                         .thenApply(res -> {

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -187,7 +187,7 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         return Futures.of(new ArrayList<>(storage.values()));
     }
 

--- a/src/peergos/shared/mutable/BufferedPointers.java
+++ b/src/peergos/shared/mutable/BufferedPointers.java
@@ -43,6 +43,13 @@ public class BufferedPointers implements MutablePointers {
         this.target = target;
     }
 
+    public Optional<Cid> getCommittedPointerTarget(PublicKeyHash writer) {
+        return writerUpdates.stream()
+                .filter(u ->  u.writer.equals(writer)).map(u -> u.prevHash)
+                .findFirst()
+                .flatMap(m -> m.toOptional().map(h ->  (Cid) h));
+    }
+
     public List<WriterUpdate> getUpdates() {
         return writerUpdates;
     }

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -60,30 +60,21 @@ public class BufferedStorage extends DelegatingStorage {
                                                           Optional<BatWithId> bat,
                                                           Optional<Cid> committedRoot) {
         if (storage.isEmpty())
-            return target.getChampLookup(owner, root, champKey, bat, committedRoot).thenApply(x -> {
-                System.out.println("BufferedStorage::getChampLookup END");
-                return x;
-            });
+            return target.getChampLookup(owner, root, champKey, bat, committedRoot);
         // If we are in a write transaction try to perform a local champ lookup from the buffer,
         // falling back to a direct champ get
         return Futures.asyncExceptionally(
                 () -> getChampLookup(owner, root, champKey, bat, committedRoot, hasher),
                 t -> target.getChampLookup(owner, root, champKey, bat, committedRoot)
-        ).thenApply(x -> {
-            System.out.println("BufferedStorage::getChampLookup END");
-            return x;
-        });
+        );
     }
 
-//    @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
                                                           Cid root,
                                                           byte[] champKey,
                                                           Optional<BatWithId> bat,
                                                           Optional<Cid> committedRoot,
                                                           Hasher hasher) {
-        System.out.println("BufferedStorage::getChampLookup " + root);
-
         CachingStorage cache = new CachingStorage(new LocalOnlyStorage(new BlockCache() {
             Map<Cid, byte[]> localCache = new HashMap<>();
             @Override

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -54,28 +54,75 @@ public class BufferedStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
+                                                          Cid root,
+                                                          byte[] champKey,
+                                                          Optional<BatWithId> bat,
+                                                          Optional<Cid> committedRoot) {
         if (storage.isEmpty())
-            return target.getChampLookup(owner, root, champKey, bat);
+            return target.getChampLookup(owner, root, champKey, bat, committedRoot).thenApply(x -> {
+                System.out.println("BufferedStorage::getChampLookup END");
+                return x;
+            });
         // If we are in a write transaction try to perform a local champ lookup from the buffer,
         // falling back to a direct champ get
         return Futures.asyncExceptionally(
-                () -> getChampLookup(root, champKey, bat, hasher),
-                t -> target.getChampLookup(owner, root, champKey, bat)
-        );
+                () -> getChampLookup(owner, root, champKey, bat, committedRoot, hasher),
+                t -> target.getChampLookup(owner, root, champKey, bat, committedRoot)
+        ).thenApply(x -> {
+            System.out.println("BufferedStorage::getChampLookup END");
+            return x;
+        });
     }
 
-    @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(Cid root, byte[] champKey, Optional<BatWithId> bat, Hasher hasher) {
-        CachingStorage cache = new CachingStorage(this, 100, 100 * 1024);
-        return ChampWrapper.create((Cid)root, x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
-                        .thenCompose(tree -> tree.get(champKey))
-                        .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
-                        .thenApply(btreeValue -> {
-                            if (btreeValue.isPresent())
-                                return cache.get((Cid) btreeValue.get(), bat);
-                            return Optional.empty();
-                        }).thenApply(x -> new ArrayList<>(cache.getCached()));
+//    @Override
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
+                                                          Cid root,
+                                                          byte[] champKey,
+                                                          Optional<BatWithId> bat,
+                                                          Optional<Cid> committedRoot,
+                                                          Hasher hasher) {
+        System.out.println("BufferedStorage::getChampLookup " + root);
+
+        CachingStorage cache = new CachingStorage(new LocalOnlyStorage(new BlockCache() {
+            Map<Cid, byte[]> localCache = new HashMap<>();
+            @Override
+            public CompletableFuture<Boolean> put(Cid hash, byte[] data) {
+                localCache.put(hash, data);
+                return Futures.of(true);
+            }
+
+            @Override
+            public CompletableFuture<Optional<byte[]>> get(Cid hash) {
+                return Futures.of(Optional.ofNullable(storage.get(hash))
+                        .map(b -> b.block)
+                        .or(() -> Optional.ofNullable(localCache.get(hash))));
+            }
+
+            @Override
+            public boolean hasBlock(Cid hash) {
+                return storage.containsKey(hash) || localCache.containsKey(hash);
+            }
+
+            @Override
+            public CompletableFuture<Boolean> clear() {
+                throw new IllegalStateException("Unimplemented!");
+            }
+        },
+                () -> committedRoot.isPresent() ?
+                        get(committedRoot.get(), Optional.empty())
+                                .thenApply(ropt -> ropt.map(WriterData::fromCbor).flatMap(wd ->  wd.tree))
+                                .thenCompose(champRoot -> target.getChampLookup(owner, (Cid) champRoot.get(), champKey, bat, Optional.empty())) :
+                        target.getChampLookup(owner, root, champKey, bat, Optional.empty()), hasher),
+                100, 1024 * 1024);
+        return ChampWrapper.create(root, x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
+                .thenCompose(tree -> tree.get(champKey))
+                .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
+                .thenApply(btreeValue -> {
+                    if (btreeValue.isPresent())
+                        return cache.get((Cid) btreeValue.get(), bat);
+                    return Optional.empty();
+                }).thenApply(x -> new ArrayList<>(cache.getCached()));
     }
 
     @Override

--- a/src/peergos/shared/storage/CachingVerifyingStorage.java
+++ b/src/peergos/shared/storage/CachingVerifyingStorage.java
@@ -84,8 +84,8 @@ public class CachingVerifyingStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return target.getChampLookup(owner, root, champKey, bat)
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, champKey, bat,committedRoot)
                 .thenCompose(blocks -> Futures.combineAllInOrder(blocks.stream()
                         .map(b -> hasher.hash(b, false)
                                 .thenApply(h -> cache(h, b)))

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -372,7 +372,6 @@ public interface ContentAddressedStorage {
             if (! isPeergosServer) {
                 return getChampLookup(root, champKey, bat, committedRoot, hasher);
             }
-            System.out.println("HTTP champ.get " + root + "::" + ArrayOps.bytesToHex(champKey));
             return poster.get(apiPrefix + CHAMP_GET + "?arg=" + root.toString()
                     + "&arg=" + ArrayOps.bytesToHex(champKey)
                     + "&owner=" + encode(owner.toString())

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -417,7 +417,7 @@ public interface ContentAddressedStorage {
             // support more than one, and to maximise use of browsers 5 connections.
             //int FRAGMENTs_PER_QUERY = isPeergosServer ? (blocks.size() > 10 ? 10 : 1) : 1;
             // multi fragment seems to break things, for now just use 1
-            int FRAGMENTs_PER_QUERY = isPeergosServer ? 10 : 1;
+            int FRAGMENTs_PER_QUERY = isPeergosServer ? 1 : 1;
             List<List<byte[]>> grouped = ArrayOps.group(blocks, FRAGMENTs_PER_QUERY);
             List<List<byte[]>> groupedSignatures = ArrayOps.group(signatures, FRAGMENTs_PER_QUERY);
             List<Integer> sizes = grouped.stream()

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -70,8 +70,8 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return target.getChampLookup(owner, root, champKey, bat);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, champKey, bat, committedRoot);
     }
 
     @Override

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -317,13 +317,13 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         return Futures.asyncExceptionally(
-                () -> fallback.getChampLookup(owner, root, champKey, bat),
+                () -> fallback.getChampLookup(owner, root, champKey, bat, committedRoot),
                 t -> {
                     if (!(t instanceof RateLimitException))
                         return Futures.errored(t);
-                    return getChampLookup(root, champKey, bat, hasher);
+                    return getChampLookup(root, champKey, bat, committedRoot, hasher);
                 });
     }
 }

--- a/src/peergos/shared/storage/LocalOnlyStorage.java
+++ b/src/peergos/shared/storage/LocalOnlyStorage.java
@@ -30,7 +30,6 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
                 .thenCompose(opt -> {
                     if (opt.isPresent())
                         return Futures.of(opt);
-                    System.out.println("Bulk fetcher call, missing " + hash);
                     return bulkFetcher.get()
                             .thenCompose(blocks -> Futures.combineAll(blocks.stream().map(data ->
                                             h.sha256(data).thenApply(hashb -> cache.put(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, hashb), data)))

--- a/src/peergos/shared/storage/PeergosBackedStorage.java
+++ b/src/peergos/shared/storage/PeergosBackedStorage.java
@@ -131,7 +131,7 @@ public class PeergosBackedStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         return Futures.of(Collections.emptyList());
     }
 

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -125,8 +125,8 @@ public class RetryStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat) {
-        return runWithRetry(() -> target.getChampLookup(owner, root, champKey, bat));
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        return runWithRetry(() -> target.getChampLookup(owner, root, champKey, bat,committedRoot));
     }
 
     @Override

--- a/src/peergos/shared/storage/UnauthedCachingStorage.java
+++ b/src/peergos/shared/storage/UnauthedCachingStorage.java
@@ -100,15 +100,10 @@ public class UnauthedCachingStorage extends DelegatingStorage {
                                                             Optional<BatWithId> bat,
                                                             Optional<Cid> committedRoot,
                                                             Hasher hasher) {
-        System.out.println("UCS::localChampLookup");
         CachingStorage cache = new CachingStorage(new LocalOnlyStorage(this.cache,
                 () -> (committedRoot.isPresent() ?
                         get(committedRoot.get(), Optional.empty())
                                 .thenApply(ropt -> ropt.map(WriterData::fromCbor).flatMap(wd ->  wd.tree))
-                                .thenApply(x -> {
-                                    System.out.println("UCS::localChampLookup got WriterData");
-                                    return x;
-                                })
                                 .thenCompose(champRoot -> target.getChampLookup(owner, (Cid) champRoot.get(), champKey, bat, Optional.empty())) :
                         target.getChampLookup(owner, root, champKey, bat, Optional.empty()))
                         .thenApply(blocks -> cacheBlocks(blocks, hasher)), hasher),
@@ -117,7 +112,6 @@ public class UnauthedCachingStorage extends DelegatingStorage {
                 .thenCompose(tree -> tree.get(champKey))
                 .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
                 .thenApply(btreeValue -> {
-                    System.out.println("UCS::localChampLookup get value block");
                     if (btreeValue.isPresent())
                         return cache.get((Cid) btreeValue.get(), bat);
                     return Optional.empty();

--- a/src/peergos/shared/storage/UnauthedCachingStorage.java
+++ b/src/peergos/shared/storage/UnauthedCachingStorage.java
@@ -79,19 +79,10 @@ public class UnauthedCachingStorage extends DelegatingStorage {
                                                           byte[] champKey,
                                                           Optional<BatWithId> bat,
                                                           Optional<Cid> committedRoot) {
-        System.out.println("UCS::getChampLookup " + root + "::" + ArrayOps.bytesToHex(champKey));
         return Futures.asyncExceptionally(
                 () -> localChampLookup(owner, root, champKey, bat, committedRoot, hasher),
-                t -> {
-                    System.out.println("UCS::getChampLookup error clause " + t.getMessage());
-                    t.printStackTrace();
-                    return target.getChampLookup(owner, root, champKey, bat,  committedRoot)
-                            .thenApply(blocks -> cacheBlocks(blocks, hasher));
-                }
-        ).thenApply(x -> {
-            System.out.println("UCS::getChampLookup END");
-            return x;
-        });
+                t -> target.getChampLookup(owner, root, champKey, bat,  committedRoot)
+                        .thenApply(blocks -> cacheBlocks(blocks, hasher)));
     }
 
     public CompletableFuture<List<byte[]>> localChampLookup(PublicKeyHash owner,


### PR DESCRIPTION
Doing a delete with an empty cache (e.g. on a new device
currently is very slow because it tries to do a champ get for each
file/chunk from the local cache, which falls back to sequential
block gets.

This PR makes it do a full champ get from the last committed root.

We could still improve much further by prefetching these champ
gets in parallel.

I'm not happy with the champ.get signature change which feels like an implementation detail, but the alternative would be to merge BufferedStorage and UnauthedCachingStorage plus BufferedNetworkAccess, which also doesn't feel  right.