### PR TITLE
Fixes to failed uploads in a different writing space

### DIFF
--- a/src/peergos/server/Playground.java
+++ b/src/peergos/server/Playground.java
@@ -50,7 +50,7 @@ public class Playground {
                 continue; // only the writer has a tree
             CommittedWriterData existing = WriterData.getWriterData(context.signer.publicKeyHash, ownedKey,
                     network.mutable, network.dhtClient).get();
-            if (existing.props.tree.isPresent())
+            if (existing.props.get().tree.isPresent())
                 continue;
             // Do something risky
         }

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -114,7 +114,7 @@ public class IpfsCoreNode implements CoreNode {
         if (! pointerTarget.isPresent())
             return MaybeMultihash.empty();
         CommittedWriterData current = getWriterData(peerIds, (Cid)pointerTarget.get(), Optional.empty(), ipfs).join();
-        return current.props.tree.map(MaybeMultihash::of).orElseGet(MaybeMultihash::empty);
+        return current.props.get().tree.map(MaybeMultihash::of).orElseGet(MaybeMultihash::empty);
 
     }
 
@@ -422,7 +422,7 @@ public class IpfsCoreNode implements CoreNode {
 
         try {
             CommittedWriterData current = WriterData.getWriterData(peergosIdentity, (Cid)currentRoot.get(), currentSequence, ipfs).get();
-            MaybeMultihash currentTree = current.props.tree.map(MaybeMultihash::of).orElseGet(MaybeMultihash::empty);
+            MaybeMultihash currentTree = current.props.get().tree.map(MaybeMultihash::of).orElseGet(MaybeMultihash::empty);
 
             ChampWrapper<CborObject.CborMerkleLink> champ = currentTree.isPresent() ?
                     ChampWrapper.create(peergosIdentity, (Cid)currentTree.get(), IpfsCoreNode::keyHash, ipfs, hasher, c -> (CborObject.CborMerkleLink)c).get() :
@@ -461,7 +461,7 @@ public class IpfsCoreNode implements CoreNode {
             synchronized (this) {
                 return IpfsTransaction.call(peergosIdentity,
                         tid -> champ.put(signer.publicKeyHash, signer, username.getBytes(), existing, new CborObject.CborMerkleLink(mergedChainHash), tid)
-                                .thenCompose(newPkiRoot -> current.props.withChamp(newPkiRoot)
+                                .thenCompose(newPkiRoot -> current.props.get().withChamp(newPkiRoot)
                                         .commit(peergosIdentity, signer, currentRoot, currentSequence, mutable, ipfs, hasher, tid)),
                         ipfs
                 ).thenApply(committed -> {

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -277,7 +277,7 @@ public class MirrorCoreNode implements CoreNode {
         MaybeMultihash newPeergosRoot = fresh.updated;
 
         CommittedWriterData currentPeergosWd = IpfsCoreNode.getWriterData(List.of(pkiPeerId), (Cid)newPeergosRoot.get(), fresh.sequence, ipfs).join();
-        PublicKeyHash pkiKey = currentPeergosWd.props.namedOwnedKeys.get("pki").ownedKey;
+        PublicKeyHash pkiKey = currentPeergosWd.props.get().namedOwnedKeys.get("pki").ownedKey;
         if (pkiKey == null)
             throw new IllegalStateException("No pki key on owner: " + pkiOwnerIdentity);
 
@@ -316,7 +316,7 @@ public class MirrorCoreNode implements CoreNode {
             if (updatedTree.isPresent()) {
                 CommittedWriterData currentWd = IpfsCoreNode.getWriterData(pkiStorageProviders,
                         (Cid) remote.pkiKeyTarget.get(), Optional.empty(), ipfs).join();
-                List<Multihash> toAdd = currentWd.props.toCbor().links().stream()
+                List<Multihash> toAdd = currentWd.props.get().toCbor().links().stream()
                         .filter(h -> updatedTree.map(m -> !m.equals(h)).orElse(true))
                         .collect(Collectors.toList());
                 for (Multihash m : toAdd) {

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -81,7 +81,7 @@ public class UserRepository implements SocialNetwork, MutablePointers {
                                             if (cas.updated.isPresent()) {
                                                 Multihash newHash = cas.updated.get();
                                                 CommittedWriterData newWriterData = DeletableContentAddressedStorage.getWriterData(us, (Cid) newHash, cas.sequence, ipfs).join();
-                                                if (!newWriterData.props.controller.equals(writer))
+                                                if (!newWriterData.props.get().controller.equals(writer))
                                                     return Futures.of(false);
                                             }
 

--- a/src/peergos/server/storage/DeletableContentAddressedStorage.java
+++ b/src/peergos/server/storage/DeletableContentAddressedStorage.java
@@ -487,10 +487,10 @@ public interface DeletableContentAddressedStorage extends ContentAddressedStorag
                                 Stream.empty()).collect(Collectors.toSet()));
 
         return retriever.getWriterData((Cid)root.get(), Optional.empty())
-                .thenCompose(wd -> wd.props.applyToOwnedKeys(owner, owned ->
+                .thenCompose(wd -> wd.props.get().applyToOwnedKeys(owner, owned ->
                                 owned.applyToAllMappings(owner, Collections.emptySet(), composer, ipfs), ipfs, hasher)
                         .thenApply(owned -> Stream.concat(owned.stream(),
-                                wd.props.namedOwnedKeys.values().stream()).collect(Collectors.toSet())))
+                                wd.props.get().namedOwnedKeys.values().stream()).collect(Collectors.toSet())))
                 .thenCompose(all -> Futures.reduceAll(all, Collections.emptySet(),
                         proofComposer,
                         (a, b) -> Stream.concat(a.stream(), b.stream())

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -30,7 +30,7 @@ import static peergos.server.tests.PeergosNetworkUtils.getUserContextsForNode;
 
 public class MultiUserTests {
 
-    private static Args args = UserTests.buildArgs();
+    private static Args args = UserTests.buildArgs().with("enable-gc", "false").with("log-to-console", "true");
     private static UserService service;
     private Random random = new Random();
     private final NetworkAccess network;
@@ -61,7 +61,7 @@ public class MultiUserTests {
                                          PublicKeyHash writer,
                                          Set<PublicKeyHash> ancestors,
                                          NetworkAccess network) {
-        WriterData props = WriterData.getWriterData(owner, writer, network.mutable, network.dhtClient).join().props;
+        WriterData props = WriterData.getWriterData(owner, writer, network.mutable, network.dhtClient).join().props.get();
         if (! props.ownedKeys.isPresent())
             return;
         OwnedKeyChamp ownedChamp = props.getOwnedKeyChamp(owner, network.dhtClient, network.hasher).join();
@@ -963,7 +963,7 @@ public class MultiUserTests {
         Optional<FileWrapper> priorUnsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         AbsoluteCapability priorPointer = priorUnsharedView.get().getPointer().capability;
         CommittedWriterData cwd = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
-        CryptreeNode priorFileAccess = network.getMetadata(cwd.props, priorPointer).get().get();
+        CryptreeNode priorFileAccess = network.getMetadata(cwd.props.get(), priorPointer).get().get();
         SymmetricKey priorMetaKey = priorFileAccess.getParentKey(priorPointer.rBaseKey);
 
         // unshare with a single user
@@ -980,7 +980,7 @@ public class MultiUserTests {
         String friendsNewPathToFile = u1.username + "/" + newname;
         Optional<FileWrapper> unsharedView2 = userToUnshareWith.getByPath(friendsNewPathToFile).get();
         CommittedWriterData cwd2 = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
-        CryptreeNode fileAccess = network.getMetadata(cwd2.props, priorPointer.withMapKey(newCap.getMapKey(), newCap.bat)).get().get();
+        CryptreeNode fileAccess = network.getMetadata(cwd2.props.get(), priorPointer.withMapKey(newCap.getMapKey(), newCap.bat)).get().get();
         // check we are trying to decrypt the correct thing
         PaddedCipherText priorPropsCipherText = ((CborObject.CborMap) priorFileAccess.toCbor()).getObject("p", PaddedCipherText::fromCbor);
         CborObject.CborMap priorFromParent = priorPropsCipherText.decrypt(priorMetaKey, x -> (CborObject.CborMap)x);

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -2424,7 +2424,7 @@ public class PeergosNetworkUtils {
         Snapshot version = new Snapshot(cap.writer,
                 WriterData.getWriterData(cap.owner, (Cid) pointer.updated.get(), pointer.sequence, network.dhtClient).join());
 
-        Optional<CryptreeNode> next = network.getMetadata(version.get(nextChunkCap.writer).props, nextChunkCap).join();
+        Optional<CryptreeNode> next = network.getMetadata(version.get(nextChunkCap.writer).props.get(), nextChunkCap).join();
         Set<AbsoluteCapability> directUnnamed = direct.stream().map(n -> n.cap).collect(Collectors.toSet());
         if (! next.isPresent())
             return Arrays.asList(directUnnamed);

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1245,7 +1245,8 @@ public class PeergosNetworkUtils {
         Assert.assertEquals(sharedFolder.getFileProperties().name, filename);
 
         // delete the parent folder
-        sharer.getByPath(dirPath).join().get().remove(sharer.getUserRoot().join(), dirPath, sharer).join();
+        FileWrapper parent = sharer.getByPath(dirPath).join().get();
+        parent.remove(sharer.getUserRoot().join(), dirPath, sharer).join();
         // check 'a' can't see the shared directory
         FileWrapper unsharedLocation = a.getByPath(sharer.username).join().get();
         Set<FileWrapper> children = unsharedLocation.getChildren(crypto.hasher, a.network).join();

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -354,7 +354,7 @@ public abstract class UserTests {
         Pair<PublicKeyHash, PublicBoxingKey> keyPairs = userContext.getPublicKeys(username).join().get();
         PublicBoxingKey initialBoxer = keyPairs.right;
         PublicKeyHash initialIdentity = keyPairs.left;
-        WriterData initialWd = WriterData.getWriterData(initialIdentity, initialIdentity, network.mutable, network.dhtClient).join().props;
+        WriterData initialWd = WriterData.getWriterData(initialIdentity, initialIdentity, network.mutable, network.dhtClient).join().props.get();
         Assert.assertTrue(initialWd.staticData.isPresent());
 
         UserContext login = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
@@ -372,7 +372,7 @@ public abstract class UserTests {
 
         SecretGenerationAlgorithm alg = WriterData.fromCbor(UserContext.getWriterDataCbor(network, username).join().right).generationAlgorithm.get();
         Assert.assertTrue("password change upgrades legacy accounts", ! alg.generateBoxerAndIdentity());
-        WriterData finalWd = WriterData.getWriterData(newIdentity, newIdentity, network.mutable, network.dhtClient).join().props;
+        WriterData finalWd = WriterData.getWriterData(newIdentity, newIdentity, network.mutable, network.dhtClient).join().props.get();
         Assert.assertTrue(finalWd.staticData.isEmpty());
     }
 
@@ -1133,7 +1133,7 @@ public abstract class UserTests {
         modified.remove("bats");
         CborObject.CborMap noBats = CborObject.CborMap.build(modified);
         CommittedWriterData cwd = WriterData.getWriterData(owner, file.writer(), network.mutable, network.dhtClient).join();
-        WriterData wd = cwd.props;
+        WriterData wd = cwd.props.get();
         SigningPrivateKeyAndPublicHash signingPair = file.signingPair();
         Cid cryptreeCid = network.dhtClient.put(owner, signingPair, noBats.serialize(), crypto.hasher,
                 TransactionId.build("hey")).join();
@@ -1180,7 +1180,7 @@ public abstract class UserTests {
                 updatedFile.getFileProperties().streamSecret, newcap.getMapKey(), Optional.empty(), crypto.hasher).join();
         Assert.assertTrue(nextChunkRel.right.isEmpty());
         NetworkAccess cleared = network.clear();
-        WriterData uwd = WriterData.getWriterData(owner, updatedFile.writer(), network.mutable, network.dhtClient).join().props;
+        WriterData uwd = WriterData.getWriterData(owner, updatedFile.writer(), network.mutable, network.dhtClient).join().props.get();
         Optional<CryptreeNode> secondChunk = cleared.getMetadata(uwd, newcap.withMapKey(nextChunkRel.left, Optional.empty())).join();
         Assert.assertTrue(secondChunk.isPresent());
         // now the third chunk
@@ -1277,7 +1277,7 @@ public abstract class UserTests {
         // check we can't get the third chunk any more
         WritableAbsoluteCapability pointer = original.writableFilePointer();
         CommittedWriterData cwd = network.synchronizer.getValue(pointer.owner, pointer.writer).join().get(pointer.writer);
-        Optional<CryptreeNode> thirdChunk = network.getMetadata(cwd.props, pointer.withMapKey(thirdChunkLabel.left, thirdChunkLabel.right)).join();
+        Optional<CryptreeNode> thirdChunk = network.getMetadata(cwd.props.get(), pointer.withMapKey(thirdChunkLabel.left, thirdChunkLabel.right)).join();
         Assert.assertTrue("File is truncated", ! thirdChunk.isPresent());
         Assert.assertTrue("File has correct size", truncated.getFileProperties().size == truncateLength);
 
@@ -1497,7 +1497,7 @@ public abstract class UserTests {
 
         AbsoluteCapability pointer = subfolder.getPointer().capability;
         CommittedWriterData cwd = network.synchronizer.getValue(pointer.owner, pointer.writer).join().get(pointer.writer);
-        Optional<CryptreeNode> subdir = network.getMetadata(cwd.props, pointer).join();
+        Optional<CryptreeNode> subdir = network.getMetadata(cwd.props.get(), pointer).join();
         Assert.assertTrue("Child deleted", ! subdir.isPresent());
     }
 

--- a/src/peergos/shared/messaging/ChatController.java
+++ b/src/peergos/shared/messaging/ChatController.java
@@ -213,7 +213,7 @@ public class ChatController {
                         .thenApply(Optional::get),
                 t -> context.getByPath(PathUtil.get(mirrorUsername).resolve(sourcePath.subpath(1, sourcePath.getNameCount())).toString(), v)
                         .thenApply(Optional::get))
-                .thenCompose(f -> f.getInputStream(f.version.get(f.writer()).props, context.network, context.crypto, x -> {})
+                .thenCompose(f -> f.getInputStream(f.version.get(f.writer()).props.get(), context.network, context.crypto, x -> {})
                         .thenCompose(r -> dir.uploadFileSection(v, c, f.getName(), r, false, 0, f.getSize(),
                                 Optional.empty(), false, false, false, context.network, context.crypto, x -> {},
                                 context.crypto.random.randomBytes(RelativeCapability.MAP_KEY_LENGTH), Optional.empty(),

--- a/src/peergos/shared/messaging/FileBackedMessageStore.java
+++ b/src/peergos/shared/messaging/FileBackedMessageStore.java
@@ -38,7 +38,7 @@ public class FileBackedMessageStore implements MessageStore {
     private CompletableFuture<Pair<Long, Integer>> getChunkByteOffset(long index) {
         if (messages.getSize() < 5*1024*1024)
             return Futures.of(new Pair<>(0L, (int) index));
-        return indexFile.getInputStream(indexFile.version.get(indexFile.writer()).props, network, crypto, x -> {})
+        return indexFile.getInputStream(indexFile.version.get(indexFile.writer()).props.get(), network, crypto, x -> {})
                         .thenCompose(reader -> findOffset(reader, new byte[1024],
                                 0L, 0L, index, indexFile.getSize()));
     }
@@ -74,7 +74,7 @@ public class FileBackedMessageStore implements MessageStore {
     @Override
     public CompletableFuture<List<SignedMessage>> getMessagesFrom(long index) {
         List<SignedMessage> res = new ArrayList<>();
-        return messages.getInputStream(messages.version.get(messages.writer()).props, network, crypto, x -> {})
+        return messages.getInputStream(messages.version.get(messages.writer()).props.get(), network, crypto, x -> {})
                         .thenCompose(reader -> getChunkByteOffset(index)
                                 .thenCompose(p -> reader.seek(p.left)
                                         .thenCompose(seeked -> seeked.parseLimitedStream(SignedMessage::fromCbor,
@@ -85,7 +85,7 @@ public class FileBackedMessageStore implements MessageStore {
     @Override
     public CompletableFuture<List<SignedMessage>> getMessages(long fromIndex, long toIndex) {
         List<SignedMessage> res = new ArrayList<>();
-        return messages.getInputStream(messages.version.get(messages.writer()).props, network, crypto, x -> {})
+        return messages.getInputStream(messages.version.get(messages.writer()).props.get(), network, crypto, x -> {})
                         .thenCompose(reader -> getChunkByteOffset(fromIndex)
                                 .thenCompose(p -> reader.seek(p.left)
                                         .thenCompose(seeked -> seeked.parseLimitedStream(SignedMessage::fromCbor,

--- a/src/peergos/shared/user/CommittedWriterData.java
+++ b/src/peergos/shared/user/CommittedWriterData.java
@@ -10,12 +10,16 @@ public class CommittedWriterData {
 
     public final MaybeMultihash hash;
     public final Optional<Long> sequence;
-    public final WriterData props;
+    public final Optional<WriterData> props;
 
-    public CommittedWriterData(MaybeMultihash hash, WriterData props, Optional<Long> sequence) {
+    public CommittedWriterData(MaybeMultihash hash, Optional<WriterData> props, Optional<Long> sequence) {
         this.hash = hash;
         this.props = props;
         this.sequence = sequence;
+    }
+
+    public CommittedWriterData(MaybeMultihash hash, WriterData props, Optional<Long> sequence) {
+        this(hash, Optional.of(props), sequence);
     }
 
     @Override

--- a/src/peergos/shared/user/Committer.java
+++ b/src/peergos/shared/user/Committer.java
@@ -4,13 +4,22 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.*;
 
+import java.util.*;
 import java.util.concurrent.*;
 
 public interface Committer {
 
     CompletableFuture<Snapshot> commit(PublicKeyHash owner,
                                        SigningPrivateKeyAndPublicHash signer,
-                                       WriterData wd,
+                                       Optional<WriterData> wd,
                                        CommittedWriterData existing,
                                        TransactionId tid);
+
+    default CompletableFuture<Snapshot> commit(PublicKeyHash owner,
+                                               SigningPrivateKeyAndPublicHash signer,
+                                               WriterData wd,
+                                               CommittedWriterData existing,
+                                               TransactionId tid) {
+        return commit(owner, signer, Optional.of(wd), existing, tid);
+    }
 }

--- a/src/peergos/shared/user/EntryPoint.java
+++ b/src/peergos/shared/user/EntryPoint.java
@@ -47,7 +47,7 @@ public class EntryPoint implements Cborable {
             if (! ownerKey.isPresent())
                 throw new IllegalStateException("No owner key present for user " + claimedOwner);
             return UserContext.getWriterData(network, ownerKey.get(), ownerKey.get())
-                    .thenCompose(wd -> wd.props.ownsKey(ownerKey.get(), entryWriter, network.dhtClient, network.mutable, network.hasher));
+                    .thenCompose(wd -> wd.props.get().ownsKey(ownerKey.get(), entryWriter, network.dhtClient, network.mutable, network.hasher));
         });
     }
 

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -229,7 +229,7 @@ public class IncomingCapCache {
                     if (capsOpt.isEmpty())
                         return recurse.get();
                     FileWrapper capsFile = capsOpt.get();
-                    return capsFile.getInputStream(capsFile.version.get(capsFile.writer()).props, network, crypto, x-> {})
+                    return capsFile.getInputStream(capsFile.version.get(capsFile.writer()).props.get(), network, crypto, x-> {})
                             .thenCompose(r -> Serialize.readFully(r, capsFile.getSize()))
                             .thenApply(CborObject::fromByteArray)
                             .thenApply(CapsInDirectory::fromCbor)

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -214,7 +214,7 @@ public class SharedWithCache {
     }
 
     private static CompletableFuture<SharedWithState> parseCacheFile(FileWrapper cache, NetworkAccess network, Crypto crypto) {
-        return cache.getInputStream(cache.version.get(cache.writer()).props, network, crypto, x -> {})
+        return cache.getInputStream(cache.version.get(cache.writer()).props.get(), network, crypto, x -> {})
                 .thenCompose(in -> Serialize.readFully(in, cache.getSize()))
                 .thenApply(CborObject::fromByteArray)
                 .thenApply(SharedWithState::fromCbor);

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -89,8 +89,8 @@ public class WriteSynchronizer {
         // and whoever commits first will win. We also need to retrieve the writer data again from the network after
         // a previous transaction has completed (another node/user with write access may have concurrently updated the mapping)
         return pending.computeIfAbsent(new Pair<>(owner, writer.publicKeyHash), p -> new AsyncLock<>(getWriterData(owner, p.right)))
-                .runWithLock(current -> IpfsTransaction.call(owner, tid -> transformer.apply(current.get(writer).props, tid)
-                                .thenCompose(wd -> committerBuilder.buildCommitter((aOwner, signer, wdr, existing, t) -> wdr.commit(aOwner, signer,
+                .runWithLock(current -> IpfsTransaction.call(owner, tid -> transformer.apply(current.get(writer).props.get(), tid)
+                                .thenCompose(wd -> committerBuilder.buildCommitter((aOwner, signer, wdr, existing, t) -> wdr.get().commit(aOwner, signer,
                                         existing.hash, existing.sequence, mutable, dht, hasher, t), owner, () -> true)
                                         .commit(owner, writer, wd, current.get(writer), tid)
                                         .thenCompose(v -> flusher.commit(owner, v, () -> true))), dht),
@@ -110,10 +110,10 @@ public class WriteSynchronizer {
                                                           Supplier<Boolean> commitWatcher) {
         return pending.computeIfAbsent(new Pair<>(owner, writer.publicKeyHash), p -> new AsyncLock<>(getWriterData(owner, p.right)))
                 .runWithLock(current -> transformer.apply(current,
-                                        committerBuilder.buildCommitter((aOwner, signer, wd, existing, tid) -> wd != null ?
-                                                wd.commit(aOwner, signer, existing.hash, existing.sequence, mutable, dht, hasher, tid) :
-                                                WriterData.commitDeletion(aOwner, signer, existing.hash, existing.sequence, mutable)
-                                                        .thenCompose(s -> updateWriterState(owner, signer.publicKeyHash, s).thenApply(x -> s)), owner, commitWatcher))
+                                        committerBuilder.buildCommitter((aOwner, signer, wd, existing, tid) -> (wd.isPresent() ?
+                                                wd.get().commit(aOwner, signer, existing.hash, existing.sequence, mutable, dht, hasher, tid) :
+                                                WriterData.commitDeletion(aOwner, signer, existing.hash, existing.sequence, mutable))
+                                                .thenCompose(s -> updateWriterState(owner, signer.publicKeyHash, s).thenApply(x -> s)), owner, commitWatcher))
                                 .thenCompose(v -> flusher.commit(owner, v, commitWatcher)),
                         () -> getWriterData(owner, writer.publicKeyHash));
     }
@@ -152,8 +152,13 @@ public class WriteSynchronizer {
         CompletableFuture<Pair<Snapshot, V>> res = new CompletableFuture<>();
         return pending.computeIfAbsent(new Pair<>(owner, writer.publicKeyHash), p -> new AsyncLock<>(getWriterData(owner, p.right)))
                 .runWithLock(current -> transformer.apply(current,
-                                committerBuilder.buildCommitter((aOwner, signer, wd, existing, tid) -> wd.commit(aOwner, signer, existing.hash, existing.sequence, mutable, dht, hasher, tid)
-                                                .thenCompose(s -> updateWriterState(owner, signer.publicKeyHash, s).thenApply(x -> s)), owner, () -> true))
+                                committerBuilder.buildCommitter((aOwner, signer, wd, existing, tid) ->
+                                                (wd.isPresent() ?
+                                                        wd.get().commit(aOwner, signer, existing.hash, existing.sequence, mutable, dht, hasher, tid) :
+                                                        WriterData.commitDeletion(aOwner, signer, existing.hash, existing.sequence, mutable))
+                                                        .thenCompose(s -> updateWriterState(owner, signer.publicKeyHash, s)
+                                                                .thenApply(x -> s)),
+                                        owner, () -> true))
                                 .thenCompose(p -> flusher.commit(owner, p.left, () -> true).thenApply(x -> p))
                                 .thenApply(p -> {
                                     res.complete(p);

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -113,7 +113,7 @@ public class WriterData implements Cborable {
                 .thenCompose(champ -> champ.add(owner, signer, newOwned, network.hasher, tid)
                         .thenApply(newRoot -> new WriterData(controller, generationAlgorithm, publicData,
                                 followRequestReceiver, Optional.of(newRoot), namedOwnedKeys, staticData, tree)))
-                .thenCompose(wd -> c.commit(owner, signer, wd, new CommittedWriterData(currentHash, this, currentSequence), tid));
+                .thenCompose(wd -> c.commit(owner, signer, wd, new CommittedWriterData(currentHash,this, currentSequence), tid));
     }
 
     public CompletableFuture<WriterData> removeOwnedKey(PublicKeyHash owner,
@@ -146,7 +146,8 @@ public class WriterData implements Cborable {
                                             return Futures.of(b);
                                         PublicKeyHash childKey = p.left;
                                         return UserContext.getWriterData(ipfs, mutable, identityKey, childKey)
-                                                .thenCompose(wd -> wd.props.ownsKey(identityKey, ownedKey, ipfs, mutable, hasher));
+                                                .thenCompose(wd -> wd.props.map(w -> w.ownsKey(identityKey, ownedKey, ipfs, mutable, hasher))
+                                                        .orElse(Futures.of(false)));
                                     },
                                     ipfs);
                         }));
@@ -267,7 +268,7 @@ public class WriterData implements Cborable {
                                         );
                             }));
                 })
-                .thenApply(version -> version.get(signer).props)
+                .thenApply(version -> version.get(signer).props.get())
                 .exceptionally(t -> {
                     if (t.getMessage().contains("cas+failed"))
                         throw new IllegalStateException("You cannot reuse a previous password!");
@@ -326,7 +327,7 @@ public class WriterData implements Cborable {
                 .thenApply(res -> {
                     if (!res)
                         throw new IllegalStateException("Mutable pointer update failed! Concurrent Modification.");
-                    CommittedWriterData committed = new CommittedWriterData(newHash, null, cas.sequence);
+                    CommittedWriterData committed = new CommittedWriterData(newHash, Optional.empty(), cas.sequence);
                     return new Snapshot(signer.publicKeyHash, committed);
                 });
     }

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -2070,7 +2070,8 @@ public class FileWrapper {
                                 network.dhtClient))
                         .thenApply(committed -> s.withVersion(parentWriter, committed.get(parentWriter))))
                 .thenCompose(s -> IpfsTransaction.call(owner,
-                        tid -> committer.commit(owner, signerToRemove, null, toRemove, tid), network.dhtClient));
+                        tid -> committer.commit(owner, signerToRemove, null, toRemove, tid), network.dhtClient)
+                        .thenApply(s::mergeAndOverwriteWith));
     }
 
     public CompletableFuture<? extends AsyncReader> getInputStream(NetworkAccess network,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -489,7 +489,7 @@ public class FileWrapper {
         CryptreeNode fileAccess = pointer.fileAccess;
         return fileAccess.retriever(pointer.capability.rBaseKey, props.streamSecret, getLocation().getMapKey(), pointer.capability.bat, crypto.hasher)
                 .thenCompose(retriever -> retriever
-                        .getMapLabelAt(version.get(writer()).props, writableFilePointer(),
+                        .getMapLabelAt(version.get(writer()).props.get(), writableFilePointer(),
                                 getFileProperties().streamSecret, offset, crypto.hasher, network)
                         .thenApply(Optional::get));
     }
@@ -512,7 +512,7 @@ public class FileWrapper {
 
         return initialVersion.withWriter(owner(), writer(), network)
                 .thenCompose(snapshot -> getMapKey(newSize, network, crypto).thenCompose(endMapKey ->
-                        getInputStream(snapshot.get(writer()).props, network, crypto, props.size, 1, x -> {}).thenCompose(originalReader -> {
+                        getInputStream(snapshot.get(writer()).props.get(), network, crypto, props.size, 1, x -> {}).thenCompose(originalReader -> {
                             long startOfLastChunk = newSize - (newSize % Chunk.MAX_SIZE);
                             return originalReader.seek(startOfLastChunk).thenCompose(seekedOriginal -> {
                                 byte[] lastChunk = new byte[(int)(newSize % Chunk.MAX_SIZE)];
@@ -971,11 +971,11 @@ public class FileWrapper {
 
                         BiFunction<Snapshot, Long, CompletableFuture<Snapshot>> composer = (version, startIndex) -> {
                             MaybeMultihash currentHash = us.pointer.fileAccess.committedHash();
-                            return retriever.getChunk(version.get(us.writer()).props, network, crypto, startIndex,
+                            return retriever.getChunk(version.get(us.writer()).props.get(), network, crypto, startIndex,
                                     filesSize.get(), ourCap, props.streamSecret, currentHash, monitor)
                                     .thenCompose(currentLocation -> {
                                                 CompletableFuture<Optional<Pair<Location, Optional<Bat>>>> locationAt = retriever
-                                                        .getMapLabelAt(version.get(us.writer()).props, ourCap,
+                                                        .getMapLabelAt(version.get(us.writer()).props.get(), ourCap,
                                                                 props.streamSecret, startIndex + Chunk.MAX_SIZE, crypto.hasher, network)
                                                         .thenApply(x -> x.map(mb -> new Pair<>(getLocation().withMapKey(mb.left), mb.right)));
                                                 return locationAt.thenCompose(locationAndBat ->
@@ -1222,7 +1222,7 @@ public class FileWrapper {
                                                         // update size only
                                                         return updatedChild.updateSize(committer, writeEnd, network);
                                                     }
-                                                    return updatedChild.getInputStream(latestSnapshot.get(updatedChild.writer()).props, network, crypto, l -> {})
+                                                    return updatedChild.getInputStream(latestSnapshot.get(updatedChild.writer()).props.get(), network, crypto, l -> {})
                                                             .thenCompose(is -> updatedChild.recalculateThumbnail(
                                                                 latestSnapshot, committer, filename, is, isHidden,
                                                                 updatedChild.getSize(), updatedChild.props.created, network, (WritableAbsoluteCapability)updatedChild.pointer.capability,
@@ -1295,7 +1295,7 @@ public class FileWrapper {
     @JsMethod
     public CompletableFuture<Boolean> calculateAndUpdateThumbnail(NetworkAccess network, Crypto crypto) {
         return network.synchronizer.applyComplexComputation(owner(), signingPair(),
-                (latestSnapshot, committer) -> getInputStream(latestSnapshot.get(writer()).props, network, crypto, l -> {})
+                (latestSnapshot, committer) -> getInputStream(latestSnapshot.get(writer()).props.get(), network, crypto, l -> {})
                         .thenCompose(is -> recalculateThumbnail(
                                 latestSnapshot, committer, getName(), is, props.isHidden,
                                 getSize(), props.created, network, (WritableAbsoluteCapability)pointer.capability,
@@ -1777,7 +1777,7 @@ public class FileWrapper {
                                                 })));
             } else {
                 return version.withWriter(owner(), writer(), network).thenCompose(snapshot ->
-                        getInputStream(snapshot.get(writer()).props, network, crypto, x -> {})
+                        getInputStream(snapshot.get(writer()).props.get(), network, crypto, x -> {})
                                 .thenCompose(stream -> target.uploadFileSection(snapshot, committer,
                                                 getName(), stream, existingThumbnail, false, 0, getSize(),
                                                 Optional.empty(), Optional.empty(), Optional.empty(), false, false, false, network, crypto, x -> {},
@@ -1861,7 +1861,7 @@ public class FileWrapper {
                                                              Committer committer) {
 
         return initialVersion.withWriter(currentCap.owner, currentCap.writer, network)
-                .thenCompose(version -> network.getMetadata(version.get(currentCap.writer).props, currentCap)
+                .thenCompose(version -> network.getMetadata(version.get(currentCap.writer).props.get(), currentCap)
                         .thenCompose(mOpt -> {
                             if (! mOpt.isPresent()) {
                                 return CompletableFuture.completedFuture(version);
@@ -1903,7 +1903,7 @@ public class FileWrapper {
                                                               Snapshot version,
                                                               Committer committer) {
         return version.withWriter(currentCap.owner, currentCap.writer, network)
-                .thenCompose(current -> network.getMetadata(current.get(currentCap.writer).props, currentCap)
+                .thenCompose(current -> network.getMetadata(current.get(currentCap.writer).props.get(), currentCap)
                         .thenCompose(mOpt -> {
                             if (! mOpt.isPresent()) {
                                 return CompletableFuture.completedFuture(current);
@@ -2062,7 +2062,7 @@ public class FileWrapper {
         CommittedWriterData toRemove = current.get(signerToRemove.publicKeyHash);
 
         return current.withWriter(owner, parentWriter, network)
-                .thenCompose(s -> s.get(parentSigner).props
+                .thenCompose(s -> s.get(parentSigner).props.get()
                         .removeOwnedKey(owner, parentSigner, signerToRemove.publicKeyHash, network.dhtClient, network.hasher)
                         .thenCompose(removed -> IpfsTransaction.call(
                                 owner,
@@ -2070,7 +2070,7 @@ public class FileWrapper {
                                 network.dhtClient))
                         .thenApply(committed -> s.withVersion(parentWriter, committed.get(parentWriter))))
                 .thenCompose(s -> IpfsTransaction.call(owner,
-                        tid -> committer.commit(owner, signerToRemove, null, toRemove, tid), network.dhtClient)
+                        tid -> committer.commit(owner, signerToRemove, Optional.empty(), toRemove, tid), network.dhtClient)
                         .thenApply(s::mergeAndOverwriteWith));
     }
 
@@ -2078,7 +2078,7 @@ public class FileWrapper {
                                                                    Crypto crypto,
                                                                    ProgressConsumer<Long> monitor) {
         return network.synchronizer.getValue(owner(), writer())
-                .thenCompose(state -> getInputStream(state.get(writer()).props, network, crypto, getFileProperties().size, 1, monitor));
+                .thenCompose(state -> getInputStream(state.get(writer()).props.get(), network, crypto, getFileProperties().size, 1, monitor));
     }
 
     public CompletableFuture<? extends AsyncReader> getInputStream(WriterData version,
@@ -2109,7 +2109,7 @@ public class FileWrapper {
                                                                    int fileSizeLow,
                                                                    ProgressConsumer<Long> monitor) {
         return network.synchronizer.getValue(owner(), writer())
-                .thenCompose(state -> getInputStream(state.get(writer()).props, network, crypto, fileSize(fileSizeHi, fileSizeLow), 1, monitor));
+                .thenCompose(state -> getInputStream(state.get(writer()).props.get(), network, crypto, fileSize(fileSizeHi, fileSizeLow), 1, monitor));
     }
 
     public CompletableFuture<? extends AsyncReader> getInputStream(NetworkAccess network,
@@ -2125,7 +2125,7 @@ public class FileWrapper {
                                                                    int nBufferedChunks,
                                                                    ProgressConsumer<Long> monitor) {
         return network.synchronizer.getValue(owner(), writer())
-                .thenCompose(state -> getInputStream(state.get(writer()).props, network, crypto, fileSize, nBufferedChunks, monitor));
+                .thenCompose(state -> getInputStream(state.get(writer()).props.get(), network, crypto, fileSize, nBufferedChunks, monitor));
     }
 
     public CompletableFuture<? extends AsyncReader> getInputStream(WriterData version,

--- a/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
+++ b/src/peergos/shared/user/fs/transaction/FileUploadTransaction.java
@@ -84,7 +84,10 @@ public class FileUploadTransaction implements Transaction {
 
     private CompletableFuture<Snapshot> clear(Snapshot version, Committer committer, NetworkAccess networkAccess, Location location) {
         return IpfsTransaction.call(owner,
-                tid -> networkAccess.deleteChunkIfPresent(version, committer, location.owner, writer, location.getMapKey(), tid), networkAccess.dhtClient);
+                tid -> version.withWriter(owner, writer.publicKeyHash, networkAccess)
+                        .thenCompose(v -> v.contains(writer.publicKeyHash) ?
+                                networkAccess.deleteChunkIfPresent(v, committer, location.owner, writer, location.getMapKey(), tid) :
+                                Futures.of(v)), networkAccess.dhtClient);
     }
 
     public CompletableFuture<Snapshot> clear(Snapshot version, Committer committer, NetworkAccess network, Hasher h) {

--- a/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
+++ b/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
@@ -95,7 +95,7 @@ public class TransactionServiceImpl implements TransactionService {
         byte[] data = new byte[size];
 
         CommittedWriterData cwd = version.get(txnFile.writer());
-        return txnFile.getInputStream(cwd.props, networkAccess, crypto, VOID_PROGRESS)
+        return txnFile.getInputStream(cwd.props.get(), networkAccess, crypto, VOID_PROGRESS)
                 .thenApply(reader -> Serialize.readFullArray(reader, data))
                 .thenApply(done -> Optional.of(Transaction.deserialize(data, txnFile.getName())))
                 .exceptionally(t -> Optional.empty());

--- a/src/peergos/shared/util/Serialize.java
+++ b/src/peergos/shared/util/Serialize.java
@@ -103,7 +103,7 @@ public class Serialize
 
     public static CompletableFuture<byte[]> readFully(FileWrapper f, Crypto crypto, NetworkAccess network) {
         long size = f.getSize();
-        return f.getInputStream(f.version.get(f.writer()).props, network, crypto, x -> {})
+        return f.getInputStream(f.version.get(f.writer()).props.get(), network, crypto, x -> {})
                 .thenCompose(stream -> readFully(stream, size));
     }
 
@@ -122,7 +122,7 @@ public class Serialize
                                                  NetworkAccess network,
                                                  Crypto crypto) {
         byte[] res = new byte[(int)f.getSize()];
-        return f.getInputStream(f.version.get(f.writer()).props,network, crypto, x -> {})
+        return f.getInputStream(f.version.get(f.writer()).props.get(),network, crypto, x -> {})
                 .thenCompose(reader -> reader.readIntoArray(res, 0, (int) f.getSize()))
                 .thenApply(i -> Cborable.parser(parser).apply(res));
     }


### PR DESCRIPTION
1. cleaning up a failed upload to a different writing space
2. correct usage decrease when deleting writing space
3. set pointer to empty when deleting writing space (to trigger 2)
4. Handle clearing an upload transaction for a removed writing space (noop)

Add test for all of this

I don't like using a null WriterData to achieve this..