### PR TITLE
Store bats in block metadata store

### DIFF
--- a/.github/actions/local-s3/action.yml
+++ b/.github/actions/local-s3/action.yml
@@ -13,14 +13,14 @@ runs:
         echo 'MINIO_ROOT_USER=test' >> $GITHUB_ENV
         echo 'MINIO_ROOT_PASSWORD=testdslocal' >> $GITHUB_ENV
         if [[ '${{ runner.os }}' == 'Linux' ]]; then
-          echo '::set-output name=release::linux-amd64'
-          echo '::set-output name=home::/usr/local/bin'
+          echo 'release=linux-amd64' >> $GITHUB_OUTPUT
+          echo 'home=/usr/local/bin' >> $GITHUB_OUTPUT
         elif [[ '${{ runner.os }}' == 'Windows' ]]; then
-          echo '::set-output name=release::windows-amd64'
-          echo "::set-output name=home::/usr/bin"
+          echo 'release=windows-amd64' >> $GITHUB_OUTPUT
+          echo "home=/usr/bin" >> $GITHUB_OUTPUT
         elif [[ '${{ runner.os }}' == 'macOS' ]]; then
-          echo '::set-output name=release::darwin-amd64'
-          echo '::set-output name=home::/usr/local/bin'
+          echo 'release=darwin-amd64' >> $GITHUB_OUTPUT
+          echo 'home=/usr/local/bin' >> $GITHUB_OUTPUT
         fi
     - name: Download minio
       shell: bash

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -189,7 +189,7 @@ public class Builder {
 
     private static SqliteBlockMetadataStorage buildBlockMetadata(Args a) {
         try {
-            File metaFile = a.fromPeergosDir("block-metadata-sql-file", "blockmetadata.sql").toFile();
+            File metaFile = a.fromPeergosDir("block-metadata-sql-file", "blockmetadata-v2.sql").toFile();
             Connection instance = new Sqlite.UncloseableConnection(Sqlite.build(metaFile.getPath()));
             int maxMetadataStoreSize = a.getInt("max-block-metadata-store-size", 0); // 0 means unlimited
             return new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), maxMetadataStoreSize, metaFile);

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -191,8 +191,7 @@ public class Builder {
         try {
             File metaFile = a.fromPeergosDir("block-metadata-sql-file", "blockmetadata-v2.sql").toFile();
             Connection instance = new Sqlite.UncloseableConnection(Sqlite.build(metaFile.getPath()));
-            int maxMetadataStoreSize = a.getInt("max-block-metadata-store-size", 0); // 0 means unlimited
-            return new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), maxMetadataStoreSize, metaFile);
+            return new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), metaFile);
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -244,7 +244,9 @@ public class Builder {
                         hasher, p2pBlockRetriever, bloomTarget);
                 return new MetadataCachingStorage(s3, metadata, hasher);
             } else {
-                return new FileContentAddressedStorage(blockstorePath(a), transactions, authoriser, hasher);
+                SqliteBlockMetadataStorage metadata = buildBlockMetadata(a);
+                FileContentAddressedStorage fileBacked = new FileContentAddressedStorage(blockstorePath(a), transactions, authoriser, hasher);
+                return new MetadataCachingStorage(fileBacked, metadata, hasher);
             }
         }
     }

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -6,9 +6,7 @@ import peergos.server.crypto.*;
 import peergos.server.crypto.asymmetric.curve25519.*;
 import peergos.server.crypto.hash.*;
 import peergos.server.crypto.random.*;
-import peergos.server.crypto.symmetric.*;
 import peergos.server.login.*;
-import peergos.server.mutable.*;
 import peergos.server.space.*;
 import peergos.server.sql.*;
 import peergos.server.storage.*;
@@ -69,33 +67,36 @@ public class Builder {
         return getDBConnector(a, dbName);
     }
 
+    public static Supplier<Connection> getPostgresConnector(Args a, String prefix) {
+        String postgresHost = a.getArg(prefix + "postgres.host");
+        int postgresPort = a.getInt(prefix + "postgres.port", 5432);
+        String databaseName = a.getArg(prefix + "postgres.database", "peergos");
+        String postgresUsername = a.getArg(prefix + "postgres.username");
+        String postgresPassword = a.getArg(prefix + "postgres.password");
+
+        Properties props = new Properties();
+        props.setProperty("dataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
+        props.setProperty("dataSource.serverName", postgresHost);
+        props.setProperty("dataSource.portNumber", "" + postgresPort);
+        props.setProperty("dataSource.user", postgresUsername);
+        props.setProperty("dataSource.password", postgresPassword);
+        props.setProperty("dataSource.databaseName", databaseName);
+        HikariConfig config = new HikariConfig(props);
+        HikariDataSource ds = new HikariDataSource(config);
+
+        return () -> {
+            try {
+                return ds.getConnection();
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
     public static Supplier<Connection> getDBConnector(Args a, String dbName) {
         boolean usePostgres = a.getBoolean("use-postgres", false);
-        HikariConfig config;
         if (usePostgres) {
-            String postgresHost = a.getArg("postgres.host");
-            int postgresPort = a.getInt("postgres.port", 5432);
-            String databaseName = a.getArg("postgres.database", "peergos");
-            String postgresUsername = a.getArg("postgres.username");
-            String postgresPassword = a.getArg("postgres.password");
-
-            Properties props = new Properties();
-            props.setProperty("dataSourceClassName", "org.postgresql.ds.PGSimpleDataSource");
-            props.setProperty("dataSource.serverName", postgresHost);
-            props.setProperty("dataSource.portNumber", "" + postgresPort);
-            props.setProperty("dataSource.user", postgresUsername);
-            props.setProperty("dataSource.password", postgresPassword);
-            props.setProperty("dataSource.databaseName", databaseName);
-            config = new HikariConfig(props);
-            HikariDataSource ds = new HikariDataSource(config);
-
-            return () -> {
-                try {
-                    return ds.getConnection();
-                } catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            };
+            return getPostgresConnector(a, "");
         } else {
             String sqlFilePath = Sqlite.getDbPath(a, dbName);
             if (":memory:".equals(sqlFilePath))
@@ -187,11 +188,16 @@ public class Builder {
         return new BlockStoreProperties(directWrites, publicReads, authedReads, publicReadUrl, authedUrl);
     }
 
-    private static SqliteBlockMetadataStorage buildBlockMetadata(Args a) {
+    public static BlockMetadataStore buildBlockMetadata(Args a) {
         try {
-            File metaFile = a.fromPeergosDir("block-metadata-sql-file", "blockmetadata-v2.sql").toFile();
-            Connection instance = new Sqlite.UncloseableConnection(Sqlite.build(metaFile.getPath()));
-            return new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), metaFile);
+            boolean usePostgres = a.getArg("block-metadata-db-type", "sqlite").equals("postgres");
+            if (usePostgres) {
+                return new JdbcBlockMetadataStore(getPostgresConnector(a, "metadb."), new PostgresCommands());
+            } else {
+                File metaFile = a.fromPeergosDir("block-metadata-sql-file", "blockmetadata-v2.sql").toFile();
+                Connection instance = new Sqlite.UncloseableConnection(Sqlite.build(metaFile.getPath()));
+                return new JdbcBlockMetadataStore(() -> instance, new SqliteCommands());
+            }
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }

--- a/src/peergos/server/net/CoreNodeHandler.java
+++ b/src/peergos/server/net/CoreNodeHandler.java
@@ -103,6 +103,7 @@ public class CoreNodeHandler implements HttpHandler
             exchange.sendResponseHeaders(200, b.length);
             exchange.getResponseBody().write(b);
         } catch (Exception e) {
+            e.printStackTrace();
             HttpUtil.replyError(exchange, e);
         } finally {
             exchange.close();

--- a/src/peergos/server/net/DHTHandler.java
+++ b/src/peergos/server/net/DHTHandler.java
@@ -89,7 +89,7 @@ public class DHTHandler implements HttpHandler {
                             .map(x -> x.intValue())
                             .collect(Collectors.toList());
                     boolean isRaw = Boolean.parseBoolean(last.apply("raw"));
-                    dht.authWrites(ownerHash, writerHash, signatures, blockSizes, isRaw, tid).thenAccept(res -> {
+                    dht.authWrites(ownerHash, writerHash, signatures, blockSizes, req.batIds, isRaw, tid).thenAccept(res -> {
                         replyBytes(httpExchange, new CborObject.CborList(res).serialize(), Optional.empty());
                     }).exceptionally(Futures::logAndThrow).get();
                     break;

--- a/src/peergos/server/sql/PostgresCommands.java
+++ b/src/peergos/server/sql/PostgresCommands.java
@@ -19,6 +19,11 @@ public class PostgresCommands implements SqlSupplier {
     }
 
     @Override
+    public String addMetadataCommand() {
+        return "INSERT INTO blockmetadata (cid, version, size, links, batids) VALUES(?, ?, ?, ?, ?) ON CONFLICT DO NOTHING;";
+    }
+
+    @Override
     public String createFollowRequestsTableCommand() {
         return "CREATE TABLE IF NOT EXISTS followrequests (id serial primary key, " +
                 "name text not null, followrequest text not null);";

--- a/src/peergos/server/sql/PostgresCommands.java
+++ b/src/peergos/server/sql/PostgresCommands.java
@@ -3,6 +3,11 @@ package peergos.server.sql;
 public class PostgresCommands implements SqlSupplier {
 
     @Override
+    public String vacuumCommand() {
+        return "";
+    }
+
+    @Override
     public String listTablesCommand() {
         return "SELECT tablename FROM pg_catalog.pg_tables " +
                 "WHERE schemaname != 'pg_catalog' AND schemaname != 'information_schema';";

--- a/src/peergos/server/sql/SqlSupplier.java
+++ b/src/peergos/server/sql/SqlSupplier.java
@@ -68,8 +68,8 @@ public interface SqlSupplier {
         return "CREATE TABLE IF NOT EXISTS blockmetadata (cid " + getByteArrayType() + " primary key not null, " +
                 "size " + sqlInteger() + " not null, " +
                 "links " + getByteArrayType() + " not null, " +
-                "accesstime " + sqlInteger() + " not null); " +
-                "CREATE INDEX IF NOT EXISTS blockmetadata_accessindex ON blockmetadata (accesstime);";
+                "batids " + getByteArrayType() + " not null, " +
+                "accesstime " + sqlInteger() + " not null);";
     }
 
     default String createServerMessageTableCommand() {

--- a/src/peergos/server/sql/SqlSupplier.java
+++ b/src/peergos/server/sql/SqlSupplier.java
@@ -66,10 +66,10 @@ public interface SqlSupplier {
 
     default String createBlockMetadataStoreTableCommand() {
         return "CREATE TABLE IF NOT EXISTS blockmetadata (cid " + getByteArrayType() + " primary key not null, " +
+                "version varchar(160)," +
                 "size " + sqlInteger() + " not null, " +
                 "links " + getByteArrayType() + " not null, " +
-                "batids " + getByteArrayType() + " not null, " +
-                "accesstime " + sqlInteger() + " not null);";
+                "batids " + getByteArrayType() + " not null);";
     }
 
     default String createServerMessageTableCommand() {

--- a/src/peergos/server/sql/SqlSupplier.java
+++ b/src/peergos/server/sql/SqlSupplier.java
@@ -20,6 +20,8 @@ public interface SqlSupplier {
 
     String ensureColumnExistsCommand(String table, String column, String type);
 
+    String vacuumCommand();
+
     default String createMutablePointersTableCommand() {
         return "CREATE TABLE IF NOT EXISTS metadatablobs (writingkey text primary key not null, hash text not null); " +
                 "CREATE UNIQUE INDEX IF NOT EXISTS index_name ON metadatablobs (writingkey);";

--- a/src/peergos/server/sql/SqlSupplier.java
+++ b/src/peergos/server/sql/SqlSupplier.java
@@ -20,6 +20,8 @@ public interface SqlSupplier {
 
     String ensureColumnExistsCommand(String table, String column, String type);
 
+    String addMetadataCommand();
+
     String vacuumCommand();
 
     default String createMutablePointersTableCommand() {

--- a/src/peergos/server/sql/SqliteCommands.java
+++ b/src/peergos/server/sql/SqliteCommands.java
@@ -18,6 +18,11 @@ public class SqliteCommands implements SqlSupplier {
     }
 
     @Override
+    public String addMetadataCommand() {
+        return "INSERT OR IGNORE INTO blockmetadata (cid, version, size, links, batids) VALUES(?, ?, ?, ?, ?);";
+    }
+
+    @Override
     public String createFollowRequestsTableCommand() {
         return "CREATE TABLE IF NOT EXISTS followrequests (id integer primary key autoincrement, " +
                 "name text not null, followrequest text not null);";

--- a/src/peergos/server/sql/SqliteCommands.java
+++ b/src/peergos/server/sql/SqliteCommands.java
@@ -3,6 +3,11 @@ package peergos.server.sql;
 public class SqliteCommands implements SqlSupplier {
 
     @Override
+    public String vacuumCommand() {
+        return "VACUUM;";
+    }
+
+    @Override
     public String listTablesCommand() {
         return "SELECT NAME FROM sqlite_master WHERE type='table';";
     }

--- a/src/peergos/server/storage/AuthedStorage.java
+++ b/src/peergos/server/storage/AuthedStorage.java
@@ -96,7 +96,7 @@ public class AuthedStorage extends DelegatingStorage implements DeletableContent
     }
 
     @Override
-    public Stream<Pair<Cid, String>> getAllBlockHashVersions() {
+    public Stream<BlockVersion> getAllBlockHashVersions() {
         return target.getAllBlockHashVersions();
     }
 

--- a/src/peergos/server/storage/BlockMetadata.java
+++ b/src/peergos/server/storage/BlockMetadata.java
@@ -1,6 +1,7 @@
 package peergos.server.storage;
 
 import peergos.shared.io.ipfs.cid.*;
+import peergos.shared.storage.auth.*;
 
 import java.util.*;
 
@@ -8,9 +9,11 @@ public class BlockMetadata {
 
     public final int size;
     public final List<Cid> links;
+    public final List<BatId> batids;
 
-    public BlockMetadata(int size, List<Cid> links) {
+    public BlockMetadata(int size, List<Cid> links, List<BatId> batids) {
         this.size = size;
         this.links = links;
+        this.batids = batids;
     }
 }

--- a/src/peergos/server/storage/BlockMetadataStore.java
+++ b/src/peergos/server/storage/BlockMetadataStore.java
@@ -19,6 +19,8 @@ public interface BlockMetadataStore {
 
     Stream<BlockVersion> list();
 
+    Stream<BlockVersion> listCbor();
+
     default BlockMetadata put(Cid block, String version, byte[] data) {
         BlockMetadata meta = extractMetadata(block, data);
         put(block, version, meta);

--- a/src/peergos/server/storage/BlockMetadataStore.java
+++ b/src/peergos/server/storage/BlockMetadataStore.java
@@ -11,15 +11,17 @@ public interface BlockMetadataStore {
 
     Optional<BlockMetadata> get(Cid block);
 
-    void put(Cid block, BlockMetadata meta);
+    void put(Cid block, String version, BlockMetadata meta);
 
     void remove(Cid block);
 
-    Stream<Cid> list();
+    long size();
 
-    default BlockMetadata put(Cid block, byte[] data) {
+    Stream<BlockVersion> list();
+
+    default BlockMetadata put(Cid block, String version, byte[] data) {
         BlockMetadata meta = extractMetadata(block, data);
-        put(block, meta);
+        put(block, version, meta);
         return meta;
     }
 

--- a/src/peergos/server/storage/BlockMetadataStore.java
+++ b/src/peergos/server/storage/BlockMetadataStore.java
@@ -15,6 +15,8 @@ public interface BlockMetadataStore {
 
     void remove(Cid block);
 
+    Stream<Cid> list();
+
     default BlockMetadata put(Cid block, byte[] data) {
         BlockMetadata meta = extractMetadata(block, data);
         put(block, meta);

--- a/src/peergos/server/storage/BlockMetadataStore.java
+++ b/src/peergos/server/storage/BlockMetadataStore.java
@@ -2,6 +2,7 @@ package peergos.server.storage;
 
 import peergos.shared.cbor.*;
 import peergos.shared.io.ipfs.cid.*;
+import peergos.shared.storage.auth.*;
 
 import java.util.*;
 import java.util.stream.*;
@@ -14,15 +15,27 @@ public interface BlockMetadataStore {
 
     void remove(Cid block);
 
-    default void put(Cid block, byte[] data) {
+    default BlockMetadata put(Cid block, byte[] data) {
+        BlockMetadata meta = extractMetadata(block, data);
+        put(block, meta);
+        return meta;
+    }
+
+    static BlockMetadata extractMetadata(Cid block, byte[] data) {
         if (block.isRaw()) {
-            put(block, new BlockMetadata(data.length, Collections.emptyList()));
+            BlockMetadata meta = new BlockMetadata(data.length, Collections.emptyList(), Bat.getRawBlockBats(data));
+            return meta;
         } else {
-            List<Cid> links = CborObject.fromByteArray(data)
+            CborObject cbor = CborObject.fromByteArray(data);
+            List<Cid> links = cbor
                     .links().stream()
                     .map(h -> (Cid) h)
                     .collect(Collectors.toList());
-            put(block, new BlockMetadata(data.length, links));
+            List<BatId> batIds = cbor instanceof CborObject.CborMap ?
+                    ((CborObject.CborMap) cbor).getList("bats", BatId::fromCbor) :
+                    Collections.emptyList();
+            BlockMetadata meta = new BlockMetadata(data.length, links, batIds);
+            return meta;
         }
     }
 

--- a/src/peergos/server/storage/BlockVersion.java
+++ b/src/peergos/server/storage/BlockVersion.java
@@ -1,0 +1,15 @@
+package peergos.server.storage;
+
+import peergos.shared.io.ipfs.cid.*;
+
+public class BlockVersion {
+    public final Cid cid;
+    public final String version;
+    public final boolean isLatest;
+
+    public BlockVersion(Cid cid, String version, boolean isLatest) {
+        this.cid = cid;
+        this.version = version;
+        this.isLatest = isLatest;
+    }
+}

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -97,8 +97,14 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<Integer> blockSizes, boolean isRaw, TransactionId tid) {
-        return target.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
+    public CompletableFuture<List<PresignedUrl>> authWrites(PublicKeyHash owner,
+                                                            PublicKeyHash writer,
+                                                            List<byte[]> signedHashes,
+                                                            List<Integer> blockSizes,
+                                                            List<List<BatId>> batIds,
+                                                            boolean isRaw,
+                                                            TransactionId tid) {
+        return target.authWrites(owner, writer, signedHashes, blockSizes, batIds, isRaw, tid);
     }
 
     @Override
@@ -176,7 +182,7 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public CompletableFuture<Pair<Integer, List<Cid>>> getLinksAndSize(Cid block, String auth) {
-        return target.getLinksAndSize(block, auth);
+    public CompletableFuture<BlockMetadata> getBlockMetadata(Cid block, String auth) {
+        return target.getBlockMetadata(block, auth);
     }
 }

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -27,7 +27,7 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public Stream<Pair<Cid, String>> getAllBlockHashVersions() {
+    public Stream<BlockVersion> getAllBlockHashVersions() {
         return target.getAllBlockHashVersions();
     }
 
@@ -57,7 +57,7 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public void bulkDelete(List<Pair<Cid, String>> blocks) {
+    public void bulkDelete(List<BlockVersion> blocks) {
         target.bulkDelete(blocks);
     }
 

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -24,7 +24,11 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
 
     Stream<Cid> getAllBlockHashes();
 
-    Stream<Pair<Cid, String>> getAllBlockHashVersions();
+    Stream<BlockVersion> getAllBlockHashVersions();
+
+    default Stream<BlockVersion> getAllRawBlockVersions() {
+        return getAllBlockHashVersions().filter(v -> v.cid.isRaw());
+    }
 
     List<Multihash> getOpenTransactionBlocks();
 
@@ -34,8 +38,8 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
 
     void delete(Cid block);
 
-    default void delete(Pair<Cid, String> blockVersion) {
-        delete(blockVersion.left);
+    default void delete(BlockVersion blockVersion) {
+        delete(blockVersion.cid);
     }
 
     default void bloomAdd(Multihash hash) {}
@@ -44,8 +48,8 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
         return Optional.empty();
     }
 
-    default void bulkDelete(List<Pair<Cid, String>> blockVersions) {
-        for (Pair<Cid, String> version : blockVersions) {
+    default void bulkDelete(List<BlockVersion> blockVersions) {
+        for (BlockVersion version : blockVersions) {
             delete(version);
         }
     }
@@ -240,8 +244,8 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
         }
 
         @Override
-        public Stream<Pair<Cid, String>> getAllBlockHashVersions() {
-            return getAllBlockHashes().map(c -> new Pair<>(c, null));
+        public Stream<BlockVersion> getAllBlockHashVersions() {
+            return getAllBlockHashes().map(c -> new BlockVersion(c, null, true));
         }
 
         @Override

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -243,8 +243,8 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public Stream<Pair<Cid, String>> getAllBlockHashVersions() {
-        return getAllBlockHashes().map(c -> new Pair<>(c, null));
+    public Stream<BlockVersion> getAllBlockHashVersions() {
+        return getAllBlockHashes().map(c -> new BlockVersion(c, null, true));
     }
 
     @Override

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -72,8 +72,9 @@ public class GarbageCollector {
         // TODO: do this more efficiently with a bloom filter, and actual streaming and multithreading
         storage.clearOldTransactions(System.currentTimeMillis() - 24*3600*1000L);
         long t0 = System.nanoTime();
-        // current versions are returned first. This is only relevant for versioned S3 buckets, otherwise version is null
-        List<Pair<Cid, String>> present = storage.getAllBlockHashVersions().collect(Collectors.toList());
+        // Versions are only relevant for versioned S3 buckets, otherwise version is null
+        // For S3, clients write raw blocks directly, we need to get them directly from S3
+        List<BlockVersion> present = Stream.concat(metadata.list(), storage.getAllRawBlockVersions()).collect(Collectors.toList());
         long t1 = System.nanoTime();
         System.out.println("Listing " + present.size() + " blocks took " + (t1-t0)/1_000_000_000 + "s");
 
@@ -91,8 +92,9 @@ public class GarbageCollector {
 
         Map<Multihash, Integer> toIndex = new HashMap<>();
         // we traverse this in reverse order because the current versions are first
-        for (int i = present.size() - 1; i >= 0; i--)
-            toIndex.put(present.get(i).left, i);
+        for (int i = 0; i < present.size(); i++)
+            if (present.get(i).isLatest)
+                toIndex.put(present.get(i).cid, i);
         BitSet reachable = new BitSet(present.size());
 
         int markParallelism = 10;
@@ -165,17 +167,17 @@ public class GarbageCollector {
     private static Pair<Long, Long> deleteUnreachableBlocks(int startIndex,
                                                             int endIndex,
                                                             BitSet reachable,
-                                                            List<Pair<Cid, String>> present,
+                                                            List<BlockVersion> present,
                                                             AtomicLong progress,
                                                             DeletableContentAddressedStorage storage,
                                                             BlockMetadataStore metadata) {
         long deletedCborBlocks = 0, deletedRawBlocks = 0;
         long logPoint = startIndex;
         final int maxDeleteCount = 1000;
-        List<Pair<Cid, String>> pendingDeletes = new ArrayList<>();
+        List<BlockVersion> pendingDeletes = new ArrayList<>();
         for (int i = reachable.nextClearBit(startIndex); i >= startIndex && i < endIndex; i = reachable.nextClearBit(i + 1)) {
-            Pair<Cid, String> version = present.get(i);
-            Cid hash = version.left;
+            BlockVersion version = present.get(i);
+            Cid hash = version.cid;
             if (hash.isRaw())
                 deletedRawBlocks++;
             else
@@ -184,8 +186,8 @@ public class GarbageCollector {
 
             if (pendingDeletes.size() >= maxDeleteCount) {
                 getWithBackoff(() -> {storage.bulkDelete(pendingDeletes); return true;});
-                for (Pair<Cid, String> block : pendingDeletes) {
-                    metadata.remove(block.left);
+                for (BlockVersion block : pendingDeletes) {
+                    metadata.remove(block.cid);
                 }
                 pendingDeletes.clear();
             }

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -73,7 +73,7 @@ public class GarbageCollector {
         storage.clearOldTransactions(System.currentTimeMillis() - 24*3600*1000L);
         long t0 = System.nanoTime();
         // Versions are only relevant for versioned S3 buckets, otherwise version is null
-        // For S3, clients write raw blocks directly, we need to get them directly from S3
+        // For S3, clients write raw blocks directly, we need to get their version directly from S3
         List<BlockVersion> present = Stream.concat(storage.getAllRawBlockVersions(), metadata.listCbor()).collect(Collectors.toList());
         long t1 = System.nanoTime();
         System.out.println("Listing " + present.size() + " blocks took " + (t1-t0)/1_000_000_000 + "s");

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -74,7 +74,7 @@ public class GarbageCollector {
         long t0 = System.nanoTime();
         // Versions are only relevant for versioned S3 buckets, otherwise version is null
         // For S3, clients write raw blocks directly, we need to get them directly from S3
-        List<BlockVersion> present = Stream.concat(metadata.list(), storage.getAllRawBlockVersions()).collect(Collectors.toList());
+        List<BlockVersion> present = Stream.concat(storage.getAllRawBlockVersions(), metadata.listCbor()).collect(Collectors.toList());
         long t1 = System.nanoTime();
         System.out.println("Listing " + present.size() + " blocks took " + (t1-t0)/1_000_000_000 + "s");
 
@@ -91,7 +91,6 @@ public class GarbageCollector {
         List<Multihash> usageRoots = usage.getAllTargets();
 
         Map<Multihash, Integer> toIndex = new HashMap<>();
-        // we traverse this in reverse order because the current versions are first
         for (int i = 0; i < present.size(); i++)
             if (present.get(i).isLatest)
                 toIndex.put(present.get(i).cid, i);

--- a/src/peergos/server/storage/JdbcBlockMetadataStore.java
+++ b/src/peergos/server/storage/JdbcBlockMetadataStore.java
@@ -15,7 +15,6 @@ import java.util.stream.*;
 public class JdbcBlockMetadataStore implements BlockMetadataStore {
 
     private static final Logger LOG = Logging.LOG();
-    private static final String CREATE = "INSERT OR IGNORE INTO blockmetadata (cid, version, size, links, batids) VALUES(?, ?, ?, ?, ?)";
     private static final String GET_INFO = "SELECT * FROM blockmetadata WHERE cid = ?;";
     private static final String REMOVE = "DELETE FROM blockmetadata where cid = ?;";
     private static final String LIST = "SELECT cid, version FROM blockmetadata;";
@@ -102,7 +101,7 @@ public class JdbcBlockMetadataStore implements BlockMetadataStore {
     @Override
     public void put(Cid block, String version, BlockMetadata meta) {
         try (Connection conn = getConnection();
-             PreparedStatement insert = conn.prepareStatement(CREATE)) {
+             PreparedStatement insert = conn.prepareStatement(commands.addMetadataCommand())) {
 
             insert.setBytes(1, block.toBytes());
             insert.setString(2, version);
@@ -126,6 +125,7 @@ public class JdbcBlockMetadataStore implements BlockMetadataStore {
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(SIZE)) {
             ResultSet rs = stmt.executeQuery();
+            rs.next();
             return rs.getInt(1);
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);

--- a/src/peergos/server/storage/MetadataCachingStorage.java
+++ b/src/peergos/server/storage/MetadataCachingStorage.java
@@ -59,6 +59,8 @@ public class MetadataCachingStorage extends DelegatingDeletableStorage {
 
     @Override
     public CompletableFuture<List<Cid>> getLinks(Cid block, String auth) {
+        if (block.isRaw())
+            return Futures.of(Collections.emptyList());
         Optional<BlockMetadata> meta = metadata.get(block);
         if (meta.isPresent())
             return Futures.of(meta.get().links);

--- a/src/peergos/server/storage/MetadataCachingStorage.java
+++ b/src/peergos/server/storage/MetadataCachingStorage.java
@@ -34,7 +34,7 @@ public class MetadataCachingStorage extends DelegatingDeletableStorage {
         return target.put(owner, writer, signedHashes, blocks, tid)
                 .thenApply(cids -> {
                     for (int i=0; i < cids.size(); i++)
-                        metadata.put(cids.get(i), blocks.get(i));
+                        metadata.put(cids.get(i), null, blocks.get(i));
                     return cids;
                 });
     }
@@ -44,7 +44,7 @@ public class MetadataCachingStorage extends DelegatingDeletableStorage {
         return target.putRaw(owner, writer, signedHashes, blocks, tid, progressCounter)
                 .thenApply(cids -> {
                     for (int i=0; i < cids.size(); i++)
-                        metadata.put(cids.get(i), blocks.get(i));
+                        metadata.put(cids.get(i), null, blocks.get(i));
                     return cids;
                 });
     }
@@ -72,14 +72,14 @@ public class MetadataCachingStorage extends DelegatingDeletableStorage {
             return Futures.of(meta.get());
         return target.getBlockMetadata(block, auth)
                 .thenApply(blockmeta -> {
-                    metadata.put(block, blockmeta);
+                    metadata.put(block, null, blockmeta);
                     return blockmeta;
                 });
     }
 
     private void cacheBlockMetadata(byte[] block, boolean isRaw) {
         Cid cid = hashToCid(block, isRaw, hasher).join();
-        metadata.put(cid, block);
+        metadata.put(cid, null, block);
     }
 
     @Override

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -60,8 +60,8 @@ public class RAMStorage implements DeletableContentAddressedStorage {
 
 
     @Override
-    public Stream<Pair<Cid, String>> getAllBlockHashVersions() {
-        return getAllBlockHashes().map(c -> new Pair<>(c, null));
+    public Stream<BlockVersion> getAllBlockHashVersions() {
+        return getAllBlockHashes().map(c -> new BlockVersion(c, null, true));
     }
 
     @Override

--- a/src/peergos/server/storage/RamBlockMetadataStore.java
+++ b/src/peergos/server/storage/RamBlockMetadataStore.java
@@ -34,6 +34,14 @@ public class RamBlockMetadataStore implements BlockMetadataStore {
     }
 
     @Override
+    public Stream<BlockVersion> listCbor() {
+        return store.keySet()
+                .stream()
+                .filter(c -> ! c.isRaw())
+                .map(c -> new BlockVersion(c, null, true));
+    }
+
+    @Override
     public long size() {
         return store.size();
     }

--- a/src/peergos/server/storage/RamBlockMetadataStore.java
+++ b/src/peergos/server/storage/RamBlockMetadataStore.java
@@ -19,7 +19,7 @@ public class RamBlockMetadataStore implements BlockMetadataStore {
     }
 
     @Override
-    public void put(Cid block, BlockMetadata meta) {
+    public void put(Cid block, String version, BlockMetadata meta) {
         store.put(block, meta);
     }
 
@@ -29,8 +29,13 @@ public class RamBlockMetadataStore implements BlockMetadataStore {
     }
 
     @Override
-    public Stream<Cid> list() {
-        return store.keySet().stream();
+    public Stream<BlockVersion> list() {
+        return store.keySet().stream().map(c -> new BlockVersion(c, null, true));
+    }
+
+    @Override
+    public long size() {
+        return store.size();
     }
 
     @Override

--- a/src/peergos/server/storage/RamBlockMetadataStore.java
+++ b/src/peergos/server/storage/RamBlockMetadataStore.java
@@ -1,31 +1,36 @@
 package peergos.server.storage;
 
 import peergos.shared.io.ipfs.cid.*;
-import peergos.shared.util.*;
 
 import java.util.*;
+import java.util.stream.*;
 
 public class RamBlockMetadataStore implements BlockMetadataStore {
 
-    private final LRUCache<Cid, BlockMetadata> cache;
+    private final Map<Cid, BlockMetadata> store;
 
     public RamBlockMetadataStore() {
-        this.cache = new LRUCache<>(50_000);
+        this.store = new HashMap<>(50_000);
     }
 
     @Override
     public Optional<BlockMetadata> get(Cid block) {
-        return Optional.ofNullable(cache.get(block));
+        return Optional.ofNullable(store.get(block));
     }
 
     @Override
     public void put(Cid block, BlockMetadata meta) {
-        cache.put(block, meta);
+        store.put(block, meta);
     }
 
     @Override
     public void remove(Cid block) {
-        cache.remove(block);
+        store.remove(block);
+    }
+
+    @Override
+    public Stream<Cid> list() {
+        return store.keySet().stream();
     }
 
     @Override

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -631,6 +631,8 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
 
     @Override
     public CompletableFuture<BlockMetadata> getBlockMetadata(Cid h, String auth) {
+        if (h.isIdentity())
+            return Futures.of(new BlockMetadata(0, CborObject.getLinks(h, h.getHash()), Bat.getBlockBats(h, h.getHash())));
         Optional<BlockMetadata> cached = blockMetadata.get(h);
         if (cached.isPresent())
             return Futures.of(cached.get());
@@ -870,7 +872,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     public static void main(String[] args) throws Exception {
-         System.out.println("Performing GC on S3 block store...");
+        System.out.println("Performing GC on S3 block store...");
         Args a = Args.parse(args);
         Crypto crypto = Main.initCrypto();
         Hasher hasher = crypto.hasher;

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -447,8 +447,9 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         transactions.clearOldTransactions(cutoffMillis);
     }
 
-    private void collectGarbage(JdbcIpnsAndSocial pointers, UsageStore usage, BlockMetadataStore metadata) {
-        GarbageCollector.collect(new MetadataCachingStorage(this, metadata, hasher), pointers, usage, this::savePointerSnapshot, metadata);
+    private void collectGarbage(JdbcIpnsAndSocial pointers, UsageStore usage, BlockMetadataStore metadata, boolean listFromBlockstore) {
+        GarbageCollector.collect(new MetadataCachingStorage(this, metadata, hasher), pointers, usage,
+                this::savePointerSnapshot, metadata, listFromBlockstore);
     }
 
     public CompletableFuture<Boolean> savePointerSnapshot(Stream<Map.Entry<PublicKeyHash, byte[]>> pointers) {
@@ -889,7 +890,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         JdbcIpnsAndSocial rawPointers = new JdbcIpnsAndSocial(database, sqlCommands);
         Supplier<Connection> usageDb = Main.getDBConnector(a, "space-usage-sql-file");
         UsageStore usageStore = new JdbcUsageStore(usageDb, sqlCommands);
-        s3.collectGarbage(rawPointers, usageStore, meta);
+        s3.collectGarbage(rawPointers, usageStore, meta, a.getBoolean("list-from-blockstore", false));
     }
 
     @Override

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -448,7 +448,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     private void collectGarbage(JdbcIpnsAndSocial pointers, UsageStore usage, BlockMetadataStore metadata, boolean listFromBlockstore) {
-        GarbageCollector.collect(new MetadataCachingStorage(this, metadata, hasher), pointers, usage,
+        GarbageCollector.collect(this, pointers, usage,
                 this::savePointerSnapshot, metadata, listFromBlockstore);
     }
 
@@ -872,6 +872,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     public static void main(String[] args) throws Exception {
+        Cid cd = Cid.decode("zb2rhXGcAe4uZnSmKJDEmtavJqLknS7qCn8YL8s7k4QxD9uGZ");
         System.out.println("Performing GC on S3 block store...");
         Args a = Args.parse(args);
         Crypto crypto = Main.initCrypto();

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -653,7 +653,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     public void updateMetadataStoreIfEmpty() {
         if (blockMetadata.size() > 0)
             return;
-        System.out.println("Updating block metadata store from S3...");
+        LOG.info("Updating block metadata store from S3...");
         List<Cid> all = getAllBlockHashes().collect(Collectors.toList());
         int updateParallelism = 10;
         ForkJoinPool pool = new ForkJoinPool(updateParallelism);
@@ -666,7 +666,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         futures.stream()
                 .map(ForkJoinTask::join)
                 .collect(Collectors.toList());
-        System.out.println("Finished updating block metadata store from S3.");
+        LOG.info("Finished updating block metadata store from S3.");
     }
 
     @Override

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -834,7 +834,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         String sqlFilePath = storeFile.getPath();
         Connection memory = Sqlite.build(sqlFilePath);
         Connection instance = new Sqlite.UncloseableConnection(memory);
-        SqliteBlockMetadataStorage store = new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), 0, storeFile);
+        SqliteBlockMetadataStorage store = new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), storeFile);
         s3.collectGarbage(rawPointers, usageStore, store);
     }
 

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -688,7 +688,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     public Stream<BlockVersion> getAllRawBlockVersions() {
         // todo make this actually streaming
         List<BlockVersion> results = new ArrayList<>();
-        applyToAllVersions("/AFK", obj -> {
+        applyToAllVersions("AFK", obj -> {
             try {
                 results.add(new BlockVersion(keyToHash(obj.key), obj.version, obj.isLatest));
             } catch (Exception e) {

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -872,7 +872,6 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     public static void main(String[] args) throws Exception {
-        Cid cd = Cid.decode("zb2rhXGcAe4uZnSmKJDEmtavJqLknS7qCn8YL8s7k4QxD9uGZ");
         System.out.println("Performing GC on S3 block store...");
         Args a = Args.parse(args);
         Crypto crypto = Main.initCrypto();

--- a/src/peergos/server/storage/S3BucketCopy.java
+++ b/src/peergos/server/storage/S3BucketCopy.java
@@ -73,7 +73,7 @@ public class S3BucketCopy {
                 Collections.emptyMap(), config.region, config.accessKey, config.secretKey, true, h).join();
         try {
             System.out.println("Copying s3://"+sourceBucket + "/" + key + " to s3://" + config.bucket);
-            String res = new String(HttpUtil.put(copyUrl, new byte[0]));
+            String res = new String(HttpUtil.putWithVersion(copyUrl, new byte[0]).left);
             if (! res.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?><CopyObjectResult") || !res.contains("</LastModified><ETag>"))
                 throw new IllegalStateException(res);
         } catch (IOException e) {
@@ -95,7 +95,7 @@ public class S3BucketCopy {
             extraHeaders.put("Content-Type", "application/octet-stream");
             boolean hashContent = true;
             String contentHash = hashContent ? ArrayOps.bytesToHex(DirectS3BlockStore.keyToHash(key).getHash()) : "UNSIGNED-PAYLOAD";
-            HttpUtil.put(S3Request.preSignPut(key, res.length, contentHash, false,
+            HttpUtil.putWithVersion(S3Request.preSignPut(key, res.length, contentHash, false,
                     S3AdminRequests.asAwsDate(ZonedDateTime.now()), target.getHost(), extraHeaders, target.region, target.accessKey, target.secretKey,  true,h).join(), res);
         } catch (IOException e) {
             System.err.println(e.getMessage());

--- a/src/peergos/server/storage/S3BucketStats.java
+++ b/src/peergos/server/storage/S3BucketStats.java
@@ -4,13 +4,10 @@ import peergos.server.*;
 import peergos.server.util.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
-import peergos.shared.storage.auth.*;
-import peergos.shared.util.*;
 
 import java.io.*;
 import java.time.*;
 import java.util.*;
-import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
 import java.util.function.*;
 import java.util.logging.*;
@@ -59,11 +56,11 @@ public class S3BucketStats {
         }
     }
 
-    private static void copyRange(String startPrefix,
-                                  Optional<String> endPrefix,
-                                  S3Config source,
-                                  AtomicLong counter,
-                                  Hasher h) {
+    private static void analyseRange(String startPrefix,
+                                     Optional<String> endPrefix,
+                                     S3Config source,
+                                     AtomicLong counter,
+                                     Hasher h) {
         AtomicLong rawBlocks = new AtomicLong(0);
         AtomicLong cborBlocks = new AtomicLong(0);
         AtomicLong cborBlocksSize = new AtomicLong(0);
@@ -89,6 +86,6 @@ public class S3BucketStats {
         Optional<String> endPrefix = Optional.empty();
 
         System.out.println("Analysing S3 bucket " + source.getHost() + "/" + source.bucket);
-        copyRange(startPrefix, endPrefix, source, new AtomicLong(0), Main.initCrypto().hasher);
+        analyseRange(startPrefix, endPrefix, source, new AtomicLong(0), Main.initCrypto().hasher);
     }
 }

--- a/src/peergos/server/storage/SqliteBlockMetadataStorage.java
+++ b/src/peergos/server/storage/SqliteBlockMetadataStorage.java
@@ -146,4 +146,24 @@ public class SqliteBlockMetadataStorage implements BlockMetadataStore {
             throw new RuntimeException(sqe);
         }
     }
+
+    @Override
+    public Stream<BlockVersion> listCbor() {
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(LIST)) {
+            ResultSet rs = stmt.executeQuery();
+            List<BlockVersion> res = new ArrayList<>();
+            while (rs.next()) {
+                Cid cid = Cid.cast(rs.getBytes("cid"));
+                String version = rs.getString("version");
+                if (! cid.isRaw()) {
+                    res.add(new BlockVersion(cid, version, true));
+                }
+            }
+            return res.stream();
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
 }

--- a/src/peergos/server/storage/SqliteBlockMetadataStorage.java
+++ b/src/peergos/server/storage/SqliteBlockMetadataStorage.java
@@ -16,10 +16,11 @@ import java.util.stream.*;
 public class SqliteBlockMetadataStorage implements BlockMetadataStore {
 
     private static final Logger LOG = Logging.LOG();
-    private static final String CREATE = "INSERT OR IGNORE INTO blockmetadata (cid, size, links, batids, accesstime) VALUES(?, ?, ?, ?, ?)";
+    private static final String CREATE = "INSERT OR IGNORE INTO blockmetadata (cid, version, size, links, batids) VALUES(?, ?, ?, ?, ?)";
     private static final String GET_INFO = "SELECT * FROM blockmetadata WHERE cid = ?;";
     private static final String REMOVE = "DELETE FROM blockmetadata where cid = ?;";
-    private static final String LIST = "SELECT cid FROM blockmetadata;";
+    private static final String LIST = "SELECT cid, version FROM blockmetadata;";
+    private static final String SIZE = "SELECT COUNT(*) FROM blockmetadata;";
     private static final String VACUUM = "VACUUM;";
 
     private Supplier<Connection> conn;
@@ -97,20 +98,20 @@ public class SqliteBlockMetadataStorage implements BlockMetadataStore {
     }
 
     @Override
-    public void put(Cid block, BlockMetadata meta) {
+    public void put(Cid block, String version, BlockMetadata meta) {
         try (Connection conn = getConnection();
              PreparedStatement insert = conn.prepareStatement(CREATE)) {
 
             insert.setBytes(1, block.toBytes());
-            insert.setLong(2, meta.size);
-            insert.setBytes(3, new CborObject.CborList(meta.links.stream()
+            insert.setString(2, version);
+            insert.setLong(3, meta.size);
+            insert.setBytes(4, new CborObject.CborList(meta.links.stream()
                     .map(Cid::toBytes)
                     .map(CborObject.CborByteArray::new)
                     .collect(Collectors.toList()))
                     .toByteArray());
-            insert.setBytes(4, new CborObject.CborList(meta.batids)
+            insert.setBytes(5, new CborObject.CborList(meta.batids)
                     .toByteArray());
-            insert.setLong(5, System.currentTimeMillis());
             insert.executeUpdate();
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
@@ -119,13 +120,25 @@ public class SqliteBlockMetadataStorage implements BlockMetadataStore {
     }
 
     @Override
-    public Stream<Cid> list() {
+    public long size() {
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(SIZE)) {
+            ResultSet rs = stmt.executeQuery();
+            return rs.getInt(1);
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    @Override
+    public Stream<BlockVersion> list() {
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(LIST)) {
             ResultSet rs = stmt.executeQuery();
-            List<Cid> res = new ArrayList<>();
+            List<BlockVersion> res = new ArrayList<>();
             while (rs.next()) {
-                res.add(Cid.cast(rs.getBytes("cid")));
+                res.add(new BlockVersion(Cid.cast(rs.getBytes("cid")), rs.getString("version"), true));
             }
             return res.stream();
         } catch (SQLException sqe) {

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -100,6 +100,12 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
     }
 
     @Override
+    public CompletableFuture<BlockMetadata> getBlockMetadata(Cid block, String auth) {
+        return getRaw(block, auth, false)
+                .thenApply(data -> BlockMetadataStore.extractMetadata(block, data.get()));
+    }
+
+    @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
                                                           Cid root,
                                                           byte[] champKey,

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -151,7 +151,7 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
     }
 
     @Override
-    public Stream<Pair<Cid, String>> getAllBlockHashVersions() {
+    public Stream<BlockVersion> getAllBlockHashVersions() {
         return target.getAllBlockHashVersions();
     }
 

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -221,7 +221,8 @@ public class MultiNodeNetworkTests {
         long usageVia2 = postMigration.getSpaceUsage().join();
         // Note we currently don't remove the old pointer after changing password,
         // so there is a 5kib reduction after migration per password change
-        Assert.assertTrue(usageVia2 == usageVia1 || (nPasswordChanges > 0 && usageVia2 < usageVia1));
+        Assert.assertTrue("Usage after migrate: " + usageVia2 + ", usage before: " + usageVia1,
+                usageVia2 == usageVia1 || (nPasswordChanges > 0 && usageVia2 < usageVia1));
 
         // check pending followRequest was transferred
         List<FollowRequestWithCipherText> followRequests = postMigration.processFollowRequests().join();

--- a/src/peergos/server/tests/RequestCountTests.java
+++ b/src/peergos/server/tests/RequestCountTests.java
@@ -103,7 +103,7 @@ public class RequestCountTests {
         // check 'a' can see the shared file in their social feed
         storageCounter.reset();
         SocialFeed feed = a.getSocialFeed().join();
-        Assert.assertTrue("initialise social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 30);
+        Assert.assertTrue("initialise social feed: " + storageCounter.requestTotal(), storageCounter.requestTotal() <= 32);
         int feedSize = 2;
 
         storageCounter.reset();

--- a/src/peergos/server/tests/SqliteBlockMetadataTest.java
+++ b/src/peergos/server/tests/SqliteBlockMetadataTest.java
@@ -1,11 +1,14 @@
 package peergos.server.tests;
 
 import org.junit.*;
+import peergos.server.*;
 import peergos.server.sql.*;
 import peergos.server.storage.*;
 import peergos.server.util.*;
+import peergos.shared.*;
 import peergos.shared.io.ipfs.cid.*;
 import peergos.shared.io.ipfs.multihash.*;
+import peergos.shared.storage.auth.*;
 
 import java.io.*;
 import java.nio.file.*;
@@ -18,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 public class SqliteBlockMetadataTest {
 
     private static final Random r = new Random(666);
+    private static Crypto crypto = Main.initCrypto();
 
     private static Cid randomCid() {
         byte[] hash = new byte[32];
@@ -48,6 +52,13 @@ public class SqliteBlockMetadataTest {
 
         // add same cid again
         store.put(cid, meta);
+        Cid cid2 = randomCid();
+        BlockMetadata meta2 = new BlockMetadata(10240, randomCids(20),
+                List.of(BatId.inline(Bat.random(crypto.random)), BatId.inline(Bat.random(crypto.random))));
+        store.put(cid2, meta2);
+
+        List<Cid> ls = store.list().collect(Collectors.toList());
+        Assert.assertTrue(ls.size() == 2);
     }
 
     @Test

--- a/src/peergos/server/tests/SqliteBlockMetadataTest.java
+++ b/src/peergos/server/tests/SqliteBlockMetadataTest.java
@@ -62,6 +62,13 @@ public class SqliteBlockMetadataTest {
 
         long size = store.size();
         Assert.assertTrue(size == 2);
+
+        // null versions
+        Cid cid3 = randomCid();
+        BlockMetadata meta3 = new BlockMetadata(10240, randomCids(20),
+                List.of(BatId.inline(Bat.random(crypto.random)), BatId.inline(Bat.random(crypto.random))));
+        store.put(cid3, null, meta3);
+        Assert.assertTrue(store.list().filter(v -> v.cid.equals(cid3)).findFirst().get().version == null);
     }
 
     @Test

--- a/src/peergos/server/tests/SqliteBlockMetadataTest.java
+++ b/src/peergos/server/tests/SqliteBlockMetadataTest.java
@@ -47,18 +47,21 @@ public class SqliteBlockMetadataTest {
         assertTrue(initialSize == 12288);
         Cid cid = randomCid();
         BlockMetadata meta = new BlockMetadata(10240, randomCids(20), Collections.emptyList());
-        store.put(cid, meta);
+        store.put(cid, "alpha", meta);
         long sizeWithBlock = store.currentSize();
 
         // add same cid again
-        store.put(cid, meta);
+        store.put(cid, "beta", meta);
         Cid cid2 = randomCid();
         BlockMetadata meta2 = new BlockMetadata(10240, randomCids(20),
                 List.of(BatId.inline(Bat.random(crypto.random)), BatId.inline(Bat.random(crypto.random))));
-        store.put(cid2, meta2);
+        store.put(cid2, "gammaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", meta2);
 
-        List<Cid> ls = store.list().collect(Collectors.toList());
+        List<BlockVersion> ls = store.list().collect(Collectors.toList());
         Assert.assertTrue(ls.size() == 2);
+
+        long size = store.size();
+        Assert.assertTrue(size == 2);
     }
 
     @Test
@@ -72,7 +75,7 @@ public class SqliteBlockMetadataTest {
         long initialSize = store.currentSize();
         assertTrue(initialSize == 12288);
         for (int i=0; i < 1500; i++)
-            store.put(randomCid(), new BlockMetadata(10240, randomCids(20), Collections.emptyList()));
+            store.put(randomCid(), null, new BlockMetadata(10240, randomCids(20), Collections.emptyList()));
         long sizeWithBlocks = store.currentSize();
         store.compact();
         long sizeAfterCompaction = store.currentSize();

--- a/src/peergos/server/tests/SqliteBlockMetadataTest.java
+++ b/src/peergos/server/tests/SqliteBlockMetadataTest.java
@@ -38,14 +38,13 @@ public class SqliteBlockMetadataTest {
         String sqlFilePath = storeFile.getPath();
         Connection memory = Sqlite.build(sqlFilePath);
         Connection instance = new Sqlite.UncloseableConnection(memory);
-        SqliteBlockMetadataStorage store = new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), 1024 * 1024, storeFile);
+        SqliteBlockMetadataStorage store = new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), storeFile);
         long initialSize = store.currentSize();
-        assertTrue(initialSize == 16384);
+        assertTrue(initialSize == 12288);
         Cid cid = randomCid();
         BlockMetadata meta = new BlockMetadata(10240, randomCids(20), Collections.emptyList());
         store.put(cid, meta);
         long sizeWithBlock = store.currentSize();
-        store.ensureWithinSize();
 
         // add same cid again
         store.put(cid, meta);
@@ -58,16 +57,14 @@ public class SqliteBlockMetadataTest {
         String sqlFilePath = storeFile.getPath();
         Connection memory = Sqlite.build(sqlFilePath);
         Connection instance = new Sqlite.UncloseableConnection(memory);
-        int maxFileSize = 1024 * 1024;
-        SqliteBlockMetadataStorage store = new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), maxFileSize, storeFile);
+        SqliteBlockMetadataStorage store = new SqliteBlockMetadataStorage(() -> instance, new SqliteCommands(), storeFile);
         long initialSize = store.currentSize();
-        assertTrue(initialSize == 16384);
+        assertTrue(initialSize == 12288);
         for (int i=0; i < 1500; i++)
             store.put(randomCid(), new BlockMetadata(10240, randomCids(20), Collections.emptyList()));
         long sizeWithBlocks = store.currentSize();
-        assertTrue(sizeWithBlocks > maxFileSize);
-        store.ensureWithinSize();
+        store.compact();
         long sizeAfterCompaction = store.currentSize();
-        assertTrue(sizeAfterCompaction < 0.6 * maxFileSize);
+        assertTrue(sizeAfterCompaction < sizeWithBlocks);
     }
 }

--- a/src/peergos/server/tests/SqliteBlockMetadataTest.java
+++ b/src/peergos/server/tests/SqliteBlockMetadataTest.java
@@ -42,7 +42,7 @@ public class SqliteBlockMetadataTest {
         long initialSize = store.currentSize();
         assertTrue(initialSize == 16384);
         Cid cid = randomCid();
-        BlockMetadata meta = new BlockMetadata(10240, randomCids(20));
+        BlockMetadata meta = new BlockMetadata(10240, randomCids(20), Collections.emptyList());
         store.put(cid, meta);
         long sizeWithBlock = store.currentSize();
         store.ensureWithinSize();
@@ -63,7 +63,7 @@ public class SqliteBlockMetadataTest {
         long initialSize = store.currentSize();
         assertTrue(initialSize == 16384);
         for (int i=0; i < 1500; i++)
-            store.put(randomCid(), new BlockMetadata(10240, randomCids(20)));
+            store.put(randomCid(), new BlockMetadata(10240, randomCids(20), Collections.emptyList()));
         long sizeWithBlocks = store.currentSize();
         assertTrue(sizeWithBlocks > maxFileSize);
         store.ensureWithinSize();

--- a/src/peergos/server/tests/slow/GCBenchmark.java
+++ b/src/peergos/server/tests/slow/GCBenchmark.java
@@ -44,7 +44,7 @@ public class GCBenchmark {
             storage.closeTransaction(owner, tid).join();
         }
 
-        GarbageCollector.collect(storage, pointers, usage, s -> Futures.of(true), new RamBlockMetadataStore());
+        GarbageCollector.collect(storage, pointers, usage, s -> Futures.of(true), new RamBlockMetadataStore(), false);
     }
 
     private static Multihash generateTree(Random r, PublicKeyHash owner, ContentAddressedStorage storage, int nLeaves, TransactionId tid) {

--- a/src/peergos/server/util/HttpUtil.java
+++ b/src/peergos/server/util/HttpUtil.java
@@ -8,6 +8,7 @@ import java.io.*;
 import java.net.*;
 import java.util.*;
 import java.util.logging.*;
+import java.util.stream.*;
 
 public class HttpUtil {
 
@@ -68,6 +69,10 @@ public class HttpUtil {
     }
 
     public static byte[] get(PresignedUrl url) throws IOException {
+        return getWithVersion(url).left;
+    }
+
+    public static Pair<byte[], String> getWithVersion(PresignedUrl url) throws IOException {
         try {
             HttpURLConnection conn = (HttpURLConnection) new URI(url.base).toURL().openConnection();
             conn.setConnectTimeout(10_000);
@@ -84,7 +89,11 @@ public class HttpUtil {
                 if (respCode == 404)
                     throw new FileNotFoundException();
                 InputStream in = conn.getInputStream();
-                return Serialize.readFully(in);
+                Map<String, String> headers = conn.getHeaderFields().entrySet()
+                        .stream()
+                        .collect(Collectors.toMap(e -> e.getKey().toLowerCase(), e -> e.getValue().get(0)));
+                String version = headers.getOrDefault("x-amz-version-id", null);
+                return new Pair<>(Serialize.readFully(in), version);
             } catch (IOException e) {
                 InputStream err = conn.getErrorStream();
                 if (err == null)
@@ -126,15 +135,15 @@ public class HttpUtil {
         }
     }
 
-    public static byte[] put(PresignedUrl target, byte[] body) throws IOException {
-        return putOrPost("PUT", target, body);
+    public static Pair<byte[], String> putWithVersion(PresignedUrl target, byte[] body) throws IOException {
+        return putOrPostWithVersion("PUT", target, body);
     }
 
     public static byte[] post(PresignedUrl target, byte[] body) throws IOException {
-        return putOrPost("POST", target, body);
+        return putOrPostWithVersion("POST", target, body).left;
     }
 
-    private static byte[] putOrPost(String method, PresignedUrl target, byte[] body) throws IOException {
+    private static Pair<byte[], String> putOrPostWithVersion(String method, PresignedUrl target, byte[] body) throws IOException {
         HttpURLConnection conn = null;
         try {
             conn = (HttpURLConnection) new URI(target.base).toURL().openConnection();
@@ -152,7 +161,11 @@ public class HttpUtil {
             if (httpCode == 503)
                 throw new RateLimitException();
             InputStream in = conn.getInputStream();
-            return Serialize.readFully(in);
+            Map<String, String> headers = conn.getHeaderFields().entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(e -> e.getKey().toLowerCase(), e -> e.getValue().get(0)));
+            String version = headers.getOrDefault("x-amz-version-id", null);
+            return new Pair(Serialize.readFully(in), version);
         } catch (IOException e) {
             if (conn != null) {
                 InputStream err = conn.getErrorStream();

--- a/src/peergos/server/util/HttpUtil.java
+++ b/src/peergos/server/util/HttpUtil.java
@@ -163,6 +163,7 @@ public class HttpUtil {
             InputStream in = conn.getInputStream();
             Map<String, String> headers = conn.getHeaderFields().entrySet()
                     .stream()
+                    .filter(e -> e.getKey() != null)
                     .collect(Collectors.toMap(e -> e.getKey().toLowerCase(), e -> e.getValue().get(0)));
             String version = headers.getOrDefault("x-amz-version-id", null);
             return new Pair(Serialize.readFully(in), version);

--- a/src/peergos/server/util/HttpUtil.java
+++ b/src/peergos/server/util/HttpUtil.java
@@ -91,6 +91,7 @@ public class HttpUtil {
                 InputStream in = conn.getInputStream();
                 Map<String, String> headers = conn.getHeaderFields().entrySet()
                         .stream()
+                        .filter(e -> e.getKey() != null)
                         .collect(Collectors.toMap(e -> e.getKey().toLowerCase(), e -> e.getValue().get(0)));
                 String version = headers.getOrDefault("x-amz-version-id", null);
                 return new Pair<>(Serialize.readFully(in), version);

--- a/src/peergos/shared/cbor/CborObject.java
+++ b/src/peergos/shared/cbor/CborObject.java
@@ -30,6 +30,16 @@ public interface CborObject extends Cborable {
 
     int LINK_TAG = 42;
 
+    static List<Cid> getLinks(Cid h, byte[] data) {
+        return h.isRaw() ?
+                Collections.emptyList() :
+                CborObject.fromByteArray(data)
+                        .links()
+                        .stream()
+                        .map(m -> (Cid) m)
+                        .collect(Collectors.toList());
+    }
+
     static CborObject fromByteArray(byte[] cbor) {
         return deserialize(new CborDecoder(new ByteArrayInputStream(cbor)), cbor.length);
     }

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -52,6 +52,7 @@ public interface ContentAddressedStorage {
                                                              PublicKeyHash writer,
                                                              List<byte[]> signedHashes,
                                                              List<Integer> blockSizes,
+                                                             List<List<BatId>> batIds,
                                                              boolean isRaw,
                                                              TransactionId tid) {
         return Futures.errored(new IllegalStateException("Unimplemented call!"));
@@ -333,6 +334,7 @@ public interface ContentAddressedStorage {
                                                                 PublicKeyHash writer,
                                                                 List<byte[]> signedHashes,
                                                                 List<Integer> blockSizes,
+                                                                List<List<BatId>> batIds,
                                                                 boolean isRaw,
                                                                 TransactionId tid) {
             if (! isPeergosServer)
@@ -340,7 +342,7 @@ public interface ContentAddressedStorage {
             List<Long> sizes = blockSizes.stream()
                     .map(Integer::longValue)
                     .collect(Collectors.toList());
-            WriteAuthRequest req = new WriteAuthRequest(signedHashes, sizes);
+            WriteAuthRequest req = new WriteAuthRequest(signedHashes, sizes, batIds);
             return poster.postUnzip(apiPrefix + AUTH_WRITES + "?owner=" + encode(owner.toString())
                     + "&writer=" + encode(writer.toString())
                     + "&transaction=" + encode(tid.toString())
@@ -547,9 +549,10 @@ public interface ContentAddressedStorage {
                                                                 PublicKeyHash writer,
                                                                 List<byte[]> signedHashes,
                                                                 List<Integer> blockSizes,
+                                                                List<List<BatId>> batIds,
                                                                 boolean isRaw,
                                                                 TransactionId tid) {
-            return local.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
+            return local.authWrites(owner, writer, signedHashes, blockSizes, batIds, isRaw, tid);
         }
 
         @Override

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -99,8 +99,9 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,
                                                             List<Integer> blockSizes,
+                                                            List<List<BatId>> batIds,
                                                             boolean isRaw,
                                                             TransactionId tid) {
-        return target.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
+        return target.authWrites(owner, writer, signedHashes, blockSizes, batIds, isRaw, tid);
     }
 }

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -91,26 +91,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
                                             List<byte[]> signedHashes,
                                             List<byte[]> blocks,
                                             TransactionId tid) {
-        return onOwnersNode(owner).thenCompose(ownersNode -> {
-            boolean allSmallBlocks = blocks.stream().map(b -> b.length).filter(len -> len > 8*1024).findAny().isEmpty();
-            if (ownersNode && directWrites && ! allSmallBlocks) {
-                CompletableFuture<List<Cid>> res = new CompletableFuture<>();
-                fallback.authWrites(owner, writer, signedHashes, blocks.stream().map(x -> x.length).collect(Collectors.toList()), false, tid)
-                        .thenCompose(preAuthed -> {
-                            List<CompletableFuture<Cid>> futures = new ArrayList<>();
-                            for (int i = 0; i < blocks.size(); i++) {
-                                PresignedUrl url = preAuthed.get(i);
-                                Cid targetName = keyToHash(url.base.substring(url.base.lastIndexOf("/") + 1));
-                                futures.add(direct.put(url.base, blocks.get(i), url.fields)
-                                        .thenApply(x -> targetName));
-                            }
-                            return Futures.combineAllInOrder(futures);
-                        }).thenApply(res::complete)
-                        .exceptionally(res::completeExceptionally);
-                return res;
-            }
-            return fallback.put(owner, writer, signedHashes, blocks, tid);
-        });
+        return fallback.put(owner, writer, signedHashes, blocks, tid);
     }
 
     private CompletableFuture<Boolean> onOwnersNode(PublicKeyHash owner) {
@@ -169,7 +150,9 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
                                                     TransactionId tid,
                                                     ProgressConsumer<Long> progressCounter) {
         CompletableFuture<List<Cid>> res = new CompletableFuture<>();
-        fallback.authWrites(owner, writer, signatures, blocks.stream().map(x -> x.length).collect(Collectors.toList()), true, tid)
+        List<Integer> sizes = blocks.stream().map(x -> x.length).collect(Collectors.toList());
+        List<List<BatId>> batIds = blocks.stream().map(Bat::getRawBlockBats).collect(Collectors.toList());
+        fallback.authWrites(owner, writer, signatures, sizes, batIds, true, tid)
                 .thenCompose(preAuthed -> {
                     List<CompletableFuture<Cid>> futures = new ArrayList<>();
                     for (int i = 0; i < blocks.size(); i++) {

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -274,7 +274,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
                     });
             return res;
         }
-        if (authedReads) {
+        if (authedReads && hash.isRaw()) {
             CompletableFuture<Optional<byte[]>> res = new CompletableFuture<>();
             fallback.authReads(Arrays.asList(new MirrorCap(hash, bat)))
                     .thenCompose(preAuthedGet -> direct.get(preAuthedGet.get(0).base, preAuthedGet.get(0).fields))

--- a/src/peergos/shared/storage/LocalOnlyStorage.java
+++ b/src/peergos/shared/storage/LocalOnlyStorage.java
@@ -118,6 +118,7 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,
                                                             List<Integer> blockSizes,
+                                                            List<List<BatId>> batIds,
                                                             boolean isRaw,
                                                             TransactionId tid) {
         throw new IllegalStateException("Unimplemented!");

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -154,8 +154,9 @@ public class RetryStorage implements ContentAddressedStorage {
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,
                                                             List<Integer> blockSizes,
+                                                            List<List<BatId>> batIds,
                                                             boolean isRaw,
                                                             TransactionId tid) {
-        return runWithRetry(() -> target.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid));
+        return runWithRetry(() -> target.authWrites(owner, writer, signedHashes, blockSizes, batIds, isRaw, tid));
     }
 }

--- a/src/peergos/shared/storage/WriteAuthRequest.java
+++ b/src/peergos/shared/storage/WriteAuthRequest.java
@@ -1,6 +1,7 @@
 package peergos.shared.storage;
 
 import peergos.shared.cbor.*;
+import peergos.shared.storage.auth.*;
 
 import java.util.*;
 import java.util.stream.*;
@@ -9,10 +10,12 @@ public class WriteAuthRequest implements Cborable {
 
     public final List<byte[]> signatures;
     public final List<Long> sizes;
+    public final List<List<BatId>> batIds;
 
-    public WriteAuthRequest(List<byte[]> signatures, List<Long> sizes) {
+    public WriteAuthRequest(List<byte[]> signatures, List<Long> sizes, List<List<BatId>> batIds) {
         this.signatures = signatures;
         this.sizes = sizes;
+        this.batIds = batIds;
     }
 
     @Override
@@ -24,6 +27,9 @@ public class WriteAuthRequest implements Cborable {
         props.put("l", new CborObject.CborList(sizes.stream()
                 .map(CborObject.CborLong::new)
                 .collect(Collectors.toList())));
+        props.put("b", new CborObject.CborList(batIds.stream()
+                .map(CborObject.CborList::new)
+                .collect(Collectors.toList())));
         return CborObject.CborMap.build(props);
     }
 
@@ -31,6 +37,7 @@ public class WriteAuthRequest implements Cborable {
         CborObject.CborMap map = (CborObject.CborMap) cbor;
         List<byte[]> signatures = map.getList("s", c -> ((CborObject.CborByteArray)c).value);
         List<Long> sizes = map.getList("l", c -> ((CborObject.CborLong)c).value);
-        return new WriteAuthRequest(signatures, sizes);
+        List<List<BatId>> batIds = map.getList("b", c -> ((CborObject.CborList)c).map(BatId::fromCbor));
+        return new WriteAuthRequest(signatures, sizes, batIds);
     }
 }

--- a/src/peergos/shared/storage/WriteFilter.java
+++ b/src/peergos/shared/storage/WriteFilter.java
@@ -2,6 +2,7 @@ package peergos.shared.storage;
 
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.cid.*;
+import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
@@ -25,13 +26,14 @@ public class WriteFilter extends DelegatingStorage {
                                                             PublicKeyHash writer,
                                                             List<byte[]> signedHashes,
                                                             List<Integer> blockSizes,
+                                                            List<List<BatId>> batIds,
                                                             boolean isRaw,
                                                             TransactionId tid) {
         if (! keyFilter.apply(writer, blockSizes.stream().mapToInt(x -> x).sum()))
             throw new IllegalStateException("Key not allowed to write to this server: " + writer);
         if (blockSizes.stream().anyMatch(s -> s > Fragment.MAX_LENGTH_WITH_BAT_PREFIX))
             throw new IllegalStateException("Block too big!");
-        return dht.authWrites(owner, writer, signedHashes, blockSizes, isRaw, tid);
+        return dht.authWrites(owner, writer, signedHashes, blockSizes, batIds, isRaw, tid);
     }
 
     @Override

--- a/src/peergos/shared/storage/auth/Bat.java
+++ b/src/peergos/shared/storage/auth/Bat.java
@@ -104,6 +104,13 @@ public class Bat implements Cborable {
         return ((CborObject.CborList) CborObject.read(bin, block.length)).map(BatId::fromCbor);
     }
 
+    public static List<BatId> getCborBlockBats(byte[] data) {
+        CborObject cbor = CborObject.fromByteArray(data);
+        if (! (cbor instanceof CborObject.CborMap))
+            return Collections.emptyList();
+        return ((CborObject.CborMap) cbor).getList("bats", BatId::fromCbor);
+    }
+
     public static byte[] removeRawBlockBatPrefix(byte[] block) {
         int magicLength = RAW_BLOCK_MAGIC_PREFIX.length;
         if (! ArrayOps.equalArrays(block, 0, magicLength, RAW_BLOCK_MAGIC_PREFIX, 0, magicLength))

--- a/src/peergos/shared/storage/auth/Bat.java
+++ b/src/peergos/shared/storage/auth/Bat.java
@@ -95,6 +95,10 @@ public class Bat implements Cborable {
         }
     }
 
+    public static List<BatId> getBlockBats(Cid h, byte[] data) {
+        return h.isRaw() ? getRawBlockBats(data) : getCborBlockBats(data);
+    }
+
     public static List<BatId> getRawBlockBats(byte[] block) {
         int magicLength = RAW_BLOCK_MAGIC_PREFIX.length;
         if (! ArrayOps.equalArrays(block, 0, magicLength, RAW_BLOCK_MAGIC_PREFIX, 0, magicLength))


### PR DESCRIPTION
Only use authWrites for raw blocks, and send the bats for these.

Update filename for block metadata store to reflect version change.

Remove access time from block metadata store which is not needed.

Make sure all puts or authWrites update block metadata store, which can then be used to list the blockstore (except versioned S3 where we need to list the raw block versions still). 