### PR TITLE
Make GC 100X more scalable (attempt  2)

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -539,7 +539,7 @@ public class Main extends Builder {
             if (enableGC) {
                 boolean useS3 = S3Config.useS3(a);
                 boolean listRawBlocks = useS3 && a.getBoolean("s3.versioned-bucket");
-                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("reachability.sql"), listRawBlocks);
+                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("reachability-sql-file", "reachability.sql"), listRawBlocks);
                 Function<Stream<Map.Entry<PublicKeyHash, byte[]>>, CompletableFuture<Boolean>> snapshotSaver =
                         useS3 ?
                                 ((S3BlockStorage) localStorage)::savePointerSnapshot :

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -539,7 +539,7 @@ public class Main extends Builder {
             if (enableGC) {
                 boolean useS3 = S3Config.useS3(a);
                 boolean listRawBlocks = useS3 && a.getBoolean("s3.versioned-bucket");
-                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("", ""), listRawBlocks);
+                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("", ""), (d, c) -> Futures.of(true), listRawBlocks);
                 Function<Stream<Map.Entry<PublicKeyHash, byte[]>>, CompletableFuture<Boolean>> snapshotSaver =
                         useS3 ?
                                 ((S3BlockStorage) localStorage)::savePointerSnapshot :

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -539,7 +539,7 @@ public class Main extends Builder {
             if (enableGC) {
                 boolean useS3 = S3Config.useS3(a);
                 boolean listRawBlocks = useS3 && a.getBoolean("s3.versioned-bucket");
-                gc = new GarbageCollector(localStorage, rawPointers, usageStore, listRawBlocks);
+                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("reachability.sql"), listRawBlocks);
                 Function<Stream<Map.Entry<PublicKeyHash, byte[]>>, CompletableFuture<Boolean>> snapshotSaver =
                         useS3 ?
                                 ((S3BlockStorage) localStorage)::savePointerSnapshot :

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -539,7 +539,7 @@ public class Main extends Builder {
             if (enableGC) {
                 boolean useS3 = S3Config.useS3(a);
                 boolean listRawBlocks = useS3 && a.getBoolean("s3.versioned-bucket");
-                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("reachability-sql-file", "reachability.sql"), listRawBlocks);
+                gc = new GarbageCollector(localStorage, rawPointers, usageStore, a.fromPeergosDir("", ""), listRawBlocks);
                 Function<Stream<Map.Entry<PublicKeyHash, byte[]>>, CompletableFuture<Boolean>> snapshotSaver =
                         useS3 ?
                                 ((S3BlockStorage) localStorage)::savePointerSnapshot :

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -33,7 +33,7 @@ import java.util.concurrent.*;
 public class UserService {
 	private static final Logger LOG = Logging.LOG();
 
-    public static final Version CURRENT_VERSION = Version.parse("0.14.1");
+    public static final Version CURRENT_VERSION = Version.parse("0.15.1");
     public static final String UI_URL = "/";
 
     private static void initTLS() {

--- a/src/peergos/server/storage/AuthedStorage.java
+++ b/src/peergos/server/storage/AuthedStorage.java
@@ -12,6 +12,7 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class AuthedStorage extends DelegatingStorage implements DeletableContentAddressedStorage {
@@ -118,12 +119,12 @@ public class AuthedStorage extends DelegatingStorage implements DeletableContent
     }
 
     @Override
-    public Stream<BlockVersion> getAllBlockHashVersions() {
-        return target.getAllBlockHashVersions();
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        target.getAllBlockHashVersions(res);
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         return target.getOpenTransactionBlocks();
     }
 

--- a/src/peergos/server/storage/BlockMetadataStore.java
+++ b/src/peergos/server/storage/BlockMetadataStore.java
@@ -5,6 +5,7 @@ import peergos.shared.storage.auth.*;
 import peergos.shared.io.ipfs.Cid;
 
 import java.util.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public interface BlockMetadataStore {
@@ -19,7 +20,7 @@ public interface BlockMetadataStore {
 
     Stream<BlockVersion> list();
 
-    Stream<BlockVersion> listCbor();
+    void listCbor(Consumer<List<BlockVersion>> res);
 
     default BlockMetadata put(Cid block, String version, byte[] data) {
         BlockMetadata meta = extractMetadata(block, data);

--- a/src/peergos/server/storage/BlockVersion.java
+++ b/src/peergos/server/storage/BlockVersion.java
@@ -2,6 +2,8 @@ package peergos.server.storage;
 
 import peergos.shared.io.ipfs.Cid;
 
+import java.util.*;
+
 public class BlockVersion {
     public final Cid cid;
     public final String version;
@@ -11,5 +13,18 @@ public class BlockVersion {
         this.cid = cid;
         this.version = version;
         this.isLatest = isLatest;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        BlockVersion that = (BlockVersion) o;
+        return Objects.equals(cid, that.cid) && Objects.equals(version, that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(cid, version);
     }
 }

--- a/src/peergos/server/storage/DelegatingBlockMetadataStore.java
+++ b/src/peergos/server/storage/DelegatingBlockMetadataStore.java
@@ -4,7 +4,8 @@ import io.ipfs.cid.Cid;
 import org.peergos.blockstore.metadatadb.BlockMetadata;
 import org.peergos.blockstore.metadatadb.BlockMetadataStore;
 
-import java.util.Optional;
+import java.util.*;
+import java.util.function.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,7 +45,12 @@ public class DelegatingBlockMetadataStore implements BlockMetadataStore {
 
     @Override
     public Stream<Cid> listCbor() {
-        return store.listCbor().filter(bv -> bv.isLatest).map(bv2 -> io.ipfs.cid.Cid.cast(bv2.cid.toBytes()));
+        List<Cid> res = new ArrayList<>(1000);
+        store.listCbor(results -> res.addAll(results.stream()
+                .filter(bv -> bv.isLatest)
+                .map(bv2 -> io.ipfs.cid.Cid.cast(bv2.cid.toBytes()))
+                .collect(Collectors.toList())));
+        return res.stream();
     }
 
     @Override

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -12,6 +12,7 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class DelegatingDeletableStorage implements DeletableContentAddressedStorage {
@@ -33,12 +34,12 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public Stream<BlockVersion> getAllBlockHashVersions() {
-        return target.getAllBlockHashVersions();
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        target.getAllBlockHashVersions(res);
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         return target.getOpenTransactionBlocks();
     }
 

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -30,13 +30,13 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
 
     Stream<Cid> getAllBlockHashes(boolean useBlockstore);
 
-    Stream<BlockVersion> getAllBlockHashVersions();
+    void getAllBlockHashVersions(Consumer<List<BlockVersion>> res);
 
-    default Stream<BlockVersion> getAllRawBlockVersions() {
-        return getAllBlockHashVersions().filter(v -> v.cid.isRaw());
+    default void getAllRawBlockVersions(Consumer<List<BlockVersion>> res) {
+        getAllBlockHashVersions(all -> res.accept(all.stream().filter(v -> v.cid.isRaw()).collect(Collectors.toList())));
     }
 
-    List<Multihash> getOpenTransactionBlocks();
+    List<Cid> getOpenTransactionBlocks();
 
     void clearOldTransactions(long cutoffMillis);
 
@@ -258,8 +258,10 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
         }
 
         @Override
-        public Stream<BlockVersion> getAllBlockHashVersions() {
-            return getAllBlockHashes(false).map(c -> new BlockVersion(c, null, true));
+        public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+            res.accept(getAllBlockHashes(false)
+                    .map(c -> new BlockVersion(c, null, true))
+                    .collect(Collectors.toList()));
         }
 
         @Override
@@ -279,7 +281,7 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
         }
 
         @Override
-        public List<Multihash> getOpenTransactionBlocks() {
+        public List<Cid> getOpenTransactionBlocks() {
             throw new IllegalStateException("Unimplemented!");
         }
 

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -78,7 +78,7 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         return transactions.getOpenTransactionBlocks();
     }
 
@@ -242,8 +242,10 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public Stream<BlockVersion> getAllBlockHashVersions() {
-        return getAllBlockHashes(false).map(c -> new BlockVersion(c, null, true));
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        res.accept(getAllBlockHashes(false)
+                .map(c -> new BlockVersion(c, null, true))
+                .collect(Collectors.toList()));
     }
 
     @Override

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -304,7 +304,7 @@ public class GarbageCollector {
         return new Pair<>(deletedCborBlocks, deletedRawBlocks);
     }
 
-    private static boolean markReachable(DeletableContentAddressedStorage storage,
+    public static boolean markReachable(DeletableContentAddressedStorage storage,
                                          Cid root,
                                          String username,
                                          SqliteBlockReachability reachability,
@@ -329,8 +329,8 @@ public class GarbageCollector {
                     .orElseGet(() -> getWithBackoff(() -> storage.getLinks(block).join()));
             queue.addAll(links);
             if (queue.size() > 1000) {
-                reachability.setReachable(links, totalReachable);
-                links.clear();
+                reachability.setReachable(queue, totalReachable);
+                queue.clear();
             }
             for (Cid link : links) {
                 markReachable(storage, false, queue, link, reachability, metadata, username, totalReachable);

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -2,6 +2,7 @@ package peergos.server.storage;
 
 import peergos.server.corenode.*;
 import peergos.server.space.*;
+import peergos.server.sql.*;
 import peergos.server.util.*;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
@@ -13,6 +14,10 @@ import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.util.*;
 
+import java.io.*;
+import java.nio.file.*;
+import java.sql.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -72,16 +77,17 @@ public class GarbageCollector {
         garbageCollector.start();
     }
 
-    private static List<BlockVersion> listBlocks(boolean listFromBlockstore,
-                                                 DeletableContentAddressedStorage storage,
-                                                 BlockMetadataStore metadata) {
-        // dedupe to guarantee no duplicate cids which might result in data loss
-        Map<Cid, BlockVersion> deduped = (listFromBlockstore ?
-                storage.getAllBlockHashVersions() :
-                Stream.concat(storage.getAllRawBlockVersions(), metadata.listCbor()))
-                .collect(Collectors.toMap(v -> v.cid, v -> v,
-                        (a, b) -> a.isLatest ? a : b.isLatest ? b : a.version.isEmpty() ? b : a));
-        return new ArrayList<>(deduped.values());
+    private static void listBlocks(SqliteBlockReachability reachability,
+                                   boolean listFromBlockstore,
+                                   DeletableContentAddressedStorage storage,
+                                   BlockMetadataStore metadata) {
+        // the reachability store dedupes on cid + version to guarantee no duplicates which would result in data loss
+        if (listFromBlockstore)
+            storage.getAllBlockHashVersions(reachability::addBlocks);
+        else {
+            storage.getAllRawBlockVersions(reachability::addBlocks);
+            metadata.listCbor(reachability::addBlocks);
+        }
     }
 
     public static void checkIntegrity(DeletableContentAddressedStorage storage,
@@ -158,16 +164,18 @@ public class GarbageCollector {
                                BlockMetadataStore metadata,
                                boolean listFromBlockstore) {
         System.out.println("Starting blockstore garbage collection on node " + storage.id().join() + "...");
-        // TODO: do this more efficiently with a bloom filter, and actual streaming and multithreading
+        // TODO: do GC in O(1) RAM with a bloom filter?: mark into bloom. Then list and check bloom to delete.
         storage.clearOldTransactions(System.currentTimeMillis() - 24*3600*1000L);
         long t0 = System.nanoTime();
+        SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb("reachability.sql");
         // Versions are only relevant for versioned S3 buckets, otherwise version is null
         // For S3, clients write raw blocks directly, we need to get their version directly from S3
-        List<BlockVersion> present = listBlocks(listFromBlockstore, storage, metadata);
+        listBlocks(reachability, listFromBlockstore, storage, metadata);
         long t1 = System.nanoTime();
-        System.out.println("Listing " + present.size() + " blocks took " + (t1-t0)/1_000_000_000 + "s");
+        long nBlocks = reachability.size();
+        System.out.println("Listing " + nBlocks + " blocks took " + (t1-t0)/1_000_000_000 + "s");
 
-        List<Multihash> pending = storage.getOpenTransactionBlocks();
+        List<Cid> pending = storage.getOpenTransactionBlocks();
         long t2 = System.nanoTime();
         System.out.println("Listing " + pending.size() + " pending blocks took " + (t2-t1)/1_000_000_000 + "s");
 
@@ -179,16 +187,10 @@ public class GarbageCollector {
         // Get the current roots from the usage store which shouldn't be GC'd until usage has been updated
         List<Pair<Multihash, String>> usageRoots = usage.getAllTargets();
 
-        Map<Multihash, Integer> toIndex = new HashMap<>();
-        for (int i = 0; i < present.size(); i++)
-            if (present.get(i).isLatest)
-                toIndex.put(present.get(i).cid, i);
-        BitSet reachable = new BitSet(present.size());
-
         int markParallelism = 10;
         ForkJoinPool markPool = Threads.newPool(markParallelism, "GC-mark-");
         List<ForkJoinTask<Boolean>> usageMarked = usageRoots.stream()
-                .map(r -> markPool.submit(() -> markReachable(storage, (Cid)r.left, r.right, toIndex, reachable, metadata)))
+                .map(r -> markPool.submit(() -> markReachable(storage, (Cid)r.left, r.right, reachability, metadata)))
                 .collect(Collectors.toList());
         usageMarked.forEach(f -> f.join());
         long t4 = System.nanoTime();
@@ -197,17 +199,14 @@ public class GarbageCollector {
         Set<Multihash> fromUsage = new HashSet<>(usageRoots.size());
         fromUsage.addAll(usageRoots.stream().map(r -> r.left).collect(Collectors.toSet()));
         List<ForkJoinTask<Boolean>> marked = allPointers.entrySet().stream()
-                .map(e -> markPool.submit(() -> markReachable(e.getKey(), e.getValue(), reachable, toIndex, storage, usage, fromUsage, metadata)))
+                .map(e -> markPool.submit(() -> markReachable(e.getKey(), e.getValue(), reachability, storage, usage, fromUsage, metadata)))
                 .collect(Collectors.toList());
         long rootsProcessed = marked.stream().filter(ForkJoinTask::join).count();
 
         long t5 = System.nanoTime();
         System.out.println("Marking reachable from "+rootsProcessed+" pointers took " + (t5-t4)/1_000_000_000 + "s");
-        for (Multihash additional : pending) {
-            int index = toIndex.getOrDefault(additional, -1);
-            if (index >= 0)
-                reachable.set(index);
-        }
+        reachability.setReachable(pending);
+
         long t6 = System.nanoTime();
         System.out.println("Marking "+pending.size()+" pending blocks reachable took " + (t6-t5)/1_000_000_000 + "s");
 
@@ -216,12 +215,10 @@ public class GarbageCollector {
 
         int deleteParallelism = 4;
         ForkJoinPool pool = Threads.newPool(deleteParallelism, "GC-delete-");
-        int batchSize = present.size() / deleteParallelism;
         AtomicLong progressCounter = new AtomicLong(0);
-        List<ForkJoinTask<Pair<Long, Long>>> futures = IntStream.range(0, deleteParallelism)
-                .mapToObj(i -> pool.submit(() -> deleteUnreachableBlocks(i * batchSize,
-                        Math.min((i + 1) * batchSize, present.size()), reachable, present, progressCounter, storage, metadata)))
-                .collect(Collectors.toList());
+        List<ForkJoinTask<Pair<Long, Long>>> futures = new ArrayList<>();
+        reachability.getUnreachable(toDel -> futures.add(pool.submit(() ->
+                deleteUnreachableBlocks(toDel, progressCounter, storage, metadata))));
         Pair<Long, Long> deleted = futures.stream()
                 .map(ForkJoinTask::join).reduce((a, b) -> new Pair<>(a.left + b.left, a.right + b.right))
                 .get();
@@ -237,8 +234,7 @@ public class GarbageCollector {
 
     private static boolean markReachable(PublicKeyHash writerHash,
                                          byte[] signedRawCas,
-                                         BitSet reachable,
-                                         Map<Multihash, Integer> toIndex,
+                                         SqliteBlockReachability reachability,
                                          DeletableContentAddressedStorage storage,
                                          UsageStore usage,
                                          Set<Multihash> done,
@@ -248,7 +244,7 @@ public class GarbageCollector {
         PointerUpdate cas = PointerUpdate.fromCbor(CborObject.fromByteArray(bothHashes));
         MaybeMultihash updated = cas.updated;
         if (updated.isPresent() && ! done.contains(updated.get())) {
-            markReachable(storage, (Cid) updated.get(), toIndex, reachable, metadata, () -> getUsername(writerHash, usage));
+            markReachable(storage, true, new ArrayList<>(1000), (Cid) updated.get(), reachability, metadata, () -> getUsername(writerHash, usage));
             return true;
         }
         return false;
@@ -262,48 +258,21 @@ public class GarbageCollector {
         }
     }
 
-    private static Pair<Long, Long> deleteUnreachableBlocks(int startIndex,
-                                                            int endIndex,
-                                                            BitSet reachable,
-                                                            List<BlockVersion> present,
+    private static Pair<Long, Long> deleteUnreachableBlocks(List<BlockVersion> toDelete,
                                                             AtomicLong progress,
                                                             DeletableContentAddressedStorage storage,
                                                             BlockMetadataStore metadata) {
-        long deletedCborBlocks = 0, deletedRawBlocks = 0;
-        long logPoint = startIndex;
-        final int maxDeleteCount = 1000;
-        List<BlockVersion> pendingDeletes = new ArrayList<>();
-        for (int i = reachable.nextClearBit(startIndex); i >= startIndex && i < endIndex; i = reachable.nextClearBit(i + 1)) {
-            BlockVersion version = present.get(i);
-            Cid hash = version.cid;
-            if (hash.isRaw())
-                deletedRawBlocks++;
-            else
-                deletedCborBlocks++;
-            pendingDeletes.add(version);
-
-            if (pendingDeletes.size() >= maxDeleteCount) {
-                getWithBackoff(() -> {storage.bulkDelete(pendingDeletes); return true;});
-                for (BlockVersion block : pendingDeletes) {
-                    metadata.remove(block.cid);
-                }
-                pendingDeletes.clear();
-            }
-
-            int tenth = (endIndex - startIndex) / 10;
-            if (i > logPoint + tenth) {
-                logPoint += tenth;
-                long updatedProgress = progress.addAndGet(tenth);
-                if (updatedProgress * 10 / present.size() > (updatedProgress - tenth) * 10 / present.size())
-                    System.out.println("Deleting unreachable blocks: " + updatedProgress * 100 / present.size() + "% done");
-            }
+        long deletedCborBlocks = toDelete.stream().filter(v -> ! v.cid.isRaw()).count();
+        long deletedRawBlocks = toDelete.size() - deletedCborBlocks;
+        getWithBackoff(() -> {storage.bulkDelete(toDelete); return true;});
+        for (BlockVersion block : toDelete) {
+            metadata.remove(block.cid);
         }
-        if (pendingDeletes.size() > 0) {
-            getWithBackoff(() -> {storage.bulkDelete(pendingDeletes); return true;});
-            for (BlockVersion block : pendingDeletes) {
-                metadata.remove(block.cid);
-            }
-        }
+
+        long logEvery = 100_000;
+        long updatedProgress = progress.addAndGet(toDelete.size());
+        if (updatedProgress / logEvery > (updatedProgress - toDelete.size()) / logEvery)
+            System.out.println("Deleting unreachable blocks: " + updatedProgress + " done");
 
         return new Pair<>(deletedCborBlocks, deletedRawBlocks);
     }
@@ -311,33 +280,37 @@ public class GarbageCollector {
     private static boolean markReachable(DeletableContentAddressedStorage storage,
                                          Cid root,
                                          String username,
-                                         Map<Multihash, Integer> toIndex,
-                                         BitSet reachable,
+                                         SqliteBlockReachability reachability,
                                          BlockMetadataStore metadata) {
-        return markReachable(storage, root, toIndex, reachable, metadata, () -> username);
+        return markReachable(storage, true, new ArrayList<>(1000), root, reachability, metadata, () -> username);
     }
 
     private static boolean markReachable(DeletableContentAddressedStorage storage,
-                                         Cid root,
-                                         Map<Multihash, Integer> toIndex,
-                                         BitSet reachable,
+                                         boolean isRoot,
+                                         List<Cid> queue,
+                                         Cid block,
+                                         SqliteBlockReachability reachability,
                                          BlockMetadataStore metadata,
                                          Supplier<String> username) {
-        int index = toIndex.getOrDefault(root, -1);
-        if (index >= 0) {
-            synchronized (reachable) {
-                reachable.set(index);
-            }
-        }
+        if (isRoot)
+            queue.add(block);
+
         try {
-            List<Cid> links = metadata.get(root).map(m -> m.links)
-                    .orElseGet(() -> getWithBackoff(() -> storage.getLinks(root).join()));
+            List<Cid> links = metadata.get(block).map(m -> m.links)
+                    .orElseGet(() -> getWithBackoff(() -> storage.getLinks(block).join()));
+            queue.addAll(links);
+            if (queue.size() > 1000) {
+                reachability.setReachable(links);
+                links.clear();
+            }
             for (Cid link : links) {
-                markReachable(storage, link, toIndex, reachable, metadata, username);
+                markReachable(storage, false, queue, link, reachability, metadata, username);
             }
         } catch (Exception e) {
             LOG.info("Error processing user " + username.get());
         }
+        if (isRoot)
+            reachability.setReachable(queue);
         return true;
     }
 

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -220,8 +220,9 @@ public class GarbageCollector {
         reachability.getUnreachable(toDel -> futures.add(pool.submit(() ->
                 deleteUnreachableBlocks(toDel, progressCounter, storage, metadata))));
         Pair<Long, Long> deleted = futures.stream()
-                .map(ForkJoinTask::join).reduce((a, b) -> new Pair<>(a.left + b.left, a.right + b.right))
-                .get();
+                .map(ForkJoinTask::join)
+                .reduce((a, b) -> new Pair<>(a.left + b.left, a.right + b.right))
+                .orElse(new Pair<>(0L, 0L));
         long deletedCborBlocks = deleted.left;
         long deletedRawBlocks = deleted.right;
         long t7 = System.nanoTime();

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -169,7 +169,8 @@ public class GarbageCollector {
         // TODO: do GC in O(1) RAM with a bloom filter?: mark into bloom. Then list and check bloom to delete.
         storage.clearOldTransactions(System.currentTimeMillis() - 24*3600*1000L);
         long t0 = System.nanoTime();
-        Path reachabilityDbFile = reachabilityDbDir.resolve("reachability-" + LocalDateTime.now() + ".sql");
+        Path reachabilityDbFile = reachabilityDbDir.resolve("reachability-" + LocalDate.now() + "-"
+                + new Random().nextInt(100_000)+".sql");
         SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb(reachabilityDbFile);
         // Versions are only relevant for versioned S3 buckets, otherwise version is null
         // For S3, clients write raw blocks directly, we need to get their version directly from S3

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -288,7 +288,7 @@ public class GarbageCollector {
         }
         getWithBackoff(() -> {storage.bulkDelete(toDelete); return true;});
 
-        long logEvery = totalBlocksToDelete / 10;
+        long logEvery = Math.max(1_000, totalBlocksToDelete / 10);
         long updatedProgress = progress.addAndGet(toDelete.size());
         if (updatedProgress / logEvery > (updatedProgress - toDelete.size()) / logEvery)
             System.out.println("Deleting unreachable blocks: " + updatedProgress * 100 / totalBlocksToDelete + "% done");

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -171,6 +171,7 @@ public class GarbageCollector {
         // TODO: do GC in O(1) RAM with a bloom filter?: mark into bloom. Then list and check bloom to delete.
         storage.clearOldTransactions(System.currentTimeMillis() - 24*3600*1000L);
         long t0 = System.nanoTime();
+        reachabilityDbFile = PathUtil.get(reachabilityDbFile.toString() + LocalDateTime.now());
         SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb(reachabilityDbFile);
         // Versions are only relevant for versioned S3 buckets, otherwise version is null
         // For S3, clients write raw blocks directly, we need to get their version directly from S3
@@ -232,6 +233,9 @@ public class GarbageCollector {
         long t7 = System.nanoTime();
         metadata.compact();
         long t8 = System.nanoTime();
+        try {
+            Files.delete(reachabilityDbFile);
+        } catch (IOException e) {}
         System.out.println("Deleting blocks took " + (t7-t6)/1_000_000_000 + "s");
         System.out.println("GC complete. Freed " + deletedCborBlocks + " cbor blocks and " + deletedRawBlocks +
                 " raw blocks, total duration: " + (t7-t0)/1_000_000_000 + "s, metadata.compact took " + (t8-t7)/1_000_000_000 + "s");

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -279,6 +279,8 @@ public class GarbageCollector {
                                                             long totalBlocksToDelete,
                                                             DeletableContentAddressedStorage storage,
                                                             BlockMetadataStore metadata) {
+        if (toDelete.isEmpty())
+            return new Pair<>(0L, 0L);
         long deletedCborBlocks = toDelete.stream().filter(v -> ! v.cid.isRaw()).count();
         long deletedRawBlocks = toDelete.size() - deletedCborBlocks;
         for (BlockVersion block : toDelete) {

--- a/src/peergos/server/storage/JdbcTransactionStore.java
+++ b/src/peergos/server/storage/JdbcTransactionStore.java
@@ -100,11 +100,11 @@ public class JdbcTransactionStore implements TransactionStore {
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         try (Connection conn = getConnection();
              PreparedStatement select = conn.prepareStatement(SELECT_TRANSACTIONS_BLOCKS)) {
             ResultSet rs = select.executeQuery();
-            List<Multihash> results = new ArrayList<>();
+            List<Cid> results = new ArrayList<>();
             while (rs.next())
             {
                 String tid = rs.getString("tid");

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -12,6 +12,7 @@ import peergos.shared.util.*;
 import java.security.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class RAMStorage implements DeletableContentAddressedStorage {
@@ -64,8 +65,10 @@ public class RAMStorage implements DeletableContentAddressedStorage {
 
 
     @Override
-    public Stream<BlockVersion> getAllBlockHashVersions() {
-        return getAllBlockHashes(false).map(c -> new BlockVersion(c, null, true));
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        res.accept(getAllBlockHashes(false)
+                .map(c -> new BlockVersion(c, null, true))
+                .collect(Collectors.toList()));
     }
 
     @Override
@@ -74,7 +77,7 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         return openTransactions.values()
                 .stream()
                 .flatMap(List::stream)

--- a/src/peergos/server/storage/RamBlockMetadataStore.java
+++ b/src/peergos/server/storage/RamBlockMetadataStore.java
@@ -3,6 +3,7 @@ package peergos.server.storage;
 import peergos.shared.io.ipfs.Cid;
 
 import java.util.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class RamBlockMetadataStore implements BlockMetadataStore {
@@ -34,11 +35,12 @@ public class RamBlockMetadataStore implements BlockMetadataStore {
     }
 
     @Override
-    public Stream<BlockVersion> listCbor() {
-        return store.keySet()
+    public void listCbor(Consumer<List<BlockVersion>> res) {
+        res.accept(store.keySet()
                 .stream()
                 .filter(c -> ! c.isRaw())
-                .map(c -> new BlockVersion(c, null, true));
+                .map(c -> new BlockVersion(c, null, true))
+                .collect(Collectors.toList()));
     }
 
     @Override

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -481,7 +481,15 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
 
     private void collectGarbage(JdbcIpnsAndSocial pointers, UsageStore usage, BlockMetadataStore metadata, boolean listFromBlockstore) {
         GarbageCollector.collect(this, pointers, usage, Paths.get(""),
-                this::savePointerSnapshot, metadata, listFromBlockstore);
+                this::savePointerSnapshot, metadata, this::confirmDeleteBlocks, listFromBlockstore);
+    }
+
+    private CompletableFuture<Boolean> confirmDeleteBlocks(long count, long total) {
+        System.out.println("Delete " + count + " blocks out of " + total + " (Y/N)");
+        String confirm = System.console().readLine();
+        if (confirm.equals("Y"))
+            return Futures.of(true);
+        throw new IllegalStateException("Aborting delete!");
     }
 
     public CompletableFuture<Boolean> savePointerSnapshot(Stream<Map.Entry<PublicKeyHash, byte[]>> pointers) {

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -480,7 +480,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     private void collectGarbage(JdbcIpnsAndSocial pointers, UsageStore usage, BlockMetadataStore metadata, boolean listFromBlockstore) {
-        GarbageCollector.collect(this, pointers, usage, Paths.get("reachability.sql"),
+        GarbageCollector.collect(this, pointers, usage, Paths.get(""),
                 this::savePointerSnapshot, metadata, listFromBlockstore);
     }
 

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -470,7 +470,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         return transactions.getOpenTransactionBlocks();
     }
 
@@ -728,47 +728,17 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public Stream<BlockVersion> getAllBlockHashVersions() {
-        // todo make this actually streaming
-        return getFileVersions(Long.MAX_VALUE).stream();
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        getFileVersions(res);
     }
 
     @Override
-    public Stream<BlockVersion> getAllRawBlockVersions() {
-        // todo make this actually streaming
-        List<BlockVersion> results = new ArrayList<>();
-        applyToAllVersions("AFK", obj -> {
-            try {
-                results.add(new BlockVersion(keyToHash(obj.key), obj.version, obj.isLatest));
-            } catch (Exception e) {
-                LOG.warning("Couldn't parse S3 key to Cid: " + obj.key);
-            }
-        }, del -> {
-            try {
-                results.add(new BlockVersion(keyToHash(del.key), del.version, del.isLatest));
-            } catch (Exception e) {
-                LOG.warning("Couldn't parse S3 key to Cid: " + del.key);
-            }
-        }, Long.MAX_VALUE);
-        return results.stream();
+    public void getAllRawBlockVersions(Consumer<List<BlockVersion>> res) {
+        applyToAllVersions("AFK", res, res);
     }
 
-    private List<BlockVersion> getFileVersions(long maxReturned) {
-        List<BlockVersion> results = new ArrayList<>();
-        applyToAllVersions("", obj -> {
-            try {
-                results.add(new BlockVersion(keyToHash(obj.key), obj.version, obj.isLatest));
-            } catch (Exception e) {
-                LOG.warning("Couldn't parse S3 key to Cid: " + obj.key);
-            }
-        }, del -> {
-            try {
-                results.add(new BlockVersion(keyToHash(del.key), del.version, del.isLatest));
-            } catch (Exception e) {
-                LOG.warning("Couldn't parse S3 key to Cid: " + del.key);
-            }
-        }, maxReturned);
-        return results;
+    private void getFileVersions(Consumer<List<BlockVersion>> res) {
+        applyToAllVersions("", res, res);
     }
 
     private List<Cid> getFiles(long maxReturned) {
@@ -824,14 +794,12 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     private void applyToAllVersions(String prefix,
-                                    Consumer<S3AdminRequests.ObjectMetadataVersion> processor,
-                                    Consumer<S3AdminRequests.DeleteMarker> deleteProcessor,
-                                    long maxObjects) {
+                                    Consumer<List<BlockVersion>> processor,
+                                    Consumer<List<BlockVersion>> deleteProcessor) {
         try {
             Optional<String> keyMarker = Optional.empty();
             Optional<String> versionIdMarker = Optional.empty();
             S3AdminRequests.ListObjectVersionsReply result;
-            long processedObjects = 0;
             do {
                 result = S3AdminRequests.listObjectVersions(folder + prefix, 1_000, keyMarker, versionIdMarker,
                         ZonedDateTime.now(), host, region, accessKeyId, secretKey, url -> {
@@ -842,32 +810,22 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
                             }
                         }, S3AdminRequests.builder::get, useHttps, hasher);
 
-                for (S3AdminRequests.ObjectMetadataVersion objectSummary : result.versions) {
-                    if (objectSummary.key.endsWith("/")) {
-                        LOG.fine(" - " + objectSummary.key + "  " + "(directory)");
-                        continue;
-                    }
-                    processor.accept(objectSummary);
-                    processedObjects++;
-                    if (processedObjects >= maxObjects)
-                        return;
-                }
-                for (S3AdminRequests.DeleteMarker deleteSummary : result.deletes) {
-                    if (deleteSummary.key.endsWith("/")) {
-                        LOG.fine(" - " + deleteSummary.key + "  " + "(directory)");
-                        continue;
-                    }
-                    deleteProcessor.accept(deleteSummary);
-                    processedObjects++;
-                    if (processedObjects >= maxObjects)
-                        return;
-                }
+                List<BlockVersion> versions = result.versions.stream()
+                        .filter(omv -> !omv.key.endsWith("/"))
+                        .map(omv -> new BlockVersion(keyToHash(omv.key), omv.version, omv.isLatest))
+                        .collect(Collectors.toList());
+                processor.accept(versions);
+
+                List<BlockVersion> deletes = result.deletes.stream()
+                        .filter(dm -> !dm.key.endsWith("/"))
+                        .map(dm -> new BlockVersion(keyToHash(dm.key), dm.version, dm.isLatest))
+                        .collect(Collectors.toList());
+                deleteProcessor.accept(deletes);
                 LOG.log(Level.FINE, "Next key marker : " + result.nextKeyMarker);
                 LOG.log(Level.FINE, "Next version id marker : " + result.nextVersionIdMarker);
                 keyMarker = result.nextKeyMarker;
                 versionIdMarker = result.nextVersionIdMarker;
             } while (result.isTruncated);
-
         } catch (Exception e) {
             LOG.log(Level.SEVERE, e.getMessage(), e);
         }

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -889,6 +889,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
 
     public static void main(String[] args) throws Exception {
         Args a = Args.parse(args);
+        Logging.init(a.with("log-to-console", "true"));
         Crypto crypto = Main.initCrypto();
         Hasher hasher = crypto.hasher;
         S3Config config = S3Config.build(a, Optional.empty());

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -480,7 +480,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     private void collectGarbage(JdbcIpnsAndSocial pointers, UsageStore usage, BlockMetadataStore metadata, boolean listFromBlockstore) {
-        GarbageCollector.collect(this, pointers, usage,
+        GarbageCollector.collect(this, pointers, usage, Paths.get("reachability.sql"),
                 this::savePointerSnapshot, metadata, listFromBlockstore);
     }
 

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -1,0 +1,236 @@
+package peergos.server.storage;
+
+import peergos.server.sql.*;
+import peergos.server.util.*;
+import peergos.shared.io.ipfs.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.sql.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.logging.*;
+import java.util.stream.*;
+
+public class SqliteBlockReachability {
+    private static final Logger LOG = peergos.server.util.Logging.LOG();
+    private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS reachability (" +
+            "hash bytes not null, " +
+            "version text, " +
+            "latest boolean not null," +
+            "reachable boolean not null); " +
+                "CREATE UNIQUE INDEX IF NOT EXISTS hash_reachable_index ON reachability (hash, version);";
+
+    private static final String SET_REACHABLE = "UPDATE reachability SET reachable=true WHERE hash = ? AND latest = true";
+    private static final String INSERT_SUFFIX = "INTO reachability (hash, version, latest, reachable) VALUES(?, ?, ?, false)";
+    private static final String UNREACHABLE = "SELECT hash, version FROM reachability WHERE reachable = false";
+    private static final String COUNT = "SELECT COUNT(*) FROM reachability";
+
+    private final Supplier<Connection> conn;
+    private final SqlSupplier cmds;
+    public SqliteBlockReachability(Supplier<Connection> conn, SqlSupplier cmds) {
+        this.conn = conn;
+        this.cmds = cmds;
+        init(cmds);
+    }
+
+    private Connection getConnection() {
+        Connection connection = conn.get();
+        try {
+            connection.setAutoCommit(true);
+            connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            return connection;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Connection getNonCommittingConnection() {
+        Connection connection = conn.get();
+        try {
+            connection.setAutoCommit(false);
+            connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            return connection;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private synchronized void init(SqlSupplier commands) {
+        try (Connection conn = getConnection()) {
+            commands.createTable(CREATE_TABLE, conn);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void addBlocks(List<BlockVersion> versions) {
+        try (Connection conn = getNonCommittingConnection();
+             PreparedStatement insert = conn.prepareStatement(cmds.insertOrIgnoreCommand("INSERT ", INSERT_SUFFIX))) {
+            List<BlockVersion> distinct = versions.stream().distinct().collect(Collectors.toList());
+            for (BlockVersion version : distinct) {
+                insert.setBytes(1, version.cid.toBytes());
+                insert.setString(2, version.version);
+                insert.setBoolean(3, version.isLatest);
+                insert.addBatch();
+            }
+            int[] changed = insert.executeBatch();
+            conn.commit();
+            if (IntStream.of(changed).sum() < distinct.size())
+                throw new IllegalStateException("Couldn't insert blocks!");
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+        }
+    }
+
+    public void setReachable(List<Cid> blocks) {
+        try (Connection conn = getNonCommittingConnection();
+             PreparedStatement update = conn.prepareStatement(SET_REACHABLE)) {
+            for (Cid block : blocks) {
+                update.setBytes(1, block.toBytes());
+                update.addBatch();
+            }
+            int[] changed = update.executeBatch();
+            conn.commit();
+            if (IntStream.of(changed).sum() < blocks.size())
+                throw new IllegalStateException("Couldn't set reachable");
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+        }
+    }
+
+    public long size() {
+        try (Connection conn = getConnection();
+             PreparedStatement query = conn.prepareStatement(COUNT)) {
+            ResultSet res = query.executeQuery();
+            res.next();
+            return res.getLong(1);
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    public void getUnreachable(Consumer<List<BlockVersion>> toDelete) {
+        try (Connection conn = getConnection();
+             PreparedStatement select = conn.prepareStatement(UNREACHABLE)) {
+            ResultSet res = select.executeQuery();
+            int batchSize = 1000;
+            List<BlockVersion> tmp = new ArrayList<>(batchSize);
+            while (res.next()) {
+                tmp.add(new BlockVersion(Cid.cast(res.getBytes(1)), res.getString(2), false));
+                if (tmp.size() % batchSize == 0) {
+                    toDelete.accept(tmp);
+                    tmp = new ArrayList<>(batchSize);
+                }
+            }
+            if (! tmp.isEmpty())
+                toDelete.accept(tmp);
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+        }
+    }
+
+    public static SqliteBlockReachability createReachabilityDb(String filename) {
+        try {
+            Path dbFile = Path.of(filename);
+            if (Files.exists(dbFile))
+                Files.delete(dbFile);
+            Connection memory = Sqlite.build(filename);
+            // We need a connection that ignores close
+            Connection instance = new Sqlite.UncloseableConnection(memory);
+            return new SqliteBlockReachability(() -> instance, new SqliteCommands());
+        } catch (SQLException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] a) throws IOException {
+        // This is a benchmark to test baseline speed of a blockstore GC
+        String filename = "temp.sql";
+        Path file = Path.of(filename);
+        if (Files.exists(file))
+            Files.delete(file);
+
+        SqliteBlockReachability reachabilityDb = createReachabilityDb(filename);
+        List<BlockVersion> versions = new ArrayList<>();
+        int count = 1_000_000;
+        boolean versioned = true;
+        Random rnd = new Random(28);
+
+        for (int i = 0; i < count; i++) {
+            byte[] hash = new byte[32];
+            rnd.nextBytes(hash);
+            Cid cid = new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
+            if (versioned)
+                versions.add(new BlockVersion(cid, ArrayOps.bytesToHex(hash), true));
+            else
+                versions.add(new BlockVersion(cid, null, true));
+        }
+        System.out.println("Starting Db load...");
+        long t0 = System.nanoTime();
+        int batchSize = 10_000;
+        for (int i = 0; i < count / batchSize; i++) {
+            reachabilityDb.addBlocks(versions.subList(i * batchSize, (i+1)* batchSize));
+        }
+        long t1 = System.nanoTime();
+        System.out.println("Load duration " + (t1-t0)/1_000_000_000 + "s, batch size = " + batchSize);
+        int markBatchSize = 1000;
+        for (int i = 0; i < count / markBatchSize; i++) {
+            List<Cid> batch = versions.subList(i * markBatchSize, (i + 1) * markBatchSize)
+                    .stream()
+                    .map(v -> v.cid)
+                    .collect(Collectors.toList());
+            reachabilityDb.setReachable(batch);
+        }
+        long t2 = System.nanoTime();
+        System.out.println("Marking reachable took " + (t2-t1)/1_000_000_000 + "s, batch size = " + markBatchSize);
+
+        List<BlockVersion> unreachable = new ArrayList<>();
+        long t3 = System.nanoTime();
+        reachabilityDb.getUnreachable(unreachable::addAll);
+        if (!unreachable.isEmpty())
+            throw new IllegalStateException("Incorrect garbage! This would lose data!");
+        long t4 = System.nanoTime();
+        System.out.println("Listing garbage took " + (t4-t3)/1_000_000 + "ms");
+
+        long size = reachabilityDb.size();
+        if (size != count)
+            throw new IllegalStateException("Missing rows!");
+
+        // Now double the size with unreachable blocks
+        for (int i = 0; i < count; i++) {
+            byte[] hash = new byte[32];
+            rnd.nextBytes(hash);
+            Cid cid = new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
+            if (versioned)
+                versions.add(new BlockVersion(cid, ArrayOps.bytesToHex(hash), true));
+            else
+                versions.add(new BlockVersion(cid, null, true));
+        }
+        for (int i = 0; i < count / batchSize; i++) {
+            reachabilityDb.addBlocks(versions.subList(count + i * batchSize, count + (i+1)* batchSize));
+        }
+        long t5 = System.nanoTime();
+        reachabilityDb.getUnreachable(unreachable::addAll);
+        long t6 = System.nanoTime();
+        if (unreachable.size() != count)
+            throw new IllegalStateException("Incorrect garbage!");
+        System.out.println("Listing garbage took " + (t6-t5)/1_000_000 + "ms");
+
+        // put the same block version in multiple times (should be idempotent)
+        long priorSize = reachabilityDb.size();
+        byte[] hash1 = new byte[32];
+        rnd.nextBytes(hash1);
+        Cid cid1 = new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash1);
+        BlockVersion v1 = new BlockVersion(cid1, ArrayOps.bytesToHex(hash1), true);
+        reachabilityDb.addBlocks(Arrays.asList(v1, v1, v1, v1, v1, v1, v1, v1, v1, v1));
+        try {
+            reachabilityDb.addBlocks(Arrays.asList(v1));
+        } catch (Exception e) {}
+        long with1Block = reachabilityDb.size();
+        if (with1Block != priorSize + 1)
+            throw new IllegalStateException("Adding not idempotent!");
+    }
+}

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -130,12 +130,11 @@ public class SqliteBlockReachability {
         }
     }
 
-    public static SqliteBlockReachability createReachabilityDb(String filename) {
+    public static SqliteBlockReachability createReachabilityDb(Path dbFile) {
         try {
-            Path dbFile = Path.of(filename);
             if (Files.exists(dbFile))
                 Files.delete(dbFile);
-            Connection memory = Sqlite.build(filename);
+            Connection memory = Sqlite.build(dbFile.toString());
             // We need a connection that ignores close
             Connection instance = new Sqlite.UncloseableConnection(memory);
             return new SqliteBlockReachability(() -> instance, new SqliteCommands());
@@ -148,10 +147,7 @@ public class SqliteBlockReachability {
         // This is a benchmark to test baseline speed of a blockstore GC
         String filename = "temp.sql";
         Path file = Path.of(filename);
-        if (Files.exists(file))
-            Files.delete(file);
-
-        SqliteBlockReachability reachabilityDb = createReachabilityDb(filename);
+        SqliteBlockReachability reachabilityDb = createReachabilityDb(file);
         List<BlockVersion> versions = new ArrayList<>();
         int count = 1_000_000;
         boolean versioned = true;

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -85,6 +85,8 @@ public class SqliteBlockReachability {
     }
 
     public void setReachable(List<Cid> blocks) {
+        if (blocks.isEmpty())
+            return;
         try (Connection conn = getNonCommittingConnection();
              PreparedStatement update = conn.prepareStatement(SET_REACHABLE)) {
             for (Cid block : blocks) {

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -65,7 +65,7 @@ public class SqliteBlockReachability {
         }
     }
 
-    public void addBlocks(List<BlockVersion> versions) {
+    public synchronized void addBlocks(List<BlockVersion> versions) {
         try (Connection conn = getNonCommittingConnection();
              PreparedStatement insert = conn.prepareStatement(cmds.insertOrIgnoreCommand("INSERT ", INSERT_SUFFIX))) {
             List<BlockVersion> distinct = versions.stream().distinct().collect(Collectors.toList());

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -91,10 +91,8 @@ public class SqliteBlockReachability {
                 update.setBytes(1, block.toBytes());
                 update.addBatch();
             }
-            int[] changed = update.executeBatch();
+            update.executeBatch(); //ignore update count
             conn.commit();
-            if (IntStream.of(changed).sum() < blocks.size())
-                throw new IllegalStateException("Couldn't set reachable");
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
         }
@@ -186,6 +184,7 @@ public class SqliteBlockReachability {
         }
         long t2 = System.nanoTime();
         System.out.println("Marking reachable took " + (t2-t1)/1_000_000_000 + "s, batch size = " + markBatchSize);
+        reachabilityDb.setReachable(Arrays.asList(versions.get(0).cid));
 
         List<BlockVersion> unreachable = new ArrayList<>();
         long t3 = System.nanoTime();

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -97,6 +97,7 @@ public class SqliteBlockReachability {
             conn.commit();
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
         }
     }
 

--- a/src/peergos/server/storage/TransactionStore.java
+++ b/src/peergos/server/storage/TransactionStore.java
@@ -1,7 +1,7 @@
 package peergos.server.storage;
 
 import peergos.shared.crypto.hash.*;
-import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.io.ipfs.*;
 import peergos.shared.storage.*;
 
 import java.util.*;
@@ -14,7 +14,7 @@ public interface TransactionStore {
 
     void closeTransaction(PublicKeyHash owner, TransactionId tid);
 
-    List<Multihash> getOpenTransactionBlocks();
+    List<Cid> getOpenTransactionBlocks();
 
     void clearOldTransactions(long cutoff);
 }

--- a/src/peergos/server/storage/TransactionStore.java
+++ b/src/peergos/server/storage/TransactionStore.java
@@ -16,5 +16,5 @@ public interface TransactionStore {
 
     List<Cid> getOpenTransactionBlocks();
 
-    void clearOldTransactions(long cutoff);
+    void clearOldTransactions(long cutoffUtcMillis);
 }

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -12,6 +12,7 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.*;
 import java.util.stream.*;
 
 public class TransactionalIpfs extends DelegatingStorage implements DeletableContentAddressedStorage {
@@ -164,8 +165,8 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
     }
 
     @Override
-    public Stream<BlockVersion> getAllBlockHashVersions() {
-        return target.getAllBlockHashVersions();
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        target.getAllBlockHashVersions(res);
     }
 
     @Override
@@ -174,7 +175,7 @@ public class TransactionalIpfs extends DelegatingStorage implements DeletableCon
     }
 
     @Override
-    public List<Multihash> getOpenTransactionBlocks() {
+    public List<Cid> getOpenTransactionBlocks() {
         return transactions.getOpenTransactionBlocks();
     }
 

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -34,7 +34,7 @@ public class GCTests {
         Path file = Path.of(filename);
         SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb(file);
 
-        int nUsers = 10;
+        int nUsers = 1;
         int nRawBlocks = 1 << 9;
         ForkJoinPool listPool = Threads.newPool(2, "GC-list-");
         List<ForkJoinTask<Cid>> futs = IntStream.range(0, nUsers)

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -1,0 +1,113 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import org.peergos.*;
+import peergos.server.sql.*;
+import peergos.server.storage.*;
+import peergos.server.util.*;
+import peergos.shared.cbor.*;
+import peergos.shared.io.ipfs.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.sql.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+public class GCTests {
+
+
+
+    @Test
+    public void correctMarkPhase() throws IOException, SQLException {
+        Path dir = Files.createTempDirectory("peergos-block-metadata");
+        File storeFile = dir.resolve("metadata.sql" + System.currentTimeMillis()).toFile();
+        String sqlFilePath = storeFile.getPath();
+        Connection db = Sqlite.build(sqlFilePath);
+        Connection instance = new Sqlite.UncloseableConnection(db);
+        BlockMetadataStore metadb = new JdbcBlockMetadataStore(() -> instance, new SqliteCommands());
+
+        String filename = "temp.sql";
+        Path file = Path.of(filename);
+        SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb(file);
+
+        int nUsers = 10;
+        int nRawBlocks = 1 << 9;
+        ForkJoinPool listPool = Threads.newPool(2, "GC-list-");
+        List<ForkJoinTask<Cid>> futs = IntStream.range(0, nUsers)
+                .mapToObj(i -> listPool.submit(() -> generateTree(i, nRawBlocks,
+                        blocks ->  reachability.addBlocks(blocks.stream().map(c ->  new BlockVersion(c, null, true)).collect(Collectors.toList())),
+                        (b, links) -> metadb.put(b, null, new BlockMetadata(0, links, Collections.emptyList()))
+                        )))
+                .collect(Collectors.toList());
+        List<Cid> roots = futs.stream()
+                .map(ForkJoinTask::join)
+                .collect(Collectors.toList());
+
+        long size = reachability.size();
+        Assert.assertTrue(size > 0);
+
+        int markParallelism = 10;
+        ForkJoinPool markPool = Threads.newPool(markParallelism, "GC-mark-");
+        AtomicLong totalReachable = new AtomicLong(0);
+        List<ForkJoinTask<Boolean>> usageMarked = roots.stream()
+                .map(r -> markPool.submit(() -> {
+                    try {
+                        return GarbageCollector.markReachable(null, r,
+                                "user-" + r, reachability, metadb, totalReachable);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        throw new RuntimeException(e);
+                    }
+                }))
+                .collect(Collectors.toList());
+        usageMarked.forEach(ForkJoinTask::join);
+
+        List<BlockVersion> garbage = new ArrayList<>();
+        reachability.getUnreachable(garbage::addAll);
+        Assert.assertTrue(garbage.isEmpty());
+    }
+
+    private Cid generateTree(int seed, int nRawBlocksLeft, Consumer<List<Cid>> listConsumer, BiConsumer<Cid, List<Cid>> linksConsumer) {
+        Random r = new Random(seed);
+        List<Cid> buffer = new ArrayList<>(1000);
+        Cid root = generateTree(r, nRawBlocksLeft, buffer, listConsumer, linksConsumer);
+        listConsumer.accept(List.of(root));
+        listConsumer.accept(buffer);
+        System.out.println("Generated tree " + seed);
+        return root;
+    }
+
+    private Cid generateTree(Random r, int nRawBlocksLeft, List<Cid> buffer, Consumer<List<Cid>> listConsumer, BiConsumer<Cid, List<Cid>> linksConsumer) {
+        if (nRawBlocksLeft == 1) {
+            Cid leaf = randomRaw(r);
+            linksConsumer.accept(leaf, Collections.emptyList());
+            return leaf;
+        }
+        int nLeft = nRawBlocksLeft / 2;
+        Cid left = generateTree(r, nLeft, buffer, listConsumer, linksConsumer);
+        Cid right = generateTree(r, nRawBlocksLeft - nLeft, buffer, listConsumer, linksConsumer);
+        byte[] raw = new CborObject.CborList(List.of(
+                new CborObject.CborMerkleLink(left),
+                new CborObject.CborMerkleLink(right)
+        )).serialize();
+        Cid root = new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, Hash.sha256(raw));
+        linksConsumer.accept(root, List.of(left, right));
+        buffer.add(left);
+        buffer.add(right);
+        if (buffer.size() > 1000) {
+            listConsumer.accept(buffer);
+            buffer.clear();
+        }
+        return root;
+    }
+
+    private Cid randomRaw(Random r) {
+        byte[] hash = new byte[32];
+        r.nextBytes(hash);
+        return new Cid(1, Cid.Codec.Raw, Multihash.Type.sha2_256, hash);
+    }
+}

--- a/src/peergos/server/tests/IpfsUserTests.java
+++ b/src/peergos/server/tests/IpfsUserTests.java
@@ -57,7 +57,7 @@ public class IpfsUserTests extends UserTests {
     }
 
     public long getBlockstoreSize() {
-        Path ipfsDir = args.fromPeergosDir("", ".ipfs");
+        Path ipfsDir = args.fromPeergosDir("", ".ipfs").resolve("blocks");
         try {
             return Files.walk(ipfsDir)
                     .filter(p -> p.toFile().isFile())

--- a/src/peergos/server/tests/IpfsUserTests.java
+++ b/src/peergos/server/tests/IpfsUserTests.java
@@ -4,10 +4,15 @@ import org.junit.*;
 import org.junit.runner.*;
 import org.junit.runners.*;
 import peergos.server.*;
-import peergos.server.storage.IpfsWrapper;
+import peergos.server.storage.*;
 import peergos.server.util.*;
 import peergos.shared.*;
+import peergos.shared.io.ipfs.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
 
+import java.io.*;
 import java.net.*;
 import java.nio.file.*;
 import java.util.*;
@@ -17,7 +22,7 @@ public class IpfsUserTests extends UserTests {
 
     private static Args args = buildArgs()
             .with("useIPFS", "true")
-//            .with("enable-gc", "true")
+            .with("enable-gc", "true")
 //            .with("gc.period.millis", "10000")
             .with("collect-metrics", "true")
             .with("metrics.address", "localhost")
@@ -49,5 +54,43 @@ public class IpfsUserTests extends UserTests {
     @Override
     public Args getArgs() {
         return args;
+    }
+
+    public long getBlockstoreSize() {
+        Path ipfsDir = args.fromPeergosDir("", ".ipfs");
+        try {
+            return Files.walk(ipfsDir)
+                    .filter(p -> p.toFile().isFile())
+                    .mapToLong(p -> p.toFile().length())
+                    .sum();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @Test
+    public void gcReclaimsSpace() {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        gc();
+        long sizeBefore = getBlockstoreSize();
+        int filesize = 10 * 1024 * 1024;
+        String filename = "file.bin";
+        context.getUserRoot().join().uploadOrReplaceFile(filename, AsyncReader.build(new byte[filesize]),
+                filesize, network, crypto, x -> {}).join();
+        long sizeWithFile = getBlockstoreSize();
+        Assert.assertTrue(sizeWithFile > sizeBefore + filesize);
+        Path filePath = PathUtil.get(username, filename);
+        context.getByPath(filePath).join().get()
+                .remove(context.getUserRoot().join(), filePath, context).join();
+        // need to clear transactions otherwise blocks won't be GC'd for a day
+        TransactionStore transactionStore = Builder.buildTransactionStore(args, Builder.getDBConnector(args.with("transactions-sql-file", "transactions.sql"),
+                "transactions-sql-file"));
+        transactionStore.clearOldTransactions(System.currentTimeMillis());
+        List<Cid> open = transactionStore.getOpenTransactionBlocks();
+        Assert.assertTrue(open.isEmpty());
+        gc();
+        long sizeAfterDelete = getBlockstoreSize();
+        Assert.assertTrue(sizeAfterDelete - sizeBefore < 20*1024); // Why not equal?
     }
 }

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -107,6 +107,7 @@ public class MultiNodeNetworkTests {
         services.add(pki);
         pki.gc.stop();
         int bootstrapSwarmPort = args.getInt("ipfs-swarm-port");
+        String bootstrapList = Main.getLocalBootstrapAddress(bootstrapSwarmPort, pkiNodeId).toString();
 
         // create two other nodes that use the first as a PKI-node
         for (int i = 0; i < 2; i++) {
@@ -124,13 +125,15 @@ public class MultiNodeNetworkTests {
                     .with("ipfs-api-address", "/ip4/127.0.0.1/tcp/" + ipfsApiPort)
                     .with("ipfs-gateway-address", "/ip4/127.0.0.1/tcp/" + ipfsGatewayPort)
                     .with("ipfs-swarm-port", "" + ipfsSwarmPort)
-                    .with(IpfsWrapper.IPFS_BOOTSTRAP_NODES, "" + Main.getLocalBootstrapAddress(bootstrapSwarmPort, pkiNodeId))
+                    .with(IpfsWrapper.IPFS_BOOTSTRAP_NODES, bootstrapList)
                     .with("proxy-target", Main.getLocalMultiAddress(proxyTargetPort).toString())
                     .with("ipfs-api-address", Main.getLocalMultiAddress(ipfsApiPort).toString());
             argsToCleanUp.add(normalNode);
             UserService service = Main.PEERGOS.main(normalNode);
             services.add(service);
             service.gc.stop();
+            Multihash ourId = service.storage.id().get();
+            bootstrapList += "," + Main.getLocalBootstrapAddress(ipfsSwarmPort, ourId);
 
 //            IPFS ipfs = new IPFS(Main.getLocalMultiAddress(ipfsApiPort));
 //            ipfs.swarm.connect(Main.getLocalBootstrapAddress(bootstrapSwarmPort, pkiNodeId).toString());

--- a/src/peergos/server/tests/SqliteTableTests.java
+++ b/src/peergos/server/tests/SqliteTableTests.java
@@ -40,7 +40,7 @@ public class SqliteTableTests {
         txns.addBlock(hash1, TransactionId.build("tid1"), owner);
 
         // check both entries are correct
-        List<Multihash> open = txns.getOpenTransactionBlocks();
+        List<Cid> open = txns.getOpenTransactionBlocks();
         Assert.assertTrue(open.size() == 2);
 
         // check an immediate GC doesn't clear the new block
@@ -51,7 +51,7 @@ public class SqliteTableTests {
         txns.clearOldTransactions(System.currentTimeMillis() + 1000);
 
         // check there are no entries left
-        List<Multihash> empty = txns.getOpenTransactionBlocks();
+        List<Cid> empty = txns.getOpenTransactionBlocks();
         Assert.assertTrue(empty.isEmpty());
     }
 }

--- a/src/peergos/server/tests/TransactionsStoreTests.java
+++ b/src/peergos/server/tests/TransactionsStoreTests.java
@@ -57,11 +57,11 @@ public class TransactionsStoreTests {
             pending.add(block);
             store.addBlock(block, tid, owner);
         }
-        List<Multihash> uncommitted = store.getOpenTransactionBlocks();
+        List<Cid> uncommitted = store.getOpenTransactionBlocks();
         Assert.assertTrue("All blocks present", uncommitted.containsAll(pending));
 
         store.closeTransaction(owner, tid);
-        List<Multihash> empty = store.getOpenTransactionBlocks();
+        List<Cid> empty = store.getOpenTransactionBlocks();
         Assert.assertTrue("All blocks removed", empty.isEmpty());
     }
 }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -106,6 +106,10 @@ public abstract class UserTests {
         f.delete();
     }
 
+    public void gc() {
+        service.gc.collect(e -> Futures.of(true));
+    }
+
     protected String generateUsername() {
         return "test" + Math.abs(random.nextInt() % 1_000_000);
     }

--- a/src/peergos/server/tests/slow/GCBenchmark.java
+++ b/src/peergos/server/tests/slow/GCBenchmark.java
@@ -44,7 +44,7 @@ public class GCBenchmark {
             storage.closeTransaction(owner, tid).join();
         }
 
-        GarbageCollector.collect(storage, pointers, usage, s -> Futures.of(true), new RamBlockMetadataStore(), false);
+        GarbageCollector.collect(storage, pointers, usage, Paths.get("reachability.sql"), s -> Futures.of(true), new RamBlockMetadataStore(), false);
     }
 
     private static Multihash generateTree(Random r, PublicKeyHash owner, ContentAddressedStorage storage, int nLeaves, TransactionId tid) {

--- a/src/peergos/server/tests/slow/GCBenchmark.java
+++ b/src/peergos/server/tests/slow/GCBenchmark.java
@@ -44,7 +44,8 @@ public class GCBenchmark {
             storage.closeTransaction(owner, tid).join();
         }
 
-        GarbageCollector.collect(storage, pointers, usage, Paths.get("reachability.sql"), s -> Futures.of(true), new RamBlockMetadataStore(), false);
+        GarbageCollector.collect(storage, pointers, usage, Paths.get("reachability.sql"), s -> Futures.of(true),
+                new RamBlockMetadataStore(), (d, c) -> Futures.of(true), false);
     }
 
     private static Multihash generateTree(Random r, PublicKeyHash owner, ContentAddressedStorage storage, int nLeaves, TransactionId tid) {


### PR DESCRIPTION
1. Store GC state in a temporary sqlite file rather than RAM
2. Process in a streaming manner, so we never have entire block list in RAM

sqlite file size for 1M blocks with versions 64 bytes long is 250 MiB. The same with null versions is 100 MiB. This corresponds to a total blockstore size of ~1TiB.

Baseline measurement for a GC with 1M live + 1M dead blocks is: 
* listing blocks into db: 100s
* marking reachable: 50s
* listing garbage: 3s

compared to a RAM GC with S3 with 2M blocks taking: 
* listing blocks into ram: 500s
* marking reachable: 2200s