### PR TITLE
Don't query blockstore when calculating usage for users that haven't changed

### DIFF
--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -514,7 +514,10 @@ public class MirrorCoreNode implements CoreNode {
             }
 
             // Make sure usage is updated
-            SpaceCheckingKeyFilter.processCorenodeEvent(username, owner, usageStore, ipfs, p2pMutable, hasher);
+            List<Multihash> us = List.of(ourNodeId.bareMultihash());
+            Set<PublicKeyHash> allUserKeys = DeletableContentAddressedStorage.getOwnedKeysRecursive(owner, owner, p2pMutable,
+                    (h, s) -> DeletableContentAddressedStorage.getWriterData(us, h,s, ipfs), ipfs, hasher).join();
+            SpaceCheckingKeyFilter.processCorenodeEvent(username, owner, allUserKeys, usageStore, ipfs, p2pMutable, hasher);
             return Futures.of(res);
         } else // Proxy call to their target storage server
             return writeTarget.migrateUser(username, newChain, migrationTargetNode, mirrorBat);

--- a/src/peergos/server/space/JdbcUsageStore.java
+++ b/src/peergos/server/space/JdbcUsageStore.java
@@ -253,6 +253,7 @@ public class JdbcUsageStore implements UsageStore {
             query.setInt(1, id);
 
             Set<PublicKeyHash> res = new HashSet<>();
+            res.add(owner);
             ResultSet resultSet = query.executeQuery();
             while (resultSet.next())
                 res.add(PublicKeyHash.decode(resultSet.getBytes(1)));

--- a/src/peergos/server/space/RamUsageStore.java
+++ b/src/peergos/server/space/RamUsageStore.java
@@ -44,6 +44,23 @@ public class RamUsageStore implements UsageStore {
     }
 
     @Override
+    public Set<PublicKeyHash> getAllWriters(PublicKeyHash owner) {
+        Set<PublicKeyHash> res = new HashSet<>();
+        getAllWriters(owner, res);
+        res.remove(owner);
+        return res;
+    }
+
+    private void getAllWriters(PublicKeyHash writer, Set<PublicKeyHash> res) {
+        res.add(writer);
+        WriterUsage current = state.currentView.get(writer);
+        for (PublicKeyHash ownedKey : current.ownedKeys()) {
+            if (! res.contains(ownedKey))
+                getAllWriters(ownedKey, res);
+        }
+    }
+
+    @Override
     public void confirmUsage(String owner, PublicKeyHash writer, long usageDelta, boolean errored) {
         UserUsage usage = state.usage.get(owner);
         usage.confirmUsage(writer, usageDelta);

--- a/src/peergos/server/space/RamUsageStore.java
+++ b/src/peergos/server/space/RamUsageStore.java
@@ -47,7 +47,6 @@ public class RamUsageStore implements UsageStore {
     public Set<PublicKeyHash> getAllWriters(PublicKeyHash owner) {
         Set<PublicKeyHash> res = new HashSet<>();
         getAllWriters(owner, res);
-        res.remove(owner);
         return res;
     }
 

--- a/src/peergos/server/space/SpaceCheckingKeyFilter.java
+++ b/src/peergos/server/space/SpaceCheckingKeyFilter.java
@@ -80,6 +80,7 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
     public void calculateUsage() {
         try {
             List<String> usernames = quotaAdmin.getLocalUsernames();
+            long t0 = System.currentTimeMillis();
             Logging.LOG().info("Calculating space usage for " + usernames.size() + " local users...");
             long done = 0;
             for (String username : usernames) {
@@ -100,7 +101,8 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                 }
             }
             usageStore.initialized();
-            Logging.LOG().info("Finished calculating space usage for " + usernames.size() + " local users...");
+            long t1 = System.currentTimeMillis();
+            Logging.LOG().info("Finished calculating space usage for " + usernames.size() + " local users in " + (t1-t0)/1_000 + "s");
         } catch (Exception e) {
             LOG.log(Level.WARNING, e.getMessage(), e);
         }
@@ -199,9 +201,9 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                                             MutablePointers mutable,
                                             Hasher hasher) {
         usageStore.addUserIfAbsent(username);
-        List<Multihash> us = List.of(dht.id().join().bareMultihash());
-        Set<PublicKeyHash> allUserKeys = DeletableContentAddressedStorage.getOwnedKeysRecursive(owner, owner, mutable,
-                (h, s) -> DeletableContentAddressedStorage.getWriterData(us, h,s, dht), dht, hasher).join();
+        // get current set of owned keys from usage db, and traverse filesystem
+        // only if a pointer has changed since last usage update
+        Set<PublicKeyHash> allUserKeys = usageStore.getAllWriters(owner);
 
         for (PublicKeyHash writerKey : allUserKeys) {
             usageStore.addWriter(username, writerKey);
@@ -290,6 +292,12 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                 HashSet<PublicKeyHash> addedOwnedKeys = new HashSet<>(updatedOwned);
                 addedOwnedKeys.removeAll(current.ownedKeys());
                 state.updateWriterUsage(writer, newRoot, removedChildren, addedOwnedKeys, current.directRetainedStorage() + changeInStorage);
+                for (PublicKeyHash added : addedOwnedKeys) {
+                    state.addWriter(current.owner, added);
+                    WriterUsage currentAdded = state.getUsage(added);
+                    MaybeMultihash updatedRoot = mutable.getPointerTarget(owner, added, dht).join().updated;
+                    processMutablePointerEvent(state, owner, added, currentAdded.target(), updatedRoot, mutable, dht, hasher);
+                }
                 System.out.println("Updated usage from " + current.directRetainedStorage() + ", adding " + changeInStorage);
             }
         } catch (Exception e) {

--- a/src/peergos/server/space/SpaceCheckingKeyFilter.java
+++ b/src/peergos/server/space/SpaceCheckingKeyFilter.java
@@ -200,10 +200,19 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                                             DeletableContentAddressedStorage dht,
                                             MutablePointers mutable,
                                             Hasher hasher) {
-        usageStore.addUserIfAbsent(username);
         // get current set of owned keys from usage db, and traverse filesystem
         // only if a pointer has changed since last usage update
         Set<PublicKeyHash> allUserKeys = usageStore.getAllWriters(owner);
+        processCorenodeEvent(username, owner, allUserKeys, usageStore, dht, mutable, hasher);
+    }
+    public static void processCorenodeEvent(String username,
+                                            PublicKeyHash owner,
+                                            Set<PublicKeyHash> allUserKeys,
+                                            UsageStore usageStore,
+                                            DeletableContentAddressedStorage dht,
+                                            MutablePointers mutable,
+                                            Hasher hasher) {
+        usageStore.addUserIfAbsent(username);
 
         for (PublicKeyHash writerKey : allUserKeys) {
             usageStore.addWriter(username, writerKey);

--- a/src/peergos/server/space/WriterUsageStore.java
+++ b/src/peergos/server/space/WriterUsageStore.java
@@ -12,6 +12,8 @@ public interface WriterUsageStore {
 
     Set<PublicKeyHash> getAllWriters();
 
+    Set<PublicKeyHash> getAllWriters(PublicKeyHash owner);
+
     WriterUsage getUsage(PublicKeyHash writer);
 
     void updateWriterUsage(PublicKeyHash writer,

--- a/src/peergos/server/tests/JdbcUsageStoreTests.java
+++ b/src/peergos/server/tests/JdbcUsageStoreTests.java
@@ -28,7 +28,7 @@ public class JdbcUsageStoreTests {
         store.updateWriterUsage(owner, MaybeMultihash.empty(), Collections.emptySet(), Set.of(writer), 0);
 
         Set<PublicKeyHash> allWriters = store.getAllWriters(owner);
-        Assert.assertTrue(allWriters.size() == 1);
+        Assert.assertTrue(allWriters.size() == 2);
         Assert.assertTrue(allWriters.contains(writer));
     }
 }

--- a/src/peergos/server/tests/JdbcUsageStoreTests.java
+++ b/src/peergos/server/tests/JdbcUsageStoreTests.java
@@ -1,0 +1,34 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.*;
+import peergos.server.space.*;
+import peergos.server.sql.*;
+import peergos.server.util.*;
+import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.*;
+
+import java.sql.*;
+import java.util.*;
+
+public class JdbcUsageStoreTests {
+
+    @Test
+    public void ownedKeys() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        String username = "bob";
+        store.addUserIfAbsent(username);
+        PublicKeyHash owner = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter(username, owner);
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter(username, writer);
+        store.updateWriterUsage(owner, MaybeMultihash.empty(), Collections.emptySet(), Set.of(writer), 0);
+
+        Set<PublicKeyHash> allWriters = store.getAllWriters(owner);
+        Assert.assertTrue(allWriters.size() == 1);
+        Assert.assertTrue(allWriters.contains(writer));
+    }
+}


### PR DESCRIPTION
Add WriterUsageStore.getAllWriters(owner)

time calculating space usage at startup

I've deployed this to test. And it dropped the usage calculation from 152s to 3s. And the total S3 requests during restart from 498 to 14.