### PR TITLE
This reduces idle bandwidth from 1.5 Mb/s to 0.1 Mb/s

### DIFF
--- a/src/peergos/server/storage/IpfsWrapper.java
+++ b/src/peergos/server/storage/IpfsWrapper.java
@@ -336,7 +336,8 @@ public class IpfsWrapper implements AutoCloseable {
                 config.bootstrap.getBootstrapAddresses(),
                 config.identity,
                 authoriser,
-                config.addresses.proxyTargetAddress.map(IpfsWrapper::proxyHandler)
+                config.addresses.proxyTargetAddress.map(IpfsWrapper::proxyHandler),
+                Optional.of("/peergos/bitswap")
         );
         ipfsWrapper.embeddedIpfs.start();
         io.ipfs.multiaddr.MultiAddress apiAddress = config.addresses.apiAddress;


### PR DESCRIPTION
Or ~12KB/s (1 GB/day)

The reason for this is go-bitswap (kubo) spams us (1000s req/s) with requests for blocks we don't have. We already block such aggressive peers in the bitswap handler by just closing the connection. But we still pay the bandwidth and CPU to setup the connection and negotiate the muxer and bitswap. By using a different protocol id kubo bitswap will not try and dial us at all.

We will need an immediate release after this, so people can upgrade. 