### PR TITLE
Guard against using bare peerid in BAT auth

### DIFF
--- a/src/peergos/server/storage/auth/BlockRequestAuthoriser.java
+++ b/src/peergos/server/storage/auth/BlockRequestAuthoriser.java
@@ -75,6 +75,8 @@ public interface BlockRequestAuthoriser {
     }
 
     static boolean isValidAuth(BlockAuth auth, Cid block, Cid sourceNode, Bat bat, Hasher h) {
+        if (sourceNode.equals(sourceNode.bareMultihash()))
+            throw new IllegalStateException("BAT auth peer ids must not be bare multihashes!");
         S3Request req = new S3Request("GET", sourceNode.toBase58(), "api/v0/block/get?arg=" + block.toBase58(), S3Request.UNSIGNED,
                 Optional.of(auth.expirySeconds), false, true,
                 Collections.emptyMap(), Collections.emptyMap(), auth.batId.toBase58(), "eu-central-1", auth.awsDatetime);

--- a/src/peergos/shared/storage/auth/Bat.java
+++ b/src/peergos/shared/storage/auth/Bat.java
@@ -75,6 +75,8 @@ public class Bat implements Cborable {
                                                      Hasher h) {
         if (batId.isIdentity())
             throw new IllegalStateException("Cannot use identity multihash in S3 signatures!");
+        if (sourceNode.equals(sourceNode.bareMultihash()))
+            throw new IllegalStateException("BAT auth peer ids must not be bare multihashes!");
         S3Request req = new S3Request("GET", sourceNode.toBase58(), "api/v0/block/get?arg=" + block.toBase58(), S3Request.UNSIGNED,
                 Optional.of(expirySeconds), false, true,
                 Collections.emptyMap(), Collections.emptyMap(), batId.toBase58(), "eu-central-1", datetime);


### PR DESCRIPTION
It must be wrapped with a libp2p codec