### PR TITLE
New secret links design

### DIFF
--- a/src/peergos/client/JsUtil.java
+++ b/src/peergos/client/JsUtil.java
@@ -7,6 +7,7 @@ import peergos.shared.login.mfa.WebauthnResponse;
 import peergos.shared.util.Either;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -14,6 +15,11 @@ import java.util.stream.Collectors;
  *
  */
 public class JsUtil {
+
+    @JsMethod
+    public static LocalDateTime fromUtcMillis(long millis) {
+        return LocalDateTime.ofEpochSecond(millis/1_000, ((int)(millis % 1000)) * 1_000_000, ZoneOffset.UTC);
+    }
 
     @JsMethod
     public static CborObject fromByteArray(byte[] cbor) {

--- a/src/peergos/gwt/emu/java/time/LocalDateTime.java
+++ b/src/peergos/gwt/emu/java/time/LocalDateTime.java
@@ -86,6 +86,7 @@ public class LocalDateTime implements Comparable<LocalDateTime>{
     	return null;
     }
 
+    @JsMethod
     public static LocalDateTime of(int year, int month, int dayOfMonth, int hour, int minute, int second) {
     	return new LocalDateTime(new LocalDate(year, month, dayOfMonth), new LocalTime(hour, minute, second, 0));
     }

--- a/src/peergos/server/AggregatedMetrics.java
+++ b/src/peergos/server/AggregatedMetrics.java
@@ -33,6 +33,7 @@ public class AggregatedMetrics {
     public static final Counter STORAGE_TRANSACTION_CLOSE  = build("storage_transaction_close", "Total DHT transaction closes.");
     public static final Counter STORAGE_CHAMP_GET  = build("storage_champ_get", "Total champ gets");
     public static final Counter STORAGE_LINK_GET  = build("storage_link_get", "Total link gets");
+    public static final Counter STORAGE_LINK_COUNTS  = build("storage_link_counts", "Total link counts");
     public static final Counter STORAGE_IPNS_GET  = build("storage_ipns_get", "Total ipns gets");
     public static final Histogram STORAGE_CHAMP_GET_DURATION = Histogram.build()
             .labelNames("duration")

--- a/src/peergos/server/AggregatedMetrics.java
+++ b/src/peergos/server/AggregatedMetrics.java
@@ -32,11 +32,19 @@ public class AggregatedMetrics {
     public static final Counter STORAGE_TRANSACTION_START  = build("storage_transaction_start", "Total DHT transaction starts.");
     public static final Counter STORAGE_TRANSACTION_CLOSE  = build("storage_transaction_close", "Total DHT transaction closes.");
     public static final Counter STORAGE_CHAMP_GET  = build("storage_champ_get", "Total champ gets");
+    public static final Counter STORAGE_LINK_GET  = build("storage_link_get", "Total link gets");
     public static final Counter STORAGE_IPNS_GET  = build("storage_ipns_get", "Total ipns gets");
     public static final Histogram STORAGE_CHAMP_GET_DURATION = Histogram.build()
             .labelNames("duration")
             .name("champ_get_duration")
             .help("Time to respond to a champ.get call")
+            .exponentialBuckets(0.01, 2, 16)
+            .register();
+
+    public static final Histogram STORAGE_LINK_GET_DURATION = Histogram.build()
+            .labelNames("duration")
+            .name("link_get_duration")
+            .help("Time to respond to a link.get call")
             .exponentialBuckets(0.01, 2, 16)
             .register();
 

--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -369,6 +369,7 @@ public class Builder {
                                          JdbcAccount rawAccount,
                                          BatCave bats,
                                          Account account,
+                                         LinkRetrievalCounter linkCounts,
                                          Crypto crypto) {
         Multihash nodeId = localStorage.id().join();
         PublicKeyHash peergosId = PublicKeyHash.fromString(a.getArg("peergos.identity.hash"));
@@ -378,7 +379,7 @@ public class Builder {
         return isPkiNode ?
                 buildPkiCorenode(localPointers, account, bats, localStorage, a) :
                 new MirrorCoreNode(new HTTPCoreNode(buildP2pHttpProxy(a), pkiServerId), rawAccount, bats, account, proxingMutable,
-                        localStorage, rawPointers, localPointers, transactions, localSocial, usageStore, pkiServerId, peergosId,
+                        localStorage, rawPointers, localPointers, transactions, localSocial, usageStore, linkCounts, pkiServerId, peergosId,
                         a.fromPeergosDir("pki-mirror-state-path","pki-state.cbor"), crypto);
     }
 

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -525,15 +525,17 @@ public class Main extends Builder {
 
             TransactionStore transactions = buildTransactionStore(a, dbConnectionPool);
 
-            DeletableContentAddressedStorage localStorage = buildLocalStorage(a, meta, transactions, blockAuth,
+            DeletableContentAddressedStorage localStorageForLinks = buildLocalStorage(a, meta, transactions, blockAuth,
                     ids, crypto.hasher);
             JdbcIpnsAndSocial rawPointers = buildRawPointers(a,
                     getDBConnector(a, "mutable-pointers-file", dbConnectionPool));
 
-            List<Cid> nodeIds = localStorage.ids().get();
 
-            MutablePointers localPointers = UserRepository.build(localStorage, rawPointers);
+            MutablePointers localPointers = UserRepository.build(localStorageForLinks, rawPointers);
             MutablePointersProxy proxingMutable = new HttpMutablePointers(p2pHttpProxy, pkiServerNodeId);
+            DeletableContentAddressedStorage localStorage = new SecretLinkStorage(localStorageForLinks, localPointers, new RamLinkRetrievalCounter(), hasher);
+
+            List<Cid> nodeIds = localStorage.ids().get();
 
             Supplier<Connection> usageDb = getDBConnector(a, "space-usage-sql-file", dbConnectionPool);
             UsageStore usageStore = new JdbcUsageStore(usageDb, sqlCommands);

--- a/src/peergos/server/Mirror.java
+++ b/src/peergos/server/Mirror.java
@@ -162,7 +162,7 @@ public class Mirror {
         }
         if (mirrorBat.isPresent()) { // get link count db
             Optional<LocalDateTime> latest = linkCounts.getLatestModificationTime(username);
-            LinkRetrievalCounter.LinkCounts updatedCounts = storage.getLinkCounts(username, latest.orElse(LocalDateTime.MIN), mirrorBat.get()).join();
+            LinkCounts updatedCounts = storage.getLinkCounts(username, latest.orElse(LocalDateTime.MIN), mirrorBat.get()).join();
             linkCounts.setCounts(username, updatedCounts);
         }
         Logging.LOG().log(Level.INFO, "Finished mirroring data for " + username);

--- a/src/peergos/server/ServerMessages.java
+++ b/src/peergos/server/ServerMessages.java
@@ -119,7 +119,7 @@ public class ServerMessages extends Builder {
             JdbcAccount account = new JdbcAccount(getDBConnector(a, "account-sql-file", dbConnectionPool),
                     cmds, new com.webauthn4j.data.client.Origin("http://localhost:8000"), "localhost");
             CoreNode core = buildCorenode(a, localStorage, transactions, rawPointers, localPointers, proxingMutable,
-                    rawSocial, usageStore, account, null, new AccountWithStorage(localStorage, localPointers, account), crypto);
+                    rawSocial, usageStore, account, null, new AccountWithStorage(localStorage, localPointers, account), null, crypto);
             return buildSpaceQuotas(a, localStorage, core,
                     getDBConnector(a, "space-requests-sql-file", dbConnectionPool),
                     getDBConnector(a, "quotas-sql-file", dbConnectionPool), false, true);

--- a/src/peergos/server/UserCleanup.java
+++ b/src/peergos/server/UserCleanup.java
@@ -82,7 +82,7 @@ public class UserCleanup {
             Set<ByteArrayWrapper> emptyKeys = new HashSet<>();
             CommittedWriterData wd = WriterData.getWriterData(owner, writer, mutable, storage).join();
             ChampWrapper<CborObject.CborMerkleLink> champ = ChampWrapper.create(owner, (Cid) wd.props.get().tree.get(),
-                    x -> Futures.of(x.data), storage, hasher, b -> (CborObject.CborMerkleLink) b).join();
+                    Optional.empty(), x -> Futures.of(x.data), storage, hasher, b -> (CborObject.CborMerkleLink) b).join();
             champ.applyToAllMappings(owner, p -> {
                 if (p.right.isPresent())
                     allKeys.put(p.left, p.right.get());

--- a/src/peergos/server/corenode/CorenodeEventPropagator.java
+++ b/src/peergos/server/corenode/CorenodeEventPropagator.java
@@ -10,6 +10,7 @@ import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -110,8 +111,9 @@ public class CorenodeEventPropagator implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
-        return target.migrateUser(username, newChain, currentStorageId, mirrorBat, currentUsage).thenApply(res -> {
+        return target.migrateUser(username, newChain, currentStorageId, mirrorBat, latestLinkCountUpdate, currentUsage).thenApply(res -> {
             processEvent(newChain);
             return res;
         });

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -426,7 +426,7 @@ public class IpfsCoreNode implements CoreNode {
             MaybeMultihash currentTree = current.props.get().tree.map(MaybeMultihash::of).orElseGet(MaybeMultihash::empty);
 
             ChampWrapper<CborObject.CborMerkleLink> champ = currentTree.isPresent() ?
-                    ChampWrapper.create(peergosIdentity, (Cid)currentTree.get(), IpfsCoreNode::keyHash, ipfs, hasher, c -> (CborObject.CborMerkleLink)c).get() :
+                    ChampWrapper.create(peergosIdentity, (Cid)currentTree.get(), Optional.empty(), IpfsCoreNode::keyHash, ipfs, hasher, c -> (CborObject.CborMerkleLink)c).get() :
                     IpfsTransaction.call(peergosIdentity,
                             tid -> ChampWrapper.create(signer.publicKeyHash, signer, IpfsCoreNode::keyHash, tid, ipfs, hasher, c -> (CborObject.CborMerkleLink)c),
                             ipfs).get();

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -1,4 +1,5 @@
 package peergos.server.corenode;
+import java.time.*;
 import java.util.logging.*;
 
 import peergos.server.storage.*;
@@ -507,6 +508,7 @@ public class IpfsCoreNode implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
         throw new IllegalStateException("Migration from pki node unimplemented!");
     }

--- a/src/peergos/server/corenode/IpfsCoreNode.java
+++ b/src/peergos/server/corenode/IpfsCoreNode.java
@@ -461,7 +461,7 @@ public class IpfsCoreNode implements CoreNode {
                     ipfs).get();
             synchronized (this) {
                 return IpfsTransaction.call(peergosIdentity,
-                        tid -> champ.put(signer.publicKeyHash, signer, username.getBytes(), existing, new CborObject.CborMerkleLink(mergedChainHash), tid)
+                        tid -> champ.put(signer.publicKeyHash, signer, username.getBytes(), existing, new CborObject.CborMerkleLink(mergedChainHash), Optional.empty(), tid)
                                 .thenCompose(newPkiRoot -> current.props.get().withChamp(newPkiRoot)
                                         .commit(peergosIdentity, signer, currentRoot, currentSequence, mutable, ipfs, hasher, tid)),
                         ipfs

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -2,7 +2,6 @@ package peergos.server.corenode;
 
 import peergos.server.*;
 import peergos.server.login.*;
-import peergos.server.net.*;
 import peergos.server.space.*;
 import peergos.server.storage.*;
 import peergos.server.util.*;
@@ -509,7 +508,7 @@ public class MirrorCoreNode implements CoreNode {
         if (currentStorageId.equals(ourNodeId)) {
             // a user is migrating away from this server
             ProofOfWork work = ProofOfWork.empty();
-            LinkRetrievalCounter.LinkCounts updated = linkCounts.getUpdatedCounts(latestLinkCountUpdate);
+            LinkCounts updated = linkCounts.getUpdatedCounts(latestLinkCountUpdate);
             UserSnapshot snapshot = getUserSnapshot(owner, currentLast.claim.storageProviders, p2pMutable, ipfs, hasher)
                     .thenApply(pointers -> new UserSnapshot(pointers,
                             localSocial.getAndParseFollowRequests(owner),

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -508,7 +508,7 @@ public class MirrorCoreNode implements CoreNode {
         if (currentStorageId.equals(ourNodeId)) {
             // a user is migrating away from this server
             ProofOfWork work = ProofOfWork.empty();
-            LinkCounts updated = linkCounts.getUpdatedCounts(latestLinkCountUpdate);
+            LinkCounts updated = linkCounts.getUpdatedCounts(username, latestLinkCountUpdate);
             UserSnapshot snapshot = getUserSnapshot(owner, currentLast.claim.storageProviders, p2pMutable, ipfs, hasher)
                     .thenApply(pointers -> new UserSnapshot(pointers,
                             localSocial.getAndParseFollowRequests(owner),

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -24,6 +24,7 @@ import peergos.shared.util.*;
 
 import java.io.*;
 import java.nio.file.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -45,6 +46,7 @@ public class MirrorCoreNode implements CoreNode {
     private final TransactionStore transactions;
     private final JdbcIpnsAndSocial localSocial;
     private final UsageStore usageStore;
+    private final LinkRetrievalCounter linkCounts;
     private final PublicKeyHash pkiOwnerIdentity;
     private final Multihash ourNodeId, pkiPeerId;
     private final Hasher hasher;
@@ -65,6 +67,7 @@ public class MirrorCoreNode implements CoreNode {
                           TransactionStore transactions,
                           JdbcIpnsAndSocial localSocial,
                           UsageStore usageStore,
+                          LinkRetrievalCounter linkCounts,
                           Multihash pkiPeerId,
                           PublicKeyHash pkiOwnerIdentity,
                           Path statePath,
@@ -80,6 +83,7 @@ public class MirrorCoreNode implements CoreNode {
         this.transactions = transactions;
         this.localSocial = localSocial;
         this.usageStore = usageStore;
+        this.linkCounts = linkCounts;
         this.pkiPeerId = pkiPeerId;
         this.pkiOwnerIdentity = pkiOwnerIdentity;
         this.statePath = statePath;
@@ -438,7 +442,8 @@ public class MirrorCoreNode implements CoreNode {
                 .collect(Collectors.toMap(p -> p.left, p -> p.right)),
                 in.pendingFollowReqs,
                 in.mirrorBats,
-                in.login);
+                in.login,
+                in.linkCounts);
     }
 
     public static CompletableFuture<Map<PublicKeyHash, byte[]>> getUserSnapshotRecursive(List<Multihash> peerIds,
@@ -489,6 +494,7 @@ public class MirrorCoreNode implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
         // check chain validity before proceeding further
         List<UserPublicKeyLink> existingChain = getChain(username).join();
@@ -503,12 +509,12 @@ public class MirrorCoreNode implements CoreNode {
         if (currentStorageId.equals(ourNodeId)) {
             // a user is migrating away from this server
             ProofOfWork work = ProofOfWork.empty();
-
+            LinkRetrievalCounter.LinkCounts updated = linkCounts.getUpdatedCounts(latestLinkCountUpdate);
             UserSnapshot snapshot = getUserSnapshot(owner, currentLast.claim.storageProviders, p2pMutable, ipfs, hasher)
                     .thenApply(pointers -> new UserSnapshot(pointers,
                             localSocial.getAndParseFollowRequests(owner),
                             batCave.getUserBats(username, new byte[0]).join(),
-                            rawAccount.getLoginData(username))).join();
+                            rawAccount.getLoginData(username), updated)).join();
             updateChain(username, newChain, work, "").join();
             // from this point on new writes are proxied to the new storage server
             return Futures.of(update(snapshot));
@@ -528,12 +534,13 @@ public class MirrorCoreNode implements CoreNode {
             }
             List<Multihash> storageProviders = getStorageProviders(owner);
             // Mirror all the data locally
-            Mirror.mirrorUser(username, Optional.empty(), mirrorBat, this, p2pMutable, null, ipfs, rawPointers, rawAccount, transactions, hasher);
+            Mirror.mirrorUser(username, Optional.empty(), mirrorBat, this, p2pMutable, null, ipfs, rawPointers, rawAccount, transactions, linkCounts, hasher);
             Map<PublicKeyHash, byte[]> mirrored = Mirror.mirrorUser(username, Optional.empty(), mirrorBat, this, p2pMutable,
-                    null, ipfs, rawPointers, rawAccount, transactions, hasher);
+                    null, ipfs, rawPointers, rawAccount, transactions, linkCounts, hasher);
 
             // Proxy call to their current storage server
-            UserSnapshot res = writeTarget.migrateUser(username, newChain, currentStorageId, mirrorBat, currentUsage).join();
+            LocalDateTime localLatestLinkCountTime = linkCounts.getLatestModificationTime(username).orElse(LocalDateTime.MIN);
+            UserSnapshot res = writeTarget.migrateUser(username, newChain, currentStorageId, mirrorBat, localLatestLinkCountTime, currentUsage).join();
             // pick up the new pki data locally
             update();
 
@@ -556,6 +563,9 @@ public class MirrorCoreNode implements CoreNode {
                 localSocial.addFollowRequest(owner, req.serialize()).join();
             }
 
+            // update local link counts
+            linkCounts.setCounts(username, res.linkCounts);
+
             // Make sure usage is updated
             List<Multihash> us = List.of(ourNodeId.bareMultihash());
             Set<PublicKeyHash> allUserKeys = DeletableContentAddressedStorage.getOwnedKeysRecursive(owner, owner, p2pMutable,
@@ -563,7 +573,7 @@ public class MirrorCoreNode implements CoreNode {
             SpaceCheckingKeyFilter.processCorenodeEvent(username, owner, allUserKeys, usageStore, ipfs, p2pMutable, hasher);
             return Futures.of(res);
         } else // Proxy call to their target storage server
-            return writeTarget.migrateUser(username, newChain, migrationTargetNode, mirrorBat, currentUsage);
+            return writeTarget.migrateUser(username, newChain, migrationTargetNode, mirrorBat, latestLinkCountUpdate, currentUsage);
     }
 
     @Override

--- a/src/peergos/server/corenode/NonWriteThroughCoreNode.java
+++ b/src/peergos/server/corenode/NonWriteThroughCoreNode.java
@@ -10,6 +10,7 @@ import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.*;
@@ -123,6 +124,7 @@ public class NonWriteThroughCoreNode implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
         throw new IllegalStateException("Unimplemented method!");
     }

--- a/src/peergos/server/corenode/SignUpFilter.java
+++ b/src/peergos/server/corenode/SignUpFilter.java
@@ -14,6 +14,7 @@ import peergos.shared.storage.*;
 import peergos.shared.user.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
@@ -165,6 +166,7 @@ public class SignUpFilter implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime linkCountsAfter,
                                                        long currentUsage) {
         if (forUs(newChain)) {
             if (! quotaStore.allowSignupOrUpdate(username, ""))
@@ -177,7 +179,7 @@ public class SignUpFilter implements CoreNode {
                 throw new IllegalStateException("Not enough space for user to migrate user to this server!");
         }
 
-        return target.migrateUser(username, newChain, currentStorageId, mirrorBat, currentUsage);
+        return target.migrateUser(username, newChain, currentStorageId, mirrorBat, linkCountsAfter, currentUsage);
     }
 
     @Override

--- a/src/peergos/server/net/CoreNodeHandler.java
+++ b/src/peergos/server/net/CoreNodeHandler.java
@@ -17,6 +17,7 @@ import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.logging.*;
 import java.util.zip.*;
@@ -182,8 +183,9 @@ public class CoreNodeHandler implements HttpHandler
         Optional<BatWithId> mirrorBat = hasBat ?
                 Optional.of(BatWithId.fromCbor(CborObject.fromByteArray(Serialize.deserializeByteArray(din, 128)))) :
                 Optional.empty();
+        long seconds = din.readLong();
         long currentUsage = din.readLong();
-        UserSnapshot state = coreNode.migrateUser(username, newChain, currentStorageId, mirrorBat, currentUsage).join();
+        UserSnapshot state = coreNode.migrateUser(username, newChain, currentStorageId, mirrorBat, LocalDateTime.ofEpochSecond(seconds, 0, ZoneOffset.UTC), currentUsage).join();
         dout.write(state.serialize());
     }
 

--- a/src/peergos/server/net/StaticHandler.java
+++ b/src/peergos/server/net/StaticHandler.java
@@ -75,6 +75,8 @@ public abstract class StaticHandler implements HttpHandler
                     indexLoads.inc();
                 path = "index.html";
             }
+            if (path.startsWith("secret/")) // secret links of form /secret/$owner/$label all get same page
+                path = "secret.html";
 
             String reqHost = httpExchange.getRequestHeaders().get("Host").stream().findFirst().orElse("");
             boolean isSubdomain = host.validSubdomain(reqHost);

--- a/src/peergos/server/net/StorageHandler.java
+++ b/src/peergos/server/net/StorageHandler.java
@@ -145,10 +145,10 @@ public class StorageHandler implements HttpHandler {
                     Histogram.Timer timer = AggregatedMetrics.STORAGE_LINK_GET_DURATION.labels("duration").startTimer();
                     PublicKeyHash ownerHash = PublicKeyHash.fromString(last.apply("owner"));
                     long label = Long.parseLong(last.apply("label"));
-                    SecretLink lookup = new SecretLink(ownerHash, label);
+                    SecretLink lookup = new SecretLink(ownerHash, label, "");
                     try {
                         dht.getSecretLink(lookup).thenAccept(link -> {
-                            replyBytes(httpExchange, link.payload.serialize(), Optional.empty());
+                            replyBytes(httpExchange, link.serialize(), Optional.empty());
                         }).exceptionally(Futures::logAndThrow).get();
                     } finally {
                         timer.observeDuration();

--- a/src/peergos/server/sql/SqlSupplier.java
+++ b/src/peergos/server/sql/SqlSupplier.java
@@ -56,6 +56,11 @@ public interface SqlSupplier {
                 "CREATE UNIQUE INDEX IF NOT EXISTS bat_index ON bats (id);";
     }
 
+    default String createLinkCountTableCommand() {
+        return "CREATE TABLE IF NOT EXISTS linkcounts (username text not null, label "+sqlInteger()+" not null, count "+sqlInteger()+" not null, modified "+sqlInteger()+" not null); " +
+                "CREATE UNIQUE INDEX IF NOT EXISTS bat_index ON linkcounts (username, label);";
+    }
+
     default String createSpaceRequestsTableCommand() {
         return "CREATE TABLE IF NOT EXISTS spacerequests (name text primary key not null, spacerequest text not null);";
     }

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -114,7 +114,7 @@ public class DelayingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         return source.getLinkCounts(owner, after, mirrorBat);
     }
 

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -6,6 +6,7 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -99,6 +100,16 @@ public class DelayingStorage implements ContentAddressedStorage {
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         sleep(4*readDelay);
         return source.getChampLookup(owner, root, champKey, bat, committedRoot);
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        try {
+            sleep(4*readDelay);
+            return source.getSecretLink(link);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
     }
 
     @Override

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -9,6 +9,7 @@ import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -110,6 +111,11 @@ public class DelayingStorage implements ContentAddressedStorage {
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        return source.getLinkCounts(owner, after, mirrorBat);
     }
 
     @Override

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -188,7 +188,7 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         return target.getLinkCounts(owner, after, mirrorBat);
     }
 

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -182,6 +182,11 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        return target.getSecretLink(link);
+    }
+
+    @Override
     public CompletableFuture<List<FragmentWithHash>> downloadFragments(PublicKeyHash owner,
                                                                        List<Cid> hashes,
                                                                        List<BatWithId> bats,

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -11,6 +11,7 @@ import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -184,6 +185,11 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
         return target.getSecretLink(link);
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        return target.getLinkCounts(owner, after, mirrorBat);
     }
 
     @Override

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -356,7 +356,7 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Shouldn't get here.");
     }
 

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -9,6 +9,7 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.io.*;
@@ -346,6 +347,11 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
             file = root.resolve(path.getFileName()).toFile();
         }
         return file.exists();
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Shouldn't get here.");
     }
 
     @Override

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -15,6 +15,7 @@ import peergos.shared.util.*;
 import java.io.*;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -351,6 +352,11 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
 
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Shouldn't get here.");
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Shouldn't get here.");
     }
 

--- a/src/peergos/server/storage/JdbcLinkRetrievalcounter.java
+++ b/src/peergos/server/storage/JdbcLinkRetrievalcounter.java
@@ -1,0 +1,150 @@
+package peergos.server.storage;
+
+import peergos.server.sql.*;
+import peergos.server.util.*;
+import peergos.shared.storage.*;
+import peergos.shared.util.*;
+
+import java.sql.*;
+import java.time.*;
+import java.util.*;
+import java.util.function.*;
+import java.util.logging.*;
+
+public class JdbcLinkRetrievalcounter implements LinkRetrievalCounter {
+
+    private static final Logger LOG = Logging.LOG();
+
+    private static final String GET = "SELECT count FROM linkcounts WHERE username = ? AND label = ?;";
+    private static final String LATEST = "SELECT MAX(modified) FROM linkcounts WHERE username = ?;";
+    private static final String AFTER = "SELECT label, count, modified FROM linkcounts WHERE username = ? AND modified > ?;";
+
+    private Supplier<Connection> conn;
+    private final SqlSupplier commands;
+
+    public JdbcLinkRetrievalcounter(Supplier<Connection> conn, SqlSupplier commands) {
+        this.conn = conn;
+        this.commands = commands;
+        init(commands);
+    }
+
+    private Connection getConnection() {
+        Connection connection = conn.get();
+        try {
+            connection.setAutoCommit(true);
+            connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            return connection;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private synchronized void init(SqlSupplier commands) {
+        try (Connection conn = getConnection()) {
+            commands.createTable(commands.createLinkCountTableCommand(), conn);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @Override
+    public void increment(String owner, long label) {
+        try (Connection conn = getConnection();
+             PreparedStatement linkInsert = conn.prepareStatement(commands.insertOrIgnoreCommand("INSERT ", "INTO linkcounts (username, label, count, modified) VALUES(?, ?, ?, ?)"));
+             PreparedStatement increment = conn.prepareStatement("UPDATE linkcounts SET count = count + 1, modified=? where username=? AND label=?;")
+             ) {
+            linkInsert.setString(1, owner);
+            linkInsert.setLong(2, label);
+            linkInsert.setLong(3, 0);
+            long now = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC);
+            linkInsert.setLong(4, now);
+            linkInsert.executeUpdate();
+
+            increment.setLong(1, now);
+            increment.setString(2, owner);
+            increment.setLong(3, label);
+            int modified = increment.executeUpdate();
+            if (modified != 1)
+                throw new IllegalStateException("No rows modified!");
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    @Override
+    public long getCount(String owner, long label) {
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(GET)) {
+            stmt.setString(1, owner);
+            stmt.setLong(2, label);
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return rs.getLong(1);
+            }
+            throw new IllegalStateException("No link present!");
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    @Override
+    public Optional<LocalDateTime> getLatestModificationTime(String owner) {
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(LATEST)) {
+            stmt.setString(1, owner);
+            ResultSet rs = stmt.executeQuery();
+            if (rs.next()) {
+                return Optional.of(LocalDateTime.ofEpochSecond(rs.getLong(1), 0, ZoneOffset.UTC));
+            }
+            return Optional.empty();
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    @Override
+    public void setCounts(String owner, LinkCounts counts) {
+        counts.counts.forEach((k, v) -> {
+            try (Connection conn = getConnection();
+                 PreparedStatement linkInsert = conn.prepareStatement(commands.insertOrIgnoreCommand("INSERT ", "INTO linkcounts (username, label, count, modified) VALUES(?, ?, ?, ?)"));
+                 PreparedStatement increment = conn.prepareStatement("UPDATE linkcounts SET count = ? where username=? AND label=?;")
+            ) {
+                linkInsert.setString(1, owner);
+                linkInsert.setLong(2, k);
+                linkInsert.setLong(3, 0);
+                linkInsert.setLong(4, v.right.toEpochSecond(ZoneOffset.UTC));
+                linkInsert.executeUpdate();
+
+                increment.setLong(1, v.left);
+                increment.setString(2, owner);
+                increment.setLong(3, k);
+                increment.executeUpdate();
+            } catch (SQLException sqe) {
+                LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+                throw new RuntimeException(sqe);
+            }
+        });
+    }
+
+    @Override
+    public LinkCounts getUpdatedCounts(String owner, LocalDateTime after) {
+        long seconds = after.toEpochSecond(ZoneOffset.UTC);
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(AFTER)) {
+            stmt.setString(1, owner);
+            stmt.setLong(2, seconds);
+            ResultSet rs = stmt.executeQuery();
+            Map<Long, Pair<Long, LocalDateTime>> res = new HashMap<>();
+            while (rs.next()) {
+                res.put(rs.getLong(1), new Pair<>(rs.getLong(2), LocalDateTime.ofEpochSecond(rs.getLong(3), 0, ZoneOffset.UTC)));
+            }
+
+            return new LinkCounts(res);
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+}

--- a/src/peergos/server/storage/JdbcLinkRetrievalcounter.java
+++ b/src/peergos/server/storage/JdbcLinkRetrievalcounter.java
@@ -81,7 +81,7 @@ public class JdbcLinkRetrievalcounter implements LinkRetrievalCounter {
             if (rs.next()) {
                 return rs.getLong(1);
             }
-            throw new IllegalStateException("No link present!");
+            return 0;
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
             throw new RuntimeException(sqe);

--- a/src/peergos/server/storage/LinkRetrievalCounter.java
+++ b/src/peergos/server/storage/LinkRetrievalCounter.java
@@ -1,10 +1,56 @@
 package peergos.server.storage;
 
-import peergos.shared.crypto.hash.*;
+import peergos.shared.cbor.*;
+import peergos.shared.util.*;
+
+import java.time.*;
+import java.util.*;
 
 public interface LinkRetrievalCounter {
 
-    void increment(PublicKeyHash owner, long label);
+    void increment(String owner, long label);
 
-    long getCount(PublicKeyHash owner, long label);
+    long getCount(String owner, long label);
+
+    Optional<LocalDateTime> getLatestModificationTime(String owner);
+
+    void setCounts(String owner, LinkCounts counts);
+
+    LinkCounts getUpdatedCounts(LocalDateTime after);
+
+    class LinkCounts implements Cborable {
+        public final Map<Long, Pair<Long, LocalDateTime>> counts;
+
+        public LinkCounts(Map<Long, Pair<Long, LocalDateTime>> counts) {
+            this.counts = counts;
+        }
+
+        @Override
+        public CborObject toCbor() {
+            SortedMap<String, Cborable> state = new TreeMap<>();
+            ArrayList<CborObject> data = new ArrayList<>(counts.size() * 3);
+            counts.forEach((k, v) -> {
+                data.add(new CborObject.CborLong(k));
+                data.add(new CborObject.CborLong(v.left));
+                data.add(new CborObject.CborLong(v.right.toEpochSecond(ZoneOffset.UTC)));
+            });
+            state.put("d", new CborObject.CborList(data));
+            return CborObject.CborMap.build(state);
+        }
+
+        public static LinkCounts fromCbor(Cborable cbor) {
+            if (! (cbor instanceof CborObject.CborMap))
+                throw new IllegalStateException("Invalid cbor for FileProperties! " + cbor);
+            CborObject.CborMap m = (CborObject.CborMap) cbor;
+            CborObject.CborList d = m.getList("d");
+            Map<Long, Pair<Long, LocalDateTime>> counts = new HashMap<>();
+            for (int i=0; i < d.value.size(); i+= 3) {
+                long key = ((CborObject.CborLong) d.value.get(i)).value;
+                long count = ((CborObject.CborLong) d.value.get(i + 1)).value;
+                long seconds = ((CborObject.CborLong) d.value.get(i + 2)).value;
+                counts.put(key, new Pair<>(count, LocalDateTime.ofEpochSecond(seconds, 0, ZoneOffset.UTC)));
+            }
+            return new LinkCounts(counts);
+        }
+    }
 }

--- a/src/peergos/server/storage/LinkRetrievalCounter.java
+++ b/src/peergos/server/storage/LinkRetrievalCounter.java
@@ -1,7 +1,6 @@
 package peergos.server.storage;
 
-import peergos.shared.cbor.*;
-import peergos.shared.util.*;
+import peergos.shared.storage.*;
 
 import java.time.*;
 import java.util.*;
@@ -18,39 +17,4 @@ public interface LinkRetrievalCounter {
 
     LinkCounts getUpdatedCounts(LocalDateTime after);
 
-    class LinkCounts implements Cborable {
-        public final Map<Long, Pair<Long, LocalDateTime>> counts;
-
-        public LinkCounts(Map<Long, Pair<Long, LocalDateTime>> counts) {
-            this.counts = counts;
-        }
-
-        @Override
-        public CborObject toCbor() {
-            SortedMap<String, Cborable> state = new TreeMap<>();
-            ArrayList<CborObject> data = new ArrayList<>(counts.size() * 3);
-            counts.forEach((k, v) -> {
-                data.add(new CborObject.CborLong(k));
-                data.add(new CborObject.CborLong(v.left));
-                data.add(new CborObject.CborLong(v.right.toEpochSecond(ZoneOffset.UTC)));
-            });
-            state.put("d", new CborObject.CborList(data));
-            return CborObject.CborMap.build(state);
-        }
-
-        public static LinkCounts fromCbor(Cborable cbor) {
-            if (! (cbor instanceof CborObject.CborMap))
-                throw new IllegalStateException("Invalid cbor for FileProperties! " + cbor);
-            CborObject.CborMap m = (CborObject.CborMap) cbor;
-            CborObject.CborList d = m.getList("d");
-            Map<Long, Pair<Long, LocalDateTime>> counts = new HashMap<>();
-            for (int i=0; i < d.value.size(); i+= 3) {
-                long key = ((CborObject.CborLong) d.value.get(i)).value;
-                long count = ((CborObject.CborLong) d.value.get(i + 1)).value;
-                long seconds = ((CborObject.CborLong) d.value.get(i + 2)).value;
-                counts.put(key, new Pair<>(count, LocalDateTime.ofEpochSecond(seconds, 0, ZoneOffset.UTC)));
-            }
-            return new LinkCounts(counts);
-        }
-    }
 }

--- a/src/peergos/server/storage/LinkRetrievalCounter.java
+++ b/src/peergos/server/storage/LinkRetrievalCounter.java
@@ -1,0 +1,10 @@
+package peergos.server.storage;
+
+import peergos.shared.crypto.hash.*;
+
+public interface LinkRetrievalCounter {
+
+    void increment(PublicKeyHash owner, long label);
+
+    long getCount(PublicKeyHash owner, long label);
+}

--- a/src/peergos/server/storage/LinkRetrievalCounter.java
+++ b/src/peergos/server/storage/LinkRetrievalCounter.java
@@ -15,6 +15,6 @@ public interface LinkRetrievalCounter {
 
     void setCounts(String owner, LinkCounts counts);
 
-    LinkCounts getUpdatedCounts(LocalDateTime after);
+    LinkCounts getUpdatedCounts(String owner, LocalDateTime after);
 
 }

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -6,6 +6,7 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -103,6 +104,11 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Unsupported operation!");
     }
 
     @Override

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -9,6 +9,7 @@ import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -108,6 +109,11 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
 
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Unsupported operation!");
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Unsupported operation!");
     }
 

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -113,7 +113,7 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Unsupported operation!");
     }
 

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -206,7 +206,7 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Shouldn't get here.");
     }
 

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -12,6 +12,7 @@ import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.security.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -201,6 +202,11 @@ public class RAMStorage implements DeletableContentAddressedStorage {
 
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Shouldn't get here.");
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Shouldn't get here.");
     }
 

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -8,6 +8,7 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.security.*;
@@ -196,6 +197,11 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     @Override
     public CompletableFuture<IpnsEntry> getIpnsEntry(Multihash signer) {
         throw new IllegalStateException("Unimplemented!");
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Shouldn't get here.");
     }
 
     public static Cid hashToCid(byte[] input, boolean isRaw) {

--- a/src/peergos/server/storage/RamLinkRetrievalCounter.java
+++ b/src/peergos/server/storage/RamLinkRetrievalCounter.java
@@ -1,0 +1,24 @@
+package peergos.server.storage;
+
+import peergos.shared.crypto.hash.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+
+public class RamLinkRetrievalCounter implements LinkRetrievalCounter {
+
+    private final Map<Pair<PublicKeyHash, Long>, Long> counts = new HashMap<>();
+
+    @Override
+    public synchronized void increment(PublicKeyHash owner, long label) {
+        Pair<PublicKeyHash, Long> key = new Pair<>(owner, label);
+        counts.putIfAbsent(key, 0L);
+        long current = counts.get(key);
+        counts.put(key, current+1);
+    }
+
+    @Override
+    public long getCount(PublicKeyHash owner, long label) {
+        return counts.getOrDefault(new Pair<>(owner, label), 0L);
+    }
+}

--- a/src/peergos/server/storage/RamLinkRetrievalCounter.java
+++ b/src/peergos/server/storage/RamLinkRetrievalCounter.java
@@ -1,24 +1,50 @@
 package peergos.server.storage;
 
-import peergos.shared.crypto.hash.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
+import java.util.stream.*;
 
 public class RamLinkRetrievalCounter implements LinkRetrievalCounter {
 
-    private final Map<Pair<PublicKeyHash, Long>, Long> counts = new HashMap<>();
+    private final Map<Pair<String, Long>, Pair<Long, LocalDateTime>> counts = new HashMap<>();
 
     @Override
-    public synchronized void increment(PublicKeyHash owner, long label) {
-        Pair<PublicKeyHash, Long> key = new Pair<>(owner, label);
-        counts.putIfAbsent(key, 0L);
-        long current = counts.get(key);
-        counts.put(key, current+1);
+    public synchronized void increment(String owner, long label) {
+        Pair<String, Long> key = new Pair<>(owner, label);
+        LocalDateTime now = LocalDateTime.now();
+        counts.putIfAbsent(key, new Pair<>(0L, now));
+        Pair<Long, LocalDateTime> current = counts.get(key);
+        counts.put(key, new Pair<>(current.left+1, now));
     }
 
     @Override
-    public long getCount(PublicKeyHash owner, long label) {
-        return counts.getOrDefault(new Pair<>(owner, label), 0L);
+    public long getCount(String owner, long label) {
+        return Optional.ofNullable(counts.get(new Pair<>(owner, label))).map(p -> p.left).orElse(0L);
+    }
+
+    @Override
+    public Optional<LocalDateTime> getLatestModificationTime(String owner) {
+        return counts.entrySet().stream()
+                .filter(e -> e.getKey().left.equals(owner))
+                .map(e -> e.getValue().right)
+                .sorted((a, b) -> -a.compareTo(b))
+                .findFirst();
+    }
+
+    @Override
+    public void setCounts(String owner, LinkCounts counts) {
+        counts.counts.forEach((k, v) -> {
+            this.counts.put(new Pair<>(owner, k), v);
+        });
+    }
+
+    @Override
+    public LinkCounts getUpdatedCounts(LocalDateTime after) {
+        return new LinkCounts(counts.entrySet()
+                .stream()
+                .filter(e -> e.getValue().right.isAfter(after))
+                .collect(Collectors.toMap(e -> e.getKey().right, Map.Entry::getValue)));
     }
 }

--- a/src/peergos/server/storage/RamLinkRetrievalCounter.java
+++ b/src/peergos/server/storage/RamLinkRetrievalCounter.java
@@ -42,10 +42,10 @@ public class RamLinkRetrievalCounter implements LinkRetrievalCounter {
     }
 
     @Override
-    public LinkCounts getUpdatedCounts(LocalDateTime after) {
+    public LinkCounts getUpdatedCounts(String owner, LocalDateTime after) {
         return new LinkCounts(counts.entrySet()
                 .stream()
-                .filter(e -> e.getValue().right.isAfter(after))
+                .filter(e -> e.getKey().left.equals(owner) && e.getValue().right.isAfter(after))
                 .collect(Collectors.toMap(e -> e.getKey().right, Map.Entry::getValue)));
     }
 }

--- a/src/peergos/server/storage/RamLinkRetrievalCounter.java
+++ b/src/peergos/server/storage/RamLinkRetrievalCounter.java
@@ -1,5 +1,6 @@
 package peergos.server.storage;
 
+import peergos.shared.storage.*;
 import peergos.shared.util.*;
 
 import java.time.*;

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -922,7 +922,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Shouldn't get here.");
     }
     public static void main(String[] args) throws Exception {

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -920,6 +920,11 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
         throw new IllegalStateException("Shouldn't get here.");
     }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        throw new IllegalStateException("Shouldn't get here.");
+    }
     public static void main(String[] args) throws Exception {
         Args a = Args.parse(args);
         Logging.init(a.with("log-to-console", "true"));

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -17,6 +17,7 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import javax.net.ssl.*;
@@ -915,6 +916,10 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         }
     }
 
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Shouldn't get here.");
+    }
     public static void main(String[] args) throws Exception {
         Args a = Args.parse(args);
         Logging.init(a.with("log-to-console", "true"));

--- a/src/peergos/server/storage/SecretLinkStorage.java
+++ b/src/peergos/server/storage/SecretLinkStorage.java
@@ -1,0 +1,48 @@
+package peergos.server.storage;
+
+import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.hamt.*;
+import peergos.shared.io.ipfs.*;
+import peergos.shared.mutable.*;
+import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
+import peergos.shared.util.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class SecretLinkStorage extends DelegatingDeletableStorage {
+
+    private final DeletableContentAddressedStorage target;
+    private final MutablePointers pointers;
+    private final Hasher hasher;
+    private final LinkRetrievalCounter counter;
+
+    public SecretLinkStorage(DeletableContentAddressedStorage target, MutablePointers pointers, LinkRetrievalCounter counter, Hasher hasher) {
+        super(target);
+        this.target = target;
+        this.pointers = pointers;
+        this.hasher = hasher;
+        this.counter = counter;
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        PublicKeyHash owner = link.owner;
+        WriterData wd = WriterData.getWriterData(owner, owner, pointers, target).join().props.get();
+        if (wd.secretLinks.isEmpty())
+            throw new IllegalStateException("No secret link published!");
+        SecretLinkChamp champ = SecretLinkChamp.build(owner, (Cid) wd.secretLinks.get(), this, hasher).join();
+        Optional<SecretLinkTarget> res = champ.get(owner, link.label).join();
+        if (res.isEmpty())
+            throw new IllegalStateException("No secret link present!");
+        SecretLinkTarget target = res.get();
+        if (target.expiry.isPresent() && target.expiry.get().isBefore(LocalDateTime.now()))
+            throw new IllegalStateException("Secret link expired!");
+        if (target.maxRetrievals.isPresent() && counter.getCount(owner, link.label) >= target.maxRetrievals.get())
+            throw new IllegalStateException("Invalid secret link!");
+        return Futures.of(target.cap);
+    }
+}

--- a/src/peergos/server/storage/SecretLinkStorage.java
+++ b/src/peergos/server/storage/SecretLinkStorage.java
@@ -53,7 +53,7 @@ public class SecretLinkStorage extends DelegatingDeletableStorage {
             throw new IllegalStateException("Secret link expired!");
         String username = pki.getUsername(owner).join();
         if (target.maxRetrievals.isPresent() && counter.getCount(username, link.label) >= target.maxRetrievals.get())
-            throw new IllegalStateException("Invalid secret link!");
+            throw new IllegalStateException("Maximum link retrievals exceed!");
         counter.increment(username, link.label);
         return Futures.of(target.cap);
     }

--- a/src/peergos/server/storage/SecretLinkStorage.java
+++ b/src/peergos/server/storage/SecretLinkStorage.java
@@ -4,6 +4,7 @@ import peergos.shared.corenode.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.*;
 import peergos.shared.mutable.*;
+import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
@@ -58,9 +59,9 @@ public class SecretLinkStorage extends DelegatingDeletableStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner,
-                                                                            LocalDateTime after,
-                                                                            BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner,
+                                                       LocalDateTime after,
+                                                       BatWithId mirrorBat) {
         byte[] supplied = hasher.sha256(mirrorBat.serialize()).join();
         List<BatWithId> mirrorBats = batstore.getUserBats(owner, new byte[0]).join();
         byte[] expected = hasher.sha256(mirrorBats.get(mirrorBats.size() - 1).serialize()).join();

--- a/src/peergos/server/storage/SecretLinkStorage.java
+++ b/src/peergos/server/storage/SecretLinkStorage.java
@@ -67,6 +67,6 @@ public class SecretLinkStorage extends DelegatingDeletableStorage {
         byte[] expected = hasher.sha256(mirrorBats.get(mirrorBats.size() - 1).serialize()).join();
         if (! Arrays.equals(expected, supplied))
             throw new IllegalStateException("Unauthorized!");
-        return Futures.of(counter.getUpdatedCounts(after));
+        return Futures.of(counter.getUpdatedCounts(owner, after));
     }
 }

--- a/src/peergos/server/tests/ChampTests.java
+++ b/src/peergos/server/tests/ChampTests.java
@@ -15,6 +15,7 @@ import peergos.shared.hamt.*;
 import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
+import peergos.shared.storage.auth.*;
 import peergos.shared.util.*;
 
 import java.nio.file.*;
@@ -75,7 +76,7 @@ public class ChampTests {
             ByteArrayWrapper key = new ByteArrayWrapper(randomHash.get().toBytes());
             Multihash value = randomHash.get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                    Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
             Optional<CborObject.CborMerkleLink> result = updated.left.get(owner, key, hasher.apply(key).join(), 0, bitWidth, storage).get();
             if (! result.equals(Optional.of(new CborObject.CborMerkleLink(value))))
                 throw new IllegalStateException("Incorrect result!");
@@ -101,7 +102,7 @@ public class ChampTests {
             Multihash value = randomHash.get();
             Optional<CborObject.CborMerkleLink> currentValue = current.get(owner, e.getKey(), hasher.apply(e.getKey()).join(), 0, bitWidth, storage).get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, currentValue,
-                    Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
             Optional<CborObject.CborMerkleLink> result = updated.left.get(owner, key, hasher.apply(key).join(), 0, bitWidth, storage).get();
             if (! result.equals(Optional.of(new CborObject.CborMerkleLink(value))))
                 throw new IllegalStateException("Incorrect result!");
@@ -115,7 +116,7 @@ public class ChampTests {
             ByteArrayWrapper key = e.getKey();
             Optional<CborObject.CborMerkleLink> currentValue = current.get(owner, e.getKey(), hasher.apply(e.getKey()).join(), 0, bitWidth, storage).get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.remove(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, currentValue,
-                    bitWidth, maxCollisions, tid, storage, writeHasher, currentHash).get();
+                    bitWidth, maxCollisions, Optional.empty(), tid, storage, writeHasher, currentHash).get();
             Optional<CborObject.CborMerkleLink> result = updated.left.get(owner, key, hasher.apply(key).join(), 0, bitWidth, storage).get();
             if (! result.equals(Optional.empty()))
                 throw new IllegalStateException("Incorrect state!");
@@ -126,9 +127,9 @@ public class ChampTests {
             ByteArrayWrapper key = new ByteArrayWrapper(randomHash.get().toBytes());
             Multihash value = randomHash.get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, Optional.empty(),
-                    Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> removed = updated.left.remove(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                    Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, tid, storage, writeHasher, updated.right).get();
+                    Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), tid, storage, writeHasher, updated.right).get();
             if (! removed.right.equals(currentHash))
                 throw new IllegalStateException("Non canonical state!");
         }
@@ -154,7 +155,7 @@ public class ChampTests {
                 ByteArrayWrapper key = mappings.get(k).getKey();
                 Multihash value = mappings.get(k).getValue().get().target;
                 Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                        Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage,
+                        Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage,
                         writeHasher, currentHash).join();
                 current = updated.left;
                 currentHash = updated.right;
@@ -189,7 +190,7 @@ public class ChampTests {
             ByteArrayWrapper key = new ByteArrayWrapper(new byte[]{0, (byte)i, 0});
             Multihash value = randomHash.get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                    Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage,
+                    Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage,
                     writeHasher, currentHash).get();
             current = updated.left;
             currentHash = updated.right;
@@ -203,7 +204,7 @@ public class ChampTests {
             Optional<CborObject.CborMerkleLink> currentValue = state.get(key);
             Optional<CborObject.CborMerkleLink> newValue = r.nextBoolean() ? Optional.of(new CborObject.CborMerkleLink(randomHash.get())) : Optional.empty();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, currentValue,
-                    newValue, bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    newValue, bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
             List<Triple<ByteArrayWrapper, Optional<CborObject.CborMerkleLink>, Optional<CborObject.CborMerkleLink>>> diffs = new ArrayList<>();
             IpfsCoreNode.applyToDiff(Collections.emptyList(), MaybeMultihash.of(currentHash), MaybeMultihash.of(updated.right), 0, hasher,
                     Collections.emptyList(), Collections.emptyList(), diffs::add, bitWidth, storage, c -> (CborObject.CborMerkleLink)c).join();
@@ -220,7 +221,7 @@ public class ChampTests {
                     .orElse(Optional.empty());
             Optional<CborObject.CborMerkleLink> newValue = Optional.of(new CborObject.CborMerkleLink(randomHash.get()));
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, currentValue,
-                    newValue, bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    newValue, bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
             List<Triple<ByteArrayWrapper, Optional<CborObject.CborMerkleLink>, Optional<CborObject.CborMerkleLink>>> diffs = new ArrayList<>();
 
             IpfsCoreNode.applyToDiff(Collections.emptyList(), MaybeMultihash.of(currentHash), MaybeMultihash.of(updated.right), 0, hasher,
@@ -238,7 +239,7 @@ public class ChampTests {
             Optional<CborObject.CborMerkleLink> currentValue = Optional.empty();
             Optional<CborObject.CborMerkleLink> newValue = Optional.of(new CborObject.CborMerkleLink(randomHash.get()));
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, currentValue,
-                    newValue, bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    newValue, bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
             List<Triple<ByteArrayWrapper, Optional<CborObject.CborMerkleLink>, Optional<CborObject.CborMerkleLink>>> diffs = new ArrayList<>();
             IpfsCoreNode.applyToDiff(Collections.emptyList(), MaybeMultihash.of(currentHash), MaybeMultihash.of(updated.right), 0, hasher,
                     Collections.emptyList(), Collections.emptyList(), diffs::add, bitWidth, storage, c -> (CborObject.CborMerkleLink)c).join();
@@ -267,16 +268,55 @@ public class ChampTests {
                 int suffixLen = 5;
                 int nKeys = r.nextInt(10);
                 Pair<Champ<CborObject.CborMerkleLink>, Multihash> root = randomTree(user, r, prefixLen, suffixLen, nKeys, bitWidth, maxCollisions,
-                        hasher, randomHash, storage);
+                        Optional.empty(), hasher, randomHash, storage);
                 byte[] keyBytes = new byte[prefixLen + suffixLen];
                 r.nextBytes(keyBytes);
                 ByteArrayWrapper key = new ByteArrayWrapper(keyBytes);
                 Multihash value = randomHash.get();
                 Pair<Champ<CborObject.CborMerkleLink>, Multihash> added = root.left.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                        Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage,
+                        Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage,
                         writeHasher, root.right).get();
                 Pair<Champ<CborObject.CborMerkleLink>, Multihash> removed = added.left.remove(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                        Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, tid, storage, writeHasher, added.right).get();
+                        Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), tid, storage, writeHasher, added.right).get();
+                if (! removed.right.equals(root.right))
+                    throw new IllegalStateException("Non canonical delete!");
+            }
+    }
+
+    @Test
+    public void mirrorOnRoot() throws Exception {
+        RAMStorage storage = new RAMStorage(crypto.hasher);
+        int bitWidth = 5;
+        int maxCollisions = 3;
+        SigningPrivateKeyAndPublicHash user = createUser(storage, crypto);
+        Random r = new Random(28);
+
+        Supplier<Multihash> randomHash = () -> {
+            byte[] hash = new byte[32];
+            r.nextBytes(hash);
+            return new Multihash(Multihash.Type.sha2_256, hash);
+        };
+        TransactionId tid = storage.startTransaction(user.publicKeyHash).get();
+        Optional<BatId> mirrorBat = Optional.of(Bat.random(crypto.random).calculateId(crypto.hasher).join());
+
+        for (int prefixLen = 0; prefixLen < 5; prefixLen++)
+            for (int i=0; i < 100; i++) {
+                int suffixLen = 5;
+                int nKeys = r.nextInt(10);
+                Pair<Champ<CborObject.CborMerkleLink>, Multihash> root = randomTree(user, r, prefixLen, suffixLen, nKeys, bitWidth, maxCollisions,
+                        mirrorBat, hasher, randomHash, storage);
+                byte[] keyBytes = new byte[prefixLen + suffixLen];
+                r.nextBytes(keyBytes);
+                ByteArrayWrapper key = new ByteArrayWrapper(keyBytes);
+                Multihash value = randomHash.get();
+                Pair<Champ<CborObject.CborMerkleLink>, Multihash> added = root.left.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
+                        Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, mirrorBat, hasher, tid, storage,
+                        writeHasher, root.right).get();
+                Assert.assertTrue(added.left.mirrorBat.isPresent());
+
+                Pair<Champ<CborObject.CborMerkleLink>, Multihash> removed = added.left.remove(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
+                        Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, mirrorBat, tid, storage, writeHasher, added.right).get();
+                Assert.assertTrue(removed.left.mirrorBat.isPresent());
                 if (! removed.right.equals(root.right))
                     throw new IllegalStateException("Non canonical delete!");
             }
@@ -307,7 +347,7 @@ public class ChampTests {
             ByteArrayWrapper key = new ByteArrayWrapper(new byte[]{0, (byte)i, 0});
             Multihash value = randomHash.get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key, hasher.apply(key).join(), 0,
-                    Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, hasher, tid, storage,
+                    Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)), bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage,
                     writeHasher, currentHash).get();
             current = updated.left;
             currentHash = updated.right;
@@ -329,7 +369,7 @@ public class ChampTests {
         ByteArrayWrapper key = new ByteArrayWrapper(new byte[]{0, 1, 0});
         Optional<CborObject.CborMerkleLink> currentValue = current.get(owner, key, hasher.apply(key).join(), 0, bitWidth, storage).get();
         Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.remove(user.publicKeyHash, user, key, hasher.apply(key).join(), 0, currentValue,
-                bitWidth, maxCollisions, tid, storage, writeHasher, currentHash).get();
+                bitWidth, maxCollisions, Optional.empty(), tid, storage, writeHasher, currentHash).get();
         current = updated.left;
         state.remove(key);
         Optional<CborObject.CborMerkleLink> result = updated.left.get(owner, key, hasher.apply(key).join(), 0, bitWidth, storage).get();
@@ -364,10 +404,11 @@ public class ChampTests {
                                                      int nKeys,
                                                      int bitWidth,
                                                      int maxCollisions,
+                                                     Optional<BatId> mirrorBat,
                                                      Function<ByteArrayWrapper, CompletableFuture<byte[]>> hasher,
                                                      Supplier<Multihash> randomHash,
                                                      RAMStorage storage) throws Exception {
-        Champ<CborObject.CborMerkleLink> current = Champ.empty(c -> (CborObject.CborMerkleLink)c);
+        Champ<CborObject.CborMerkleLink> current = Champ.empty(c -> (CborObject.CborMerkleLink)c).withBat(mirrorBat);
         TransactionId tid = storage.startTransaction(user.publicKeyHash).get();
         Multihash currentHash = storage.put(user.publicKeyHash, user, current.serialize(), writeHasher, tid).get();
         // build a random tree and keep track of the state
@@ -378,7 +419,7 @@ public class ChampTests {
             Multihash value = randomHash.get();
             Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(user.publicKeyHash, user, key,
                     hasher.apply(key).join(), 0, Optional.empty(), Optional.of(new CborObject.CborMerkleLink(value)),
-                    bitWidth, maxCollisions, hasher, tid, storage, writeHasher, currentHash).get();
+                    bitWidth, maxCollisions, mirrorBat, hasher, tid, storage, writeHasher, currentHash).get();
             current = updated.left;
             currentHash = updated.right;
         }

--- a/src/peergos/server/tests/JdbcLinkRetrievalCounterTests.java
+++ b/src/peergos/server/tests/JdbcLinkRetrievalCounterTests.java
@@ -1,0 +1,42 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.*;
+import peergos.server.space.*;
+import peergos.server.sql.*;
+import peergos.server.storage.*;
+import peergos.server.util.*;
+import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.*;
+import peergos.shared.storage.*;
+
+import java.sql.*;
+import java.time.*;
+import java.util.*;
+
+public class JdbcLinkRetrievalCounterTests {
+
+    @Test
+    public void basicUsage() throws Exception {
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcLinkRetrievalcounter store = new JdbcLinkRetrievalcounter(() -> db, new SqliteCommands());
+        String name = "bob";
+        LocalDateTime start = LocalDateTime.now();
+        Thread.sleep(2_000);
+        store.increment(name, 1);
+
+        Assert.assertTrue(1 == store.getCount(name, 1));
+        Assert.assertTrue(store.getLatestModificationTime(name).get().isBefore(LocalDateTime.now()));
+        for (int i=0; i < 100; i++) {
+            store.increment(name, 1);
+            long count = store.getCount(name, 1);
+            Assert.assertTrue(2 + i == count);
+        }
+
+        LinkCounts updatedCounts = store.getUpdatedCounts(name, start);
+        Assert.assertTrue(updatedCounts.counts.containsKey(1L));
+
+//        store.setCounts();
+    }
+}

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -431,6 +431,9 @@ public class MultiNodeNetworkTests {
         rotateServerIdentity(iNode1);
         startServer(iNode1);
 
+        stopServer(iNode2);
+        startServer(iNode2);
+
         // login through other server
         ensureSignedUp(username, password, getNode(iNode2), crypto);
 

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -261,7 +261,7 @@ public class MultiNodeNetworkTests {
         Assert.assertTrue(bats.equals(batsViaNewNode));
         Optional<BatWithId> mirrorBat = Optional.of(bats.get(bats.size() - 1));
         long usageVia1 = user.getSpaceUsage().join();
-        userViaNewServer.network.coreNode.migrateUser(username, newChain, originalNodeId, mirrorBat, usageVia1).join();
+        userViaNewServer.network.coreNode.migrateUser(username, newChain, originalNodeId, mirrorBat, LocalDateTime.now(), usageVia1).join();
 
         List<UserPublicKeyLink> chain = userViaNewServer.network.coreNode.getChain(username).join();
         Multihash storageNode = chain.get(chain.size() - 1).claim.storageProviders.stream().findFirst().get();
@@ -285,7 +285,7 @@ public class MultiNodeNetworkTests {
 
         // check a reverse migration can't be triggered by anyone else
         try {
-            node1.coreNode.migrateUser(username, existing, newStorageNodeId, mirrorBat, usageVia2).join();
+            node1.coreNode.migrateUser(username, existing, newStorageNodeId, mirrorBat, LocalDateTime.now(), usageVia2).join();
             throw new RuntimeException("Shouldn't get here!");
         } catch (CompletionException e) {
             if (! e.getCause().getMessage().startsWith("Migration+claim+has+earlier+expiry+than+current+one"))
@@ -330,7 +330,7 @@ public class MultiNodeNetworkTests {
         List<BatWithId> bats = user.network.batCave.getUserBats(username, userViaNewServer.signer).join();
         Optional<BatWithId> mirrorBat = Optional.of(bats.get(bats.size() - 1));
         try {
-            userViaNewServer.network.coreNode.migrateUser(username, newChain, originalNodeId, mirrorBat, 1_000_000).join();
+            userViaNewServer.network.coreNode.migrateUser(username, newChain, originalNodeId, mirrorBat, LocalDateTime.now(), 1_000_000).join();
             throw new RuntimeException("Shouldn't get here!");
         } catch (CompletionException e) {}
 

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -431,9 +431,6 @@ public class MultiNodeNetworkTests {
         rotateServerIdentity(iNode1);
         startServer(iNode1);
 
-        stopServer(iNode2);
-        startServer(iNode2);
-
         // login through other server
         ensureSignedUp(username, password, getNode(iNode2), crypto);
 

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -430,6 +430,7 @@ public class MultiNodeNetworkTests {
         stopServer(iNode1);
         rotateServerIdentity(iNode1);
         startServer(iNode1);
+        Thread.sleep(60_000); // wait one DNS cycle
 
         // login through other server
         ensureSignedUp(username, password, getNode(iNode2), crypto);

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -206,6 +206,10 @@ public class PeergosNetworkUtils {
                 sharerUser.network, crypto, l -> {}).join();
         Optional<Bat> originalBat = uploaded.writableFilePointer().bat;
 
+        // create a secret link to the file
+        String userLinkPassword = "forbob";
+        SecretLink link = sharerUser.createSecretLink(Paths.get(sharerUser.username, filename), false, Optional.empty(), Optional.empty(), userLinkPassword).join();
+
         // share the file from sharer to each of the sharees
         Set<String> shareeNames = shareeUsers.stream()
                 .map(u -> u.username)
@@ -219,6 +223,9 @@ public class PeergosNetworkUtils {
             Assert.assertTrue("File is read only", ! sharedFile.get().isWritable());
             checkFileContents(originalFileContents, sharedFile.get(), userContext);
         }
+
+        // check secret link works
+        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userLinkPassword), shareeNode, crypto).join();
 
         // check other users can browse to the friend's root
         for (UserContext userContext : shareeUsers) {
@@ -245,6 +252,9 @@ public class PeergosNetworkUtils {
 
                     }
                 }).collect(Collectors.toList());
+
+        // check secret link works
+        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userLinkPassword), shareeNode, crypto).join();
 
         //test that the other user cannot access it from scratch
         Optional<FileWrapper> otherUserView = updatedShareeUsers.get(0).getByPath(sharerUser.username + "/" + filename).join();

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -239,7 +239,7 @@ public class PeergosNetworkUtils {
         List<UserContext> updatedShareeUsers = shareeUsers.stream()
                 .map(e -> {
                     try {
-                        return ensureSignedUp(e.username, shareePasswords.get(shareeUsers.indexOf(e)), shareeNode, crypto);
+                        return ensureSignedUp(e.username, shareePasswords.get(shareeUsers.indexOf(e)), shareeNode.clear(), crypto);
                     } catch (Exception ex) {
                         throw new IllegalStateException(ex.getMessage(), ex);
 

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -208,7 +208,7 @@ public class PeergosNetworkUtils {
 
         // create a secret link to the file
         String userLinkPassword = "forbob";
-        SecretLink link = sharerUser.createSecretLink(Paths.get(sharerUser.username, filename), false, Optional.empty(), Optional.empty(), userLinkPassword).join();
+        LinkProperties link = sharerUser.createSecretLink(Paths.get(sharerUser.username, filename).toString(), false, Optional.empty(), Optional.empty(), userLinkPassword).join();
 
         // share the file from sharer to each of the sharees
         Set<String> shareeNames = shareeUsers.stream()
@@ -225,7 +225,7 @@ public class PeergosNetworkUtils {
         }
 
         // check secret link works
-        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userLinkPassword), shareeNode, crypto).join();
+        UserContext.fromSecretLinkV2(link.toLinkString(uploaded.owner()), () -> Futures.of(userLinkPassword), shareeNode, crypto).join();
 
         // check other users can browse to the friend's root
         for (UserContext userContext : shareeUsers) {
@@ -254,7 +254,7 @@ public class PeergosNetworkUtils {
                 }).collect(Collectors.toList());
 
         // check secret link works
-        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userLinkPassword), shareeNode, crypto).join();
+        UserContext.fromSecretLinkV2(link.toLinkString(uploaded.owner()), () -> Futures.of(userLinkPassword), shareeNode, crypto).join();
 
         //test that the other user cannot access it from scratch
         Optional<FileWrapper> otherUserView = updatedShareeUsers.get(0).getByPath(sharerUser.username + "/" + filename).join();

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -574,5 +574,12 @@ public class RamUserTests extends UserTests {
 
         SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
         Assert.assertTrue(sharingState.hasLink(filename));
+
+        user.deleteSecretLink(link.label, filePath, writable).join();
+
+        try {
+            network.getSecretLink(link).join();
+            throw new RuntimeException("Shouldn't get here");
+        } catch (IllegalStateException expected) {}
     }
 }

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -570,7 +570,7 @@ public class RamUserTests extends UserTests {
         EncryptedCapability retrieved = network.getSecretLink(link).join();
         AbsoluteCapability cap = retrieved.decryptFromPassword(link.labelString(), linkPassword, crypto).join();
         FileWrapper resolvedFile = network.getFile(cap, username).join().get();
-        Assert.assertTrue(! (resolvedFile.isWritable() ^ writable));
+        Assert.assertTrue(resolvedFile.isWritable() == writable);
 
         SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
         Assert.assertTrue(sharingState.hasLink(filename));

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -562,7 +562,7 @@ public class RamUserTests extends UserTests {
 
         boolean writable = false;
         Optional<LocalDateTime> expiry = Optional.of(LocalDateTime.now().plusDays(1));
-        Optional<Integer> maxRetrievals = Optional.of(1);
+        Optional<Integer> maxRetrievals = Optional.of(2);
 
         String userPassword = "youre-terrible-muriel";
         SecretLink link = user.createSecretLink(filePath, writable, expiry, maxRetrievals, userPassword).join();
@@ -574,6 +574,12 @@ public class RamUserTests extends UserTests {
 
         SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
         Assert.assertTrue(sharingState.hasLink(filename));
+
+        UserContext.fromSecretLinkV2(link.toLink(), userPassword, network, crypto).join();
+        try {
+            UserContext.fromSecretLinkV2(link.toLink(), userPassword, network, crypto).join();
+            throw new RuntimeException("Shouldn't get here");
+        } catch (IllegalStateException expected) {}
 
         user.deleteSecretLink(link.label, filePath, writable).join();
 

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -575,11 +575,11 @@ public class RamUserTests extends UserTests {
 
         SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
         Assert.assertTrue(sharingState.hasLink(filename));
-        LinkProperties props = sharingState.get(filename).readLinks.stream().findFirst().get();
+        LinkProperties props = sharingState.get(filename).links.stream().findFirst().get();
 
         // try changing the password
         String newPass = "different";
-        user.updateSecretLink(filePath.toString(), writable, new LinkProperties(props.label, props.linkPassword, newPass, props.maxRetrievals, props.expiry, props.existing)).join();
+        user.updateSecretLink(filePath.toString(), new LinkProperties(props.label, props.linkPassword, newPass, writable, props.maxRetrievals, props.expiry, props.existing)).join();
 
         UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(newPass), network, crypto).join();
         try {

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -574,10 +574,15 @@ public class RamUserTests extends UserTests {
 
         SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
         Assert.assertTrue(sharingState.hasLink(filename));
+        LinkProperties props = sharingState.get(filename).readLinks.stream().findFirst().get();
 
-        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userPassword), network, crypto).join();
+        // try changing the password
+        String newPass = "different";
+        user.updateSecretLink(filePath, writable, new LinkProperties(props.label, props.linkPassword, newPass, props.maxRetrievals, props.expiry, props.existing)).join();
+
+        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(newPass), network, crypto).join();
         try {
-            UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userPassword), network, crypto).join();
+            UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(newPass), network, crypto).join();
             throw new RuntimeException("Shouldn't get here");
         } catch (IllegalStateException expected) {}
 

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -565,7 +565,8 @@ public class RamUserTests extends UserTests {
         Optional<Integer> maxRetrievals = Optional.of(2);
 
         String userPassword = "youre-terrible-muriel";
-        SecretLink link = user.createSecretLink(filePath, writable, expiry, maxRetrievals, userPassword).join();
+        LinkProperties linkProps = user.createSecretLink(filePath.toString(), writable, expiry, maxRetrievals, userPassword).join();
+        SecretLink link = linkProps.toLink(userRoot.owner());
 
         EncryptedCapability retrieved = network.getSecretLink(link).join();
         AbsoluteCapability cap = retrieved.decryptFromPassword(link.labelString(), link.linkPassword + userPassword, crypto).join();
@@ -578,7 +579,7 @@ public class RamUserTests extends UserTests {
 
         // try changing the password
         String newPass = "different";
-        user.updateSecretLink(filePath, writable, new LinkProperties(props.label, props.linkPassword, newPass, props.maxRetrievals, props.expiry, props.existing)).join();
+        user.updateSecretLink(filePath.toString(), writable, new LinkProperties(props.label, props.linkPassword, newPass, props.maxRetrievals, props.expiry, props.existing)).join();
 
         UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(newPass), network, crypto).join();
         try {
@@ -595,8 +596,8 @@ public class RamUserTests extends UserTests {
 
         // now a writable secret link
         String wpass = "modifyme";
-        SecretLink writeLink = user.createSecretLink(filePath, true, Optional.empty(), Optional.empty(), wpass).join();
-        UserContext writableContext = UserContext.fromSecretLinkV2(writeLink.toLink(), () -> Futures.of(wpass), network, crypto).join();
+        LinkProperties writeLink = user.createSecretLink(filePath.toString(), true, Optional.empty(), Optional.empty(), wpass).join();
+        UserContext writableContext = UserContext.fromSecretLinkV2(writeLink.toLinkString(userRoot.owner()), () -> Futures.of(wpass), network, crypto).join();
         FileWrapper wf = writableContext.getByPath(filePath).join().get();
         Assert.assertTrue(wf.isWritable());
     }

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -564,11 +564,11 @@ public class RamUserTests extends UserTests {
         Optional<LocalDateTime> expiry = Optional.of(LocalDateTime.now().plusDays(1));
         Optional<Integer> maxRetrievals = Optional.of(1);
 
-        String linkPassword = "youre-terrible-muriel";
-        SecretLink link = user.createSecretLink(filePath, writable, expiry, maxRetrievals, linkPassword).join();
+        String userPassword = "youre-terrible-muriel";
+        SecretLink link = user.createSecretLink(filePath, writable, expiry, maxRetrievals, userPassword).join();
 
         EncryptedCapability retrieved = network.getSecretLink(link).join();
-        AbsoluteCapability cap = retrieved.decryptFromPassword(link.labelString(), linkPassword, crypto).join();
+        AbsoluteCapability cap = retrieved.decryptFromPassword(link.labelString(), link.linkPassword + userPassword, crypto).join();
         FileWrapper resolvedFile = network.getFile(cap, username).join().get();
         Assert.assertTrue(resolvedFile.isWritable() == writable);
 

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -592,5 +592,12 @@ public class RamUserTests extends UserTests {
             network.getSecretLink(link).join();
             throw new RuntimeException("Shouldn't get here");
         } catch (IllegalStateException expected) {}
+
+        // now a writable secret link
+        String wpass = "modifyme";
+        SecretLink writeLink = user.createSecretLink(filePath, true, Optional.empty(), Optional.empty(), wpass).join();
+        UserContext writableContext = UserContext.fromSecretLinkV2(writeLink.toLink(), () -> Futures.of(wpass), network, crypto).join();
+        FileWrapper wf = writableContext.getByPath(filePath).join().get();
+        Assert.assertTrue(wf.isWritable());
     }
 }

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -571,5 +571,8 @@ public class RamUserTests extends UserTests {
         AbsoluteCapability cap = retrieved.decryptFromPassword(link.labelString(), linkPassword, crypto).join();
         FileWrapper resolvedFile = network.getFile(cap, username).join().get();
         Assert.assertTrue(! (resolvedFile.isWritable() ^ writable));
+
+        SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
+        Assert.assertTrue(sharingState.hasLink(filename));
     }
 }

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -575,9 +575,9 @@ public class RamUserTests extends UserTests {
         SharedWithState sharingState = user.getDirectorySharingState(Paths.get(username)).join();
         Assert.assertTrue(sharingState.hasLink(filename));
 
-        UserContext.fromSecretLinkV2(link.toLink(), userPassword, network, crypto).join();
+        UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userPassword), network, crypto).join();
         try {
-            UserContext.fromSecretLinkV2(link.toLink(), userPassword, network, crypto).join();
+            UserContext.fromSecretLinkV2(link.toLink(), () -> Futures.of(userPassword), network, crypto).join();
             throw new RuntimeException("Shouldn't get here");
         } catch (IllegalStateException expected) {}
 

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -10,6 +10,7 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.ProgressConsumer;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -125,6 +126,11 @@ public class RetryStorageTests {
                 counter=1;
                 return CompletableFuture.completedFuture(Collections.emptyList());
             }
+        }
+
+        @Override
+        public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+            throw new IllegalStateException("Unimplemented!");
         }
 
         @Override

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -136,7 +136,7 @@ public class RetryStorageTests {
         }
 
         @Override
-        public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
             throw new IllegalStateException("Unimplemented!");
         }
 

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -3,7 +3,7 @@ package peergos.server.tests;
 import org.junit.Assert;
 import org.junit.Test;
 import peergos.server.*;
-import peergos.server.storage.RAMStorage;
+import peergos.server.storage.*;
 import peergos.shared.cbor.CborObject;
 import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.io.ipfs.Cid;
@@ -12,6 +12,8 @@ import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.ProgressConsumer;
+
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
@@ -130,6 +132,11 @@ public class RetryStorageTests {
 
         @Override
         public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+            throw new IllegalStateException("Unimplemented!");
+        }
+
+        @Override
+        public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
             throw new IllegalStateException("Unimplemented!");
         }
 

--- a/src/peergos/server/tests/slow/EfficiencyComparison.java
+++ b/src/peergos/server/tests/slow/EfficiencyComparison.java
@@ -53,7 +53,7 @@ public class EfficiencyComparison {
 
                 for (Map.Entry<ByteArrayWrapper, Optional<CborObject.CborMerkleLink>> e : state.entrySet()) {
                     current = current.left.put(champUser.publicKeyHash, champUser, e.getKey(), e.getKey().data, 0, Optional.empty(),
-                            e.getValue(), bitWidth, maxCollisions, x -> Futures.of(x.data),
+                            e.getValue(), bitWidth, maxCollisions, Optional.empty(), x -> Futures.of(x.data),
                             champStorage.startTransaction(champUser.publicKeyHash).get(), champStorage, crypto.hasher,
                             current.right).get();
                 }

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -223,7 +223,7 @@ public class NetworkAccess {
     public static CompletableFuture<NetworkAccess> buildJS(boolean isPublic,
                                                            int cacheSizeKiB,
                                                            boolean allowOfflineLogin) {
-        JavaScriptPoster relative = new JavaScriptPoster(false, isPublic);
+        JavaScriptPoster relative = new JavaScriptPoster(true, isPublic);
         ScryptJS hasher = new ScryptJS();
         boolean isPeergosServer = true; // we used to support using web ui through an ipfs gateway directly
         ContentAddressedStorage localDht = buildLocalDht(relative, isPeergosServer, hasher);

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -469,6 +469,10 @@ public class NetworkAccess {
                 });
     }
 
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        return dhtClient.getSecretLink(link);
+    }
+
     @JsMethod
     public CompletableFuture<Optional<FileWrapper>> getFile(AbsoluteCapability cap, String owner) {
         return synchronizer.getValue(cap.owner, cap.writer)

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -558,7 +558,7 @@ public class NetworkAccess {
                 .thenCompose(bat -> Futures.asyncExceptionally(
                         () -> dhtClient.getChampLookup(cap.owner, (Cid) base.tree.get(), cap.getMapKey(), bat,committedRoot),
                         t -> dhtClient.getChampLookup(cap.owner, (Cid) base.tree.get(), cap.getMapKey(), bat, committedRoot, hasher)
-                ).thenCompose(blocks -> ChampWrapper.create(cap.owner, (Cid)base.tree.get(), x -> Futures.of(x.data), dhtClient, hasher, c -> (CborObject.CborMerkleLink) c)
+                ).thenCompose(blocks -> ChampWrapper.create(cap.owner, (Cid)base.tree.get(), Optional.empty(), x -> Futures.of(x.data), dhtClient, hasher, c -> (CborObject.CborMerkleLink) c)
                         .thenCompose(tree -> tree.get(cap.getMapKey()))
                         .thenApply(c -> c.map(x -> x.target))
                         .thenCompose(btreeValue -> {

--- a/src/peergos/shared/corenode/CoreNode.java
+++ b/src/peergos/shared/corenode/CoreNode.java
@@ -9,6 +9,7 @@ import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -71,6 +72,7 @@ public interface CoreNode {
                                                 List<UserPublicKeyLink> newChain,
                                                 Multihash currentStorageId,
                                                 Optional<BatWithId> mirrorBat,
+                                                LocalDateTime latestLinkCountUpdate,
                                                 long usage);
 
     CompletableFuture<Optional<Multihash>> getNextServerId(Multihash serverId);

--- a/src/peergos/shared/corenode/HTTPCoreNode.java
+++ b/src/peergos/shared/corenode/HTTPCoreNode.java
@@ -1,5 +1,6 @@
 
 package peergos.shared.corenode;
+import java.time.*;
 import java.util.logging.*;
 
 import peergos.shared.cbor.*;
@@ -256,6 +257,7 @@ public class HTTPCoreNode implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
         String modifiedPrefix = urlPrefix.isEmpty() ? "" : getProxyUrlPrefix(currentStorageId);
         try {
@@ -268,6 +270,7 @@ public class HTTPCoreNode implements CoreNode {
             dout.writeBoolean(mirrorBat.isPresent());
             if (mirrorBat.isPresent())
                 Serialize.serialize(mirrorBat.get().serialize(), dout);
+            dout.writeLong(latestLinkCountUpdate.toEpochSecond(ZoneOffset.UTC));
             dout.writeLong(currentUsage);
             dout.flush();
 

--- a/src/peergos/shared/corenode/OfflineCorenode.java
+++ b/src/peergos/shared/corenode/OfflineCorenode.java
@@ -10,6 +10,7 @@ import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -102,8 +103,9 @@ public class OfflineCorenode implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
-        return target.migrateUser(username, newChain, currentStorageId, mirrorBat, currentUsage);
+        return target.migrateUser(username, newChain, currentStorageId, mirrorBat, latestLinkCountUpdate, currentUsage);
     }
 
     @Override

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -1,5 +1,6 @@
 package peergos.shared.corenode;
 
+import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
@@ -13,6 +14,7 @@ import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.*;
@@ -200,6 +202,11 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
 
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Unsupported operation!");
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Unsupported operation!");
     }
 

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -1,6 +1,5 @@
 package peergos.shared.corenode;
 
-import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
@@ -206,7 +205,7 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Unsupported operation!");
     }
 

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -10,6 +10,7 @@ import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.user.*;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -195,6 +196,11 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         return Futures.of(new ArrayList<>(storage.values()));
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Unsupported operation!");
     }
 
     @Override

--- a/src/peergos/shared/corenode/TofuCoreNode.java
+++ b/src/peergos/shared/corenode/TofuCoreNode.java
@@ -12,6 +12,7 @@ import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.io.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -177,8 +178,9 @@ public class TofuCoreNode implements CoreNode {
                                                        List<UserPublicKeyLink> newChain,
                                                        Multihash currentStorageId,
                                                        Optional<BatWithId> mirrorBat,
+                                                       LocalDateTime latestLinkCountUpdate,
                                                        long currentUsage) {
-        return source.migrateUser(username, newChain, currentStorageId, mirrorBat, currentUsage)
+        return source.migrateUser(username, newChain, currentStorageId, mirrorBat, latestLinkCountUpdate, currentUsage)
                 .thenCompose(res -> source.getChain(username)
                         .thenCompose(chain -> tofu.updateChain(username, chain, network.dhtClient)
                                 .thenCompose(x -> commit())

--- a/src/peergos/shared/hamt/ChampWrapper.java
+++ b/src/peergos/shared/hamt/ChampWrapper.java
@@ -48,11 +48,12 @@ public class ChampWrapper<V extends Cborable> implements ImmutableTree<V>
 
     public static <V extends Cborable> CompletableFuture<ChampWrapper<V>> create(PublicKeyHash owner,
                                                                                  Cid rootHash,
+                                                                                 Optional<BatWithId> bat,
                                                                                  Function<ByteArrayWrapper, CompletableFuture<byte[]>> hasher,
                                                                                  ContentAddressedStorage dht,
                                                                                  Hasher writeHasher,
                                                                                  Function<Cborable, V> fromCbor) {
-        return dht.get(owner, rootHash, Optional.empty()).thenApply(rawOpt -> {
+        return dht.get(owner, rootHash, bat).thenApply(rawOpt -> {
             if (! rawOpt.isPresent())
                 throw new IllegalStateException("Champ root not present: " + rootHash);
             return new ChampWrapper<>(Champ.fromCbor(rawOpt.get(), fromCbor), rootHash, owner, hasher, dht, writeHasher, BIT_WIDTH);

--- a/src/peergos/shared/hamt/ChampWrapper.java
+++ b/src/peergos/shared/hamt/ChampWrapper.java
@@ -6,6 +6,7 @@ import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
+import peergos.shared.storage.auth.*;
 import peergos.shared.user.*;
 import peergos.shared.util.*;
 
@@ -98,11 +99,12 @@ public class ChampWrapper<V extends Cborable> implements ImmutableTree<V>
                                             byte[] rawKey,
                                             Optional<V> existing,
                                             V value,
+                                            Optional<BatId> mirrorBat,
                                             TransactionId tid) {
         ByteArrayWrapper key = new ByteArrayWrapper(rawKey);
         return keyHasher.apply(key)
                 .thenCompose(keyHash -> root.left.put(owner, writer, key, keyHash, 0, existing, Optional.of(value),
-                        BIT_WIDTH, MAX_HASH_COLLISIONS_PER_LEVEL, keyHasher, tid, storage, writeHasher, root.right))
+                        BIT_WIDTH, MAX_HASH_COLLISIONS_PER_LEVEL, mirrorBat, keyHasher, tid, storage, writeHasher, root.right))
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
 
@@ -117,11 +119,12 @@ public class ChampWrapper<V extends Cborable> implements ImmutableTree<V>
                                                SigningPrivateKeyAndPublicHash writer,
                                                byte[] rawKey,
                                                Optional<V> existing,
+                                               Optional<BatId> mirrorBat,
                                                TransactionId tid) {
         ByteArrayWrapper key = new ByteArrayWrapper(rawKey);
         return keyHasher.apply(key)
                 .thenCompose(keyHash -> root.left.remove(owner, writer, key, keyHash, 0, existing,
-                        BIT_WIDTH, MAX_HASH_COLLISIONS_PER_LEVEL, tid, storage, writeHasher, root.right))
+                        BIT_WIDTH, MAX_HASH_COLLISIONS_PER_LEVEL, mirrorBat, tid, storage, writeHasher, root.right))
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
 

--- a/src/peergos/shared/inode/DirectoryInode.java
+++ b/src/peergos/shared/inode/DirectoryInode.java
@@ -92,7 +92,7 @@ public class DirectoryInode implements Cborable {
                                 .thenApply(d -> d.children.b()) :
                         Futures.of(children.b())
                 ).thenCompose(champ -> champ.put(owner, writer, key, keyHash, 0, Optional.empty(), Optional.of(child), bitWidth,
-                        ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, keyHasher, tid, storage, writeHasher, null)
+                        ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, Optional.empty(), keyHasher, tid, storage, writeHasher, null)
                         .thenApply(rootPair -> new DirectoryInode(rootPair.left, writeHasher, bitWidth, owner, keyHasher, storage)))
         );
     }
@@ -112,7 +112,7 @@ public class DirectoryInode implements Cborable {
         ByteArrayWrapper key = new ByteArrayWrapper(child.inode.name.name.getBytes());
         return keyHasher.apply(key).thenCompose(keyHash ->
                 children.b().remove(owner, writer, key, keyHash, 0, Optional.of(child), bitWidth,
-                        ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, tid, storage, writeHasher, null)
+                        ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, Optional.empty(), tid, storage, writeHasher, null)
                         .thenApply(rootPair -> new DirectoryInode(rootPair.left, writeHasher, bitWidth, owner, keyHasher, storage)));
     }
 
@@ -140,7 +140,7 @@ public class DirectoryInode implements Cborable {
         return Futures.reduceAll(children, Champ.empty(InodeCap::fromCbor),
                 (c, v) -> keyHasher.apply(toChampKey(v)).thenCompose(keyHash ->
                         c.put(owner, writer, toChampKey(v), keyHash, 0, Optional.empty(), Optional.of(v), bitWidth,
-                                ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, keyHasher, tid, storage, writeHasher, null))
+                                ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, Optional.empty(), keyHasher, tid, storage, writeHasher, null))
                         .thenApply(p -> p.left),
                 (a, b) -> b)
                 .thenApply(champ -> new DirectoryInode(champ, writeHasher, bitWidth, owner, keyHasher, storage));

--- a/src/peergos/shared/inode/InodeFileSystem.java
+++ b/src/peergos/shared/inode/InodeFileSystem.java
@@ -270,7 +270,7 @@ public class InodeFileSystem implements Cborable {
         Function<ByteArrayWrapper, CompletableFuture<byte[]>> keyHasher = b -> hasher.sha256(b.data);
         Function<Cborable, DirectoryInode> fromCbor =
                 c -> DirectoryInode.fromCbor(c, hasher, ChampWrapper.BIT_WIDTH, owner, keyHasher, storage);
-        return ChampWrapper.create(owner, (Cid)root, keyHasher, storage, hasher, fromCbor)
+        return ChampWrapper.create(owner, (Cid)root, Optional.empty(), keyHasher, storage, hasher, fromCbor)
                 .thenApply(cw -> new InodeFileSystem(inodeCount, cw, storage));
     }
 

--- a/src/peergos/shared/inode/InodeFileSystem.java
+++ b/src/peergos/shared/inode/InodeFileSystem.java
@@ -38,7 +38,7 @@ public class InodeFileSystem implements Cborable {
                                                         DirectoryInode value,
                                                         TransactionId tid) {
         byte[] raw = key.serialize();
-        return champ.put(owner, writer, raw, existing, value, tid)
+        return champ.put(owner, writer, raw, existing, value, Optional.empty(), tid)
                 .thenApply(h -> new InodeFileSystem(existing.isPresent() ? inodeCount : inodeCount + 1, champ, storage));
     }
 
@@ -48,7 +48,7 @@ public class InodeFileSystem implements Cborable {
                                                       Optional<DirectoryInode> existing,
                                                       TransactionId tid) {
         byte[] raw = key.serialize();
-        return champ.remove(owner, writer, raw, existing, tid)
+        return champ.remove(owner, writer, raw, existing, Optional.empty(), tid)
                 .thenApply(h -> new InodeFileSystem(inodeCount, champ, storage));
     }
 

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -106,7 +106,7 @@ public class BufferedStorage extends DelegatingStorage {
                                 .thenCompose(champRoot -> target.getChampLookup(owner, (Cid) champRoot.get(), champKey, bat, Optional.empty())) :
                         target.getChampLookup(owner, root, champKey, bat, Optional.empty()), hasher),
                 100, 1024 * 1024);
-        return ChampWrapper.create(owner, root, x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
+        return ChampWrapper.create(owner, root, Optional.empty(), x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
                 .thenCompose(tree -> tree.get(champKey))
                 .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
                 .thenApply(btreeValue -> {

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -1,6 +1,5 @@
 package peergos.shared.storage;
 
-import peergos.server.storage.*;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
@@ -199,7 +198,7 @@ public interface ContentAddressedStorage {
 
     CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link);
 
-    CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat);
+    CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat);
 
     default CompletableFuture<Cid> hashToCid(byte[] input, boolean isRaw, Hasher hasher) {
         return hasher.sha256(input)
@@ -425,13 +424,13 @@ public interface ContentAddressedStorage {
         }
 
         @Override
-        public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
             return poster.get(apiPrefix + LINK_COUNTS
                     + "?after=" + after.toEpochSecond(ZoneOffset.UTC)
                     + "?bat=" + mirrorBat.encode()
                     + "&owner=" + owner
             ).thenApply(CborObject::fromByteArray)
-                    .thenApply(LinkRetrievalCounter.LinkCounts::fromCbor);
+                    .thenApply(LinkCounts::fromCbor);
         }
 
         @Override
@@ -665,7 +664,7 @@ public interface ContentAddressedStorage {
         }
 
         @Override
-        public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
             return core.getPublicKeyHash(owner)
                     .thenCompose(id -> Proxy.redirectCall(core,
                             ourNodeIds,

--- a/src/peergos/shared/storage/ContentAddressedStorage.java
+++ b/src/peergos/shared/storage/ContentAddressedStorage.java
@@ -177,7 +177,7 @@ public interface ContentAddressedStorage {
                                                            Optional<Cid> committedRoot,
                                                            Hasher hasher) {
         CachingStorage cache = new CachingStorage(this, 100, 1024 * 1024);
-        return ChampWrapper.create(owner, (Cid)root, x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
+        return ChampWrapper.create(owner, (Cid)root, Optional.empty(), x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
                 .thenCompose(tree -> tree.get(champKey))
                 .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
                 .thenApply(btreeValue -> {
@@ -419,8 +419,7 @@ public interface ContentAddressedStorage {
                     + "?label=" + link.labelString()
                     + "&owner=" + encode(link.owner.toString())
             ).thenApply(CborObject::fromByteArray)
-                    .thenApply(CipherText::fromCbor)
-                    .thenApply(EncryptedCapability::new);
+                    .thenApply(EncryptedCapability::fromCbor);
         }
 
         @Override

--- a/src/peergos/shared/storage/ContentAddressedStorageProxy.java
+++ b/src/peergos/shared/storage/ContentAddressedStorageProxy.java
@@ -115,8 +115,7 @@ public interface ContentAddressedStorageProxy {
                     + "link/get?label=" + link.labelString()
                     + "&owner=" + encode(link.owner.toString()))
                     .thenApply(CborObject::fromByteArray)
-                    .thenApply(CipherText::fromCbor)
-                    .thenApply(EncryptedCapability::new);
+                    .thenApply(EncryptedCapability::fromCbor);
         }
 
         @Override

--- a/src/peergos/shared/storage/ContentAddressedStorageProxy.java
+++ b/src/peergos/shared/storage/ContentAddressedStorageProxy.java
@@ -1,6 +1,5 @@
 package peergos.shared.storage;
 
-import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
@@ -29,7 +28,7 @@ public interface ContentAddressedStorageProxy {
 
     CompletableFuture<EncryptedCapability> getSecretLink(Multihash targetServerId, SecretLink link);
 
-    CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(Multihash targetServerId, String owner, LocalDateTime after, BatWithId mirrorBat);
+    CompletableFuture<LinkCounts> getLinkCounts(Multihash targetServerId, String owner, LocalDateTime after, BatWithId mirrorBat);
 
     CompletableFuture<List<Cid>> put(Multihash targetServerId,
                                      PublicKeyHash owner,
@@ -121,16 +120,16 @@ public interface ContentAddressedStorageProxy {
         }
 
         @Override
-        public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(Multihash targetServerId,
-                                                                                String owner,
-                                                                                LocalDateTime after,
-                                                                                BatWithId mirrorBat) {
+        public CompletableFuture<LinkCounts> getLinkCounts(Multihash targetServerId,
+                                                           String owner,
+                                                           LocalDateTime after,
+                                                           BatWithId mirrorBat) {
             return poster.get(getProxyUrlPrefix(targetServerId) + apiPrefix
                     + "link/counts?after=" + after.toEpochSecond(ZoneOffset.UTC)
                     + "?bat=" + mirrorBat.encode()
                     + "&owner=" + owner)
                     .thenApply(CborObject::fromByteArray)
-                    .thenApply(LinkRetrievalCounter.LinkCounts::fromCbor);
+                    .thenApply(LinkCounts::fromCbor);
         }
 
         @Override

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -1,6 +1,5 @@
 package peergos.shared.storage;
 
-import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
@@ -87,7 +86,7 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         return target.getLinkCounts(owner, after, mirrorBat);
     }
 

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -1,5 +1,6 @@
 package peergos.shared.storage;
 
+import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
@@ -8,6 +9,7 @@ import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -82,6 +84,11 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
         return target.getSecretLink(link);
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        return target.getLinkCounts(owner, after, mirrorBat);
     }
 
     @Override

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -80,6 +80,11 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        return target.getSecretLink(link);
+    }
+
+    @Override
     public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
         return target.getSize(block);
     }

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -1,6 +1,5 @@
 package peergos.shared.storage;
 
-import peergos.server.storage.*;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
@@ -328,7 +327,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         return fallback.getLinkCounts(owner, after, mirrorBat);
     }
 }

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -1,5 +1,6 @@
 package peergos.shared.storage;
 
+import peergos.server.storage.*;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.corenode.*;
@@ -12,6 +13,7 @@ import peergos.shared.user.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
@@ -323,5 +325,10 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
         return fallback.getSecretLink(link);
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        return fallback.getLinkCounts(owner, after, mirrorBat);
     }
 }

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -319,4 +319,9 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
                     return getChampLookup(owner, root, champKey, bat, committedRoot, hasher);
                 });
     }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        return fallback.getSecretLink(link);
+    }
 }

--- a/src/peergos/shared/storage/LinkCounts.java
+++ b/src/peergos/shared/storage/LinkCounts.java
@@ -1,0 +1,44 @@
+package peergos.shared.storage;
+
+import peergos.server.storage.*;
+import peergos.shared.cbor.*;
+import peergos.shared.util.*;
+
+import java.time.*;
+import java.util.*;
+
+public class LinkCounts implements Cborable {
+    public final Map<Long, Pair<Long, LocalDateTime>> counts;
+
+    public LinkCounts(Map<Long, Pair<Long, LocalDateTime>> counts) {
+        this.counts = counts;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        ArrayList<CborObject> data = new ArrayList<>(counts.size() * 3);
+        counts.forEach((k, v) -> {
+            data.add(new CborObject.CborLong(k));
+            data.add(new CborObject.CborLong(v.left));
+            data.add(new CborObject.CborLong(v.right.toEpochSecond(ZoneOffset.UTC)));
+        });
+        state.put("d", new CborObject.CborList(data));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static LinkCounts fromCbor(Cborable cbor) {
+        if (!(cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for FileProperties! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        CborObject.CborList d = m.getList("d");
+        Map<Long, Pair<Long, LocalDateTime>> counts = new HashMap<>();
+        for (int i = 0; i < d.value.size(); i += 3) {
+            long key = ((CborObject.CborLong) d.value.get(i)).value;
+            long count = ((CborObject.CborLong) d.value.get(i + 1)).value;
+            long seconds = ((CborObject.CborLong) d.value.get(i + 2)).value;
+            counts.put(key, new Pair<>(count, LocalDateTime.ofEpochSecond(seconds, 0, ZoneOffset.UTC)));
+        }
+        return new LinkCounts(counts);
+    }
+}

--- a/src/peergos/shared/storage/LocalOnlyStorage.java
+++ b/src/peergos/shared/storage/LocalOnlyStorage.java
@@ -1,6 +1,5 @@
 package peergos.shared.storage;
 
-import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
@@ -111,7 +110,7 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Unimplemented!");
     }
 

--- a/src/peergos/shared/storage/LocalOnlyStorage.java
+++ b/src/peergos/shared/storage/LocalOnlyStorage.java
@@ -104,6 +104,11 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Unimplemented!");
+    }
+
+    @Override
     public CompletableFuture<IpnsEntry> getIpnsEntry(Multihash signer) {
         throw new IllegalStateException("Unimplemented!");
     }

--- a/src/peergos/shared/storage/LocalOnlyStorage.java
+++ b/src/peergos/shared/storage/LocalOnlyStorage.java
@@ -1,5 +1,6 @@
 package peergos.shared.storage;
 
+import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
@@ -8,6 +9,7 @@ import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -105,6 +107,11 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
 
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Unimplemented!");
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         throw new IllegalStateException("Unimplemented!");
     }
 

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -5,7 +5,7 @@ import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.auth.*;
-import peergos.shared.user.fs.FragmentWithHash;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.net.*;
@@ -132,6 +132,11 @@ public class RetryStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
         return runWithRetry(() -> target.getChampLookup(owner, root, champKey, bat,committedRoot));
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        return runWithRetry(() -> target.getSecretLink(link));
     }
 
     @Override

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -1,6 +1,5 @@
 package peergos.shared.storage;
 
-import peergos.server.storage.*;
 import peergos.shared.cbor.CborObject;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
@@ -142,7 +141,7 @@ public class RetryStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
         return runWithRetry(() -> target.getLinkCounts(owner, after, mirrorBat));
     }
 

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -1,5 +1,6 @@
 package peergos.shared.storage;
 
+import peergos.server.storage.*;
 import peergos.shared.cbor.CborObject;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
@@ -9,6 +10,7 @@ import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.net.*;
+import java.time.*;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
@@ -137,6 +139,11 @@ public class RetryStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
         return runWithRetry(() -> target.getSecretLink(link));
+    }
+
+    @Override
+    public CompletableFuture<LinkRetrievalCounter.LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        return runWithRetry(() -> target.getLinkCounts(owner, after, mirrorBat));
     }
 
     @Override

--- a/src/peergos/shared/storage/UnauthedCachingStorage.java
+++ b/src/peergos/shared/storage/UnauthedCachingStorage.java
@@ -99,7 +99,7 @@ public class UnauthedCachingStorage extends DelegatingStorage {
                         target.getChampLookup(owner, root, champKey, bat, Optional.empty()))
                         .thenApply(blocks -> cacheBlocks(blocks, hasher)), hasher),
                 100, 1024*1024);
-        return ChampWrapper.create(owner, root, x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
+        return ChampWrapper.create(owner, root, Optional.empty(), x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
                 .thenCompose(tree -> tree.get(champKey))
                 .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
                 .thenApply(btreeValue -> {

--- a/src/peergos/shared/user/FileSharedWithState.java
+++ b/src/peergos/shared/user/FileSharedWithState.java
@@ -6,15 +6,14 @@ import java.util.*;
 @JsType
 public class FileSharedWithState {
     public static final FileSharedWithState EMPTY = new FileSharedWithState(Collections.emptySet(),
-            Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+            Collections.emptySet(), Collections.emptySet());
     public final Set<String> readAccess, writeAccess;
-    public final Set<LinkProperties> readLinks, writelinks;
+    public final Set<LinkProperties> links;
 
-    public FileSharedWithState(Set<String> readAccess, Set<String> writeAccess, Set<LinkProperties> readLinks, Set<LinkProperties> writelinks) {
+    public FileSharedWithState(Set<String> readAccess, Set<String> writeAccess, Set<LinkProperties> links) {
         this.readAccess = readAccess;
         this.writeAccess = writeAccess;
-        this.readLinks = readLinks;
-        this.writelinks = writelinks;
+        this.links = links;
     }
 
     public Set<String> get(SharedWithCache.Access type) {

--- a/src/peergos/shared/user/FileSharedWithState.java
+++ b/src/peergos/shared/user/FileSharedWithState.java
@@ -5,12 +5,16 @@ import jsinterop.annotations.JsType;
 import java.util.*;
 @JsType
 public class FileSharedWithState {
-    public static final FileSharedWithState EMPTY = new FileSharedWithState(Collections.emptySet(), Collections.emptySet());
+    public static final FileSharedWithState EMPTY = new FileSharedWithState(Collections.emptySet(),
+            Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
     public final Set<String> readAccess, writeAccess;
+    public final Set<LinkProperties> readLinks, writelinks;
 
-    public FileSharedWithState(Set<String> readAccess, Set<String> writeAccess) {
+    public FileSharedWithState(Set<String> readAccess, Set<String> writeAccess, Set<LinkProperties> readLinks, Set<LinkProperties> writelinks) {
         this.readAccess = readAccess;
         this.writeAccess = writeAccess;
+        this.readLinks = readLinks;
+        this.writelinks = writelinks;
     }
 
     public Set<String> get(SharedWithCache.Access type) {

--- a/src/peergos/shared/user/ImmutableTree.java
+++ b/src/peergos/shared/user/ImmutableTree.java
@@ -5,6 +5,7 @@ import peergos.shared.crypto.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.storage.*;
+import peergos.shared.storage.auth.*;
 
 import java.io.*;
 import java.util.*;
@@ -35,6 +36,7 @@ public interface ImmutableTree<V extends Cborable> {
                                      byte[] rawKey,
                                      Optional<V> existing,
                                      V value,
+                                     Optional<BatId> mirrorBat,
                                      TransactionId tid);
 
     /**
@@ -47,5 +49,6 @@ public interface ImmutableTree<V extends Cborable> {
                                         SigningPrivateKeyAndPublicHash writer,
                                         byte[] rawKey,
                                         Optional<V> existing,
+                                        Optional<BatId> mirrorBat,
                                         TransactionId tid);
 }

--- a/src/peergos/shared/user/JavaScriptPoster.java
+++ b/src/peergos/shared/user/JavaScriptPoster.java
@@ -61,7 +61,7 @@ public class JavaScriptPoster implements HttpPoster {
                 headersArray[index++] = e.getKey();
                 headersArray[index++] = e.getValue();
             }
-            return http.getWithHeaders(url, headersArray);
+            return http.getWithHeaders(canonicalise(url), headersArray);
         }
         return postUnzip(url, new byte[0]);
     }

--- a/src/peergos/shared/user/JavaScriptPoster.java
+++ b/src/peergos/shared/user/JavaScriptPoster.java
@@ -54,7 +54,7 @@ public class JavaScriptPoster implements HttpPoster {
 
     @Override
     public CompletableFuture<byte[]> get(String url, Map<String, String> headers) {
-        if (isAbsolute || useGet) {// Still do a get if we are served from an IPFS gateway
+        if (useGet) {
             String[] headersArray = new String[headers.size() * 2];
             int index = 0;
             for (Map.Entry<String, String> e : headers.entrySet()) {

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -9,14 +9,15 @@ import java.util.*;
 
 class LinkProperties implements Cborable {
     public final long label;
-    public final String password;
+    public final String linkPassword, userPassword;
     public final Optional<Integer> maxCount;
     public final Optional<LocalDateTime> expiry;
 
 
-    public LinkProperties(long label, String password, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
+    public LinkProperties(long label, String linkPassword, String userPassword, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
         this.label = label;
-        this.password = password;
+        this.linkPassword = linkPassword;
+        this.userPassword = userPassword;
         this.maxCount = maxCount;
         this.expiry = expiry;
     }
@@ -30,7 +31,8 @@ class LinkProperties implements Cborable {
     public CborObject toCbor() {
         SortedMap<String, Cborable> state = new TreeMap<>();
         state.put("l", new CborObject.CborLong(label));
-        state.put("p", new CborObject.CborString(password));
+        state.put("p", new CborObject.CborString(linkPassword));
+        state.put("u", new CborObject.CborString(userPassword));
         maxCount.ifPresent(m -> state.put("m", new CborObject.CborLong(m)));
         expiry.ifPresent(e -> state.put("e", new CborObject.CborLong(e.toEpochSecond(ZoneOffset.UTC))));
         return CborObject.CborMap.build(state);
@@ -42,8 +44,9 @@ class LinkProperties implements Cborable {
         CborObject.CborMap m = (CborObject.CborMap) cbor;
         long label = m.getLong("l");
         String password = m.getString("p");
+        String userPassword = m.getString("u");
         Optional<Integer> maxCount = m.getOptionalLong("m").map(Long::intValue);
         Optional<LocalDateTime> expiry = m.getOptionalLong("e").map(s -> LocalDateTime.ofEpochSecond(s, 0, ZoneOffset.UTC));
-        return new LinkProperties(label, password, maxCount, expiry);
+        return new LinkProperties(label, password, userPassword, maxCount, expiry);
     }
 }

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -13,18 +13,18 @@ import java.util.*;
 public class LinkProperties implements Cborable {
     public final long label;
     public final String linkPassword, userPassword;
-    public final boolean isWritable;
+    public final boolean isLinkWritable;
     public final Optional<Integer> maxRetrievals;
     public final Optional<LocalDateTime> expiry;
     public final Optional<Multihash> existing;
 
 
-    public LinkProperties(long label, String linkPassword, String userPassword, boolean isWritable,
+    public LinkProperties(long label, String linkPassword, String userPassword, boolean isLinkWritable,
                           Optional<Integer> maxRetrievals, Optional<LocalDateTime> expiry, Optional<Multihash> existing) {
         this.label = label;
         this.linkPassword = linkPassword;
         this.userPassword = userPassword;
-        this.isWritable = isWritable;
+        this.isLinkWritable = isLinkWritable;
         this.maxRetrievals = maxRetrievals;
         this.expiry = expiry;
         this.existing = existing;
@@ -33,11 +33,11 @@ public class LinkProperties implements Cborable {
     @JsMethod
     public LinkProperties with(String userPassword, String maxRetrievals, Optional<LocalDateTime> expiry) {
         Optional<Integer> maxRetrievalsOpt = maxRetrievals.isEmpty() ? Optional.empty() : Optional.of(Integer.parseInt(maxRetrievals));
-        return new LinkProperties(label, linkPassword, userPassword, isWritable, maxRetrievalsOpt, expiry, existing);
+        return new LinkProperties(label, linkPassword, userPassword, isLinkWritable, maxRetrievalsOpt, expiry, existing);
     }
 
     public LinkProperties withExisting(Optional<Multihash> existing) {
-        return new LinkProperties(label, linkPassword, userPassword, isWritable, maxRetrievals, expiry, existing);
+        return new LinkProperties(label, linkPassword, userPassword, isLinkWritable, maxRetrievals, expiry, existing);
     }
 
     public SecretLink toLink(PublicKeyHash owner) {
@@ -65,7 +65,7 @@ public class LinkProperties implements Cborable {
         state.put("l", new CborObject.CborLong(label));
         state.put("p", new CborObject.CborString(linkPassword));
         state.put("u", new CborObject.CborString(userPassword));
-        state.put("w", new CborObject.CborBoolean(isWritable));
+        state.put("w", new CborObject.CborBoolean(isLinkWritable));
         existing.ifPresent(e -> state.put("h", new CborObject.CborMerkleLink(e)));
         maxRetrievals.ifPresent(m -> state.put("m", new CborObject.CborLong(m)));
         expiry.ifPresent(e -> state.put("e", new CborObject.CborLong(e.toEpochSecond(ZoneOffset.UTC))));

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -31,8 +31,9 @@ public class LinkProperties implements Cborable {
     }
 
     @JsMethod
-    public LinkProperties with(String userPassword, Optional<Integer> maxRetrievals, Optional<LocalDateTime> expiry) {
-        return new LinkProperties(label, linkPassword, userPassword, isWritable, maxRetrievals, expiry, existing);
+    public LinkProperties with(String userPassword, String maxRetrievals, Optional<LocalDateTime> expiry) {
+        Optional<Integer> maxRetrievalsOpt = maxRetrievals.isEmpty() ? Optional.empty() : Optional.of(Integer.parseInt(maxRetrievals));
+        return new LinkProperties(label, linkPassword, userPassword, isWritable, maxRetrievalsOpt, expiry, existing);
     }
 
     public LinkProperties withExisting(Optional<Multihash> existing) {

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -45,6 +45,11 @@ public class LinkProperties implements Cborable {
     }
 
     @JsMethod
+    public String maxRetrievalsString() {
+        return maxRetrievals.map(Long::toString).orElse("");
+    }
+
+    @JsMethod
     public String toLinkString(PublicKeyHash owner) {
         return toLink(owner).toLink();
     }

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -13,15 +13,18 @@ import java.util.*;
 public class LinkProperties implements Cborable {
     public final long label;
     public final String linkPassword, userPassword;
+    public final boolean isWritable;
     public final Optional<Integer> maxRetrievals;
     public final Optional<LocalDateTime> expiry;
     public final Optional<Multihash> existing;
 
 
-    public LinkProperties(long label, String linkPassword, String userPassword, Optional<Integer> maxRetrievals, Optional<LocalDateTime> expiry, Optional<Multihash> existing) {
+    public LinkProperties(long label, String linkPassword, String userPassword, boolean isWritable,
+                          Optional<Integer> maxRetrievals, Optional<LocalDateTime> expiry, Optional<Multihash> existing) {
         this.label = label;
         this.linkPassword = linkPassword;
         this.userPassword = userPassword;
+        this.isWritable = isWritable;
         this.maxRetrievals = maxRetrievals;
         this.expiry = expiry;
         this.existing = existing;
@@ -29,11 +32,11 @@ public class LinkProperties implements Cborable {
 
     @JsMethod
     public LinkProperties with(String userPassword, Optional<Integer> maxRetrievals, Optional<LocalDateTime> expiry) {
-        return new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, existing);
+        return new LinkProperties(label, linkPassword, userPassword, isWritable, maxRetrievals, expiry, existing);
     }
 
     public LinkProperties withExisting(Optional<Multihash> existing) {
-        return new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, existing);
+        return new LinkProperties(label, linkPassword, userPassword, isWritable, maxRetrievals, expiry, existing);
     }
 
     public SecretLink toLink(PublicKeyHash owner) {
@@ -56,6 +59,7 @@ public class LinkProperties implements Cborable {
         state.put("l", new CborObject.CborLong(label));
         state.put("p", new CborObject.CborString(linkPassword));
         state.put("u", new CborObject.CborString(userPassword));
+        state.put("w", new CborObject.CborBoolean(isWritable));
         existing.ifPresent(e -> state.put("h", new CborObject.CborMerkleLink(e)));
         maxRetrievals.ifPresent(m -> state.put("m", new CborObject.CborLong(m)));
         expiry.ifPresent(e -> state.put("e", new CborObject.CborLong(e.toEpochSecond(ZoneOffset.UTC))));
@@ -69,8 +73,9 @@ public class LinkProperties implements Cborable {
         long label = m.getLong("l");
         String password = m.getString("p");
         String userPassword = m.getString("u");
+        boolean isWritable = m.getBoolean("w");
         Optional<Integer> maxCount = m.getOptionalLong("m").map(Long::intValue);
         Optional<LocalDateTime> expiry = m.getOptionalLong("e").map(s -> LocalDateTime.ofEpochSecond(s, 0, ZoneOffset.UTC));
-        return new LinkProperties(label, password, userPassword, maxCount, expiry, m.getOptional("h", c -> ((CborObject.CborMerkleLink)c).target));
+        return new LinkProperties(label, password, userPassword, isWritable, maxCount, expiry, m.getOptional("h", c -> ((CborObject.CborMerkleLink)c).target));
     }
 }

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -1,9 +1,11 @@
 package peergos.shared.user;
 
+import jsinterop.annotations.JsMethod;
 import peergos.shared.cbor.*;
 
 import java.time.*;
 import java.util.*;
+
 
 class LinkProperties implements Cborable {
     public final long label;
@@ -17,6 +19,11 @@ class LinkProperties implements Cborable {
         this.password = password;
         this.maxCount = maxCount;
         this.expiry = expiry;
+    }
+
+    @JsMethod
+    public String getLinkLabel() {
+        return "" + label;
     }
 
     @Override

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -2,15 +2,21 @@ package peergos.shared.user;
 
 import peergos.shared.cbor.*;
 
+import java.time.*;
 import java.util.*;
 
 class LinkProperties implements Cborable {
     public final long label;
     public final String password;
+    public final Optional<Integer> maxCount;
+    public final Optional<LocalDateTime> expiry;
 
-    public LinkProperties(long label, String password) {
+
+    public LinkProperties(long label, String password, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
         this.label = label;
         this.password = password;
+        this.maxCount = maxCount;
+        this.expiry = expiry;
     }
 
     @Override
@@ -18,6 +24,8 @@ class LinkProperties implements Cborable {
         SortedMap<String, Cborable> state = new TreeMap<>();
         state.put("l", new CborObject.CborLong(label));
         state.put("p", new CborObject.CborString(password));
+        maxCount.ifPresent(m -> state.put("m", new CborObject.CborLong(m)));
+        expiry.ifPresent(e -> state.put("e", new CborObject.CborLong(e.toEpochSecond(ZoneOffset.UTC))));
         return CborObject.CborMap.build(state);
     }
 
@@ -25,6 +33,10 @@ class LinkProperties implements Cborable {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Invalid cbor for LinkProperties! " + cbor);
         CborObject.CborMap m = (CborObject.CborMap) cbor;
-        return new LinkProperties(m.getLong("l"), m.getString("p"));
+        long label = m.getLong("l");
+        String password = m.getString("p");
+        Optional<Integer> maxCount = m.getOptionalLong("m").map(Long::intValue);
+        Optional<LocalDateTime> expiry = m.getOptionalLong("e").map(s -> LocalDateTime.ofEpochSecond(s, 0, ZoneOffset.UTC));
+        return new LinkProperties(label, password, maxCount, expiry);
     }
 }

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -2,7 +2,9 @@ package peergos.shared.user;
 
 import jsinterop.annotations.JsMethod;
 import peergos.shared.cbor.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.*;
+import peergos.shared.user.fs.*;
 
 import java.time.*;
 import java.util.*;
@@ -27,6 +29,15 @@ public class LinkProperties implements Cborable {
 
     public LinkProperties withExisting(Optional<Multihash> existing) {
         return new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, existing);
+    }
+
+    public SecretLink toLink(PublicKeyHash owner) {
+        return new SecretLink(owner, label, linkPassword);
+    }
+
+    @JsMethod
+    public String toLinkString(PublicKeyHash owner) {
+        return toLink(owner).toLink();
     }
 
     @JsMethod

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -27,6 +27,11 @@ public class LinkProperties implements Cborable {
         this.existing = existing;
     }
 
+    @JsMethod
+    public LinkProperties with(String userPassword, Optional<Integer> maxRetrievals, Optional<LocalDateTime> expiry) {
+        return new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, existing);
+    }
+
     public LinkProperties withExisting(Optional<Multihash> existing) {
         return new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, existing);
     }

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -22,8 +22,8 @@ class LinkProperties implements Cborable {
     }
 
     @JsMethod
-    public String getLinkLabel() {
-        return "" + label;
+    public long getLinkLabel() {
+        return label;
     }
 
     @Override

--- a/src/peergos/shared/user/LinkProperties.java
+++ b/src/peergos/shared/user/LinkProperties.java
@@ -1,0 +1,30 @@
+package peergos.shared.user;
+
+import peergos.shared.cbor.*;
+
+import java.util.*;
+
+class LinkProperties implements Cborable {
+    public final long label;
+    public final String password;
+
+    public LinkProperties(long label, String password) {
+        this.label = label;
+        this.password = password;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("l", new CborObject.CborLong(label));
+        state.put("p", new CborObject.CborString(password));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static LinkProperties fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for LinkProperties! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new LinkProperties(m.getLong("l"), m.getString("p"));
+    }
+}

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -1,4 +1,5 @@
 package peergos.shared.user;
+import java.util.*;
 import java.util.logging.*;
 
 import peergos.shared.*;
@@ -51,7 +52,7 @@ public class MutableTreeImpl implements MutableTree {
         return (base.tree.isPresent() ?
                 ChampWrapper.create(owner, (Cid)base.tree.get(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c) :
                 ChampWrapper.create(owner, writer, hasher, tid, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
-        ).thenCompose(tree -> tree.put(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), new CborObject.CborMerkleLink(value), tid))
+        ).thenCompose(tree -> tree.put(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), new CborObject.CborMerkleLink(value), Optional.empty(), tid))
                 .thenApply(newRoot -> LOGGING ? log(newRoot, "TREE.put (" + ArrayOps.bytesToHex(mapKey)
                         + ", " + value + ") => CAS(" + base.tree + ", " + newRoot + ")") : newRoot)
                 .thenApply(base::withChamp);
@@ -78,7 +79,7 @@ public class MutableTreeImpl implements MutableTree {
         if (! base.tree.isPresent())
             throw new IllegalStateException("Tree root not present!");
         return ChampWrapper.create(owner, (Cid)base.tree.get(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
-                .thenCompose(tree -> tree.remove(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), tid))
+                .thenCompose(tree -> tree.remove(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), Optional.empty(), tid))
                 .thenApply(pair -> LOGGING ? log(pair, "TREE.rm ("
                         + ArrayOps.bytesToHex(mapKey) + "  => " + pair) : pair)
                 .thenApply(newTreeRoot -> base.withChamp(newTreeRoot));

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -50,7 +50,7 @@ public class MutableTreeImpl implements MutableTree {
                                              Multihash value,
                                              TransactionId tid) {
         return (base.tree.isPresent() ?
-                ChampWrapper.create(owner, (Cid)base.tree.get(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c) :
+                ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c) :
                 ChampWrapper.create(owner, writer, hasher, tid, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
         ).thenCompose(tree -> tree.put(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), new CborObject.CborMerkleLink(value), Optional.empty(), tid))
                 .thenApply(newRoot -> LOGGING ? log(newRoot, "TREE.put (" + ArrayOps.bytesToHex(mapKey)
@@ -62,7 +62,7 @@ public class MutableTreeImpl implements MutableTree {
     public CompletableFuture<MaybeMultihash> get(WriterData base, PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey) {
         if (! base.tree.isPresent())
             throw new IllegalStateException("Tree root not present for " + writer);
-        return ChampWrapper.create(owner, (Cid)base.tree.get(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c).thenCompose(tree -> tree.get(mapKey))
+        return ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c).thenCompose(tree -> tree.get(mapKey))
                 .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
                 .thenApply(maybe -> LOGGING ?
                         log(maybe, "TREE.get (" + ArrayOps.bytesToHex(mapKey)
@@ -78,7 +78,7 @@ public class MutableTreeImpl implements MutableTree {
                                                 TransactionId tid) {
         if (! base.tree.isPresent())
             throw new IllegalStateException("Tree root not present!");
-        return ChampWrapper.create(owner, (Cid)base.tree.get(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
+        return ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
                 .thenCompose(tree -> tree.remove(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), Optional.empty(), tid))
                 .thenApply(pair -> LOGGING ? log(pair, "TREE.rm ("
                         + ArrayOps.bytesToHex(mapKey) + "  => " + pair) : pair)

--- a/src/peergos/shared/user/OwnedKeyChamp.java
+++ b/src/peergos/shared/user/OwnedKeyChamp.java
@@ -67,7 +67,7 @@ public class OwnedKeyChamp {
                                             TransactionId tid) {
         return ipfs.put(owner, writer, proof.serialize(), hasher, tid)
                 .thenCompose(valueHash ->
-                        champ.put(owner, writer, keyToBytes(proof.ownedKey), Optional.empty(), new CborObject.CborMerkleLink(valueHash), tid));
+                        champ.put(owner, writer, keyToBytes(proof.ownedKey), Optional.empty(), new CborObject.CborMerkleLink(valueHash), Optional.empty(), tid));
     }
 
     public CompletableFuture<Multihash> remove(PublicKeyHash owner,
@@ -76,7 +76,7 @@ public class OwnedKeyChamp {
                                                TransactionId tid) {
         byte[] keyBytes = keyToBytes(key);
         return champ.get(keyBytes)
-                .thenCompose(existing -> champ.remove(owner, writer, keyBytes, existing, tid));
+                .thenCompose(existing -> champ.remove(owner, writer, keyBytes, existing, Optional.empty(), tid));
     }
 
     public CompletableFuture<Boolean> contains(PublicKeyHash ownedKey) {

--- a/src/peergos/shared/user/OwnedKeyChamp.java
+++ b/src/peergos/shared/user/OwnedKeyChamp.java
@@ -37,7 +37,7 @@ public class OwnedKeyChamp {
     }
 
     public static CompletableFuture<OwnedKeyChamp> build(PublicKeyHash owner, Cid root, ContentAddressedStorage ipfs, Hasher hasher) {
-        return ChampWrapper.create(owner, root, b -> Futures.of(b.data), ipfs, hasher, c -> (CborObject.CborMerkleLink)c)
+        return ChampWrapper.create(owner, root, Optional.empty(), b -> Futures.of(b.data), ipfs, hasher, c -> (CborObject.CborMerkleLink)c)
                 .thenApply(c -> new OwnedKeyChamp(root, c, ipfs));
     }
 

--- a/src/peergos/shared/user/ScryptGenerator.java
+++ b/src/peergos/shared/user/ScryptGenerator.java
@@ -7,7 +7,7 @@ import java.util.*;
 
 public class ScryptGenerator implements SecretGenerationAlgorithm {
 
-    public static final int MIN_MEMORY_COST = 17;
+    public static final int MIN_MEMORY_COST = 15; // 15 is only used for secret links, 17 is used for login
 
     @JsProperty
     public final int memoryCost, cpuCost, parallelism, outputBytes;

--- a/src/peergos/shared/user/SecretLinkChamp.java
+++ b/src/peergos/shared/user/SecretLinkChamp.java
@@ -47,8 +47,8 @@ public class SecretLinkChamp {
 
     private CompletableFuture<byte[]> keyToBytes(long key) {
         byte[] copy = new byte[8];
-        for(int i=0; i < 8; i++) {
-            copy[0] = (byte) (key >> (8 * i));
+        for (int i=0; i < 8; i++) {
+            copy[i] = (byte) (key >> (8 * i));
         }
         return hasher.sha256(copy);
     }
@@ -68,6 +68,7 @@ public class SecretLinkChamp {
                                             Optional<BatId> mirrorBat,
                                             Hasher hasher,
                                             TransactionId tid) {
+        System.out.println("adding label " + label);
         return keyToBytes(label)
                 .thenCompose(key -> ipfs.put(owner.publicKeyHash, owner, target.serialize(), hasher, tid)
                         .thenCompose(valueHash ->

--- a/src/peergos/shared/user/SecretLinkChamp.java
+++ b/src/peergos/shared/user/SecretLinkChamp.java
@@ -62,17 +62,17 @@ public class SecretLinkChamp {
                         CompletableFuture.completedFuture(Optional.empty()));
     }
 
-    public CompletableFuture<Multihash> add(SigningPrivateKeyAndPublicHash owner,
+    public CompletableFuture<Pair<Multihash, Cid>> add(SigningPrivateKeyAndPublicHash owner,
                                             long label,
                                             SecretLinkTarget target,
+                                            Optional<CborObject.CborMerkleLink> existing,
                                             Optional<BatId> mirrorBat,
                                             Hasher hasher,
                                             TransactionId tid) {
-        System.out.println("adding label " + label);
         return keyToBytes(label)
                 .thenCompose(key -> ipfs.put(owner.publicKeyHash, owner, target.serialize(), hasher, tid)
                         .thenCompose(valueHash ->
-                                champ.put(owner.publicKeyHash, owner, key, Optional.empty(), new CborObject.CborMerkleLink(valueHash), mirrorBat, tid)));
+                                champ.put(owner.publicKeyHash, owner, key, existing, new CborObject.CborMerkleLink(valueHash), mirrorBat, tid).thenApply(root -> new Pair<>(root, valueHash))));
     }
 
     public CompletableFuture<Multihash> remove(PublicKeyHash owner,

--- a/src/peergos/shared/user/SecretLinkChamp.java
+++ b/src/peergos/shared/user/SecretLinkChamp.java
@@ -44,9 +44,11 @@ public class SecretLinkChamp {
     }
 
     private CompletableFuture<byte[]> keyToBytes(long key) {
-        byte[] raw = {(byte) key, (byte) (key >> 8), (byte) (key >> 16), (byte) (key >> 24),
-                (byte) (key >> 32), (byte) (key >> 40), (byte) (key >> 48), (byte) (key >> 56)};
-        return hasher.sha256(raw);
+        byte[] copy = new byte[8];
+        for(int i=0; i < 8; i++) {
+            copy[0] = (byte) (key >> (8 * i));
+        }
+        return hasher.sha256(copy);
     }
 
     public CompletableFuture<Optional<SecretLinkTarget>> get(PublicKeyHash owner,

--- a/src/peergos/shared/user/SecretLinkChamp.java
+++ b/src/peergos/shared/user/SecretLinkChamp.java
@@ -40,8 +40,8 @@ public class SecretLinkChamp {
                 .thenCompose(hash -> ipfs.put(owner, writer.publicKeyHash, writer.secret.signMessage(hash), raw, tid));
     }
 
-    public static CompletableFuture<SecretLinkChamp> build(PublicKeyHash owner, Cid root, ContentAddressedStorage ipfs, Hasher hasher) {
-        return ChampWrapper.create(owner, root, b -> Futures.of(b.data), ipfs, hasher, c -> (CborObject.CborMerkleLink)c)
+    public static CompletableFuture<SecretLinkChamp> build(PublicKeyHash owner, Cid root, Optional<BatWithId> mirrorBat, ContentAddressedStorage ipfs, Hasher hasher) {
+        return ChampWrapper.create(owner, root, mirrorBat, b -> Futures.of(b.data), ipfs, hasher, c -> (CborObject.CborMerkleLink)c)
                 .thenApply(c -> new SecretLinkChamp(root, c, ipfs, hasher));
     }
 

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -343,6 +343,10 @@ public class SharedWithCache {
         return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, password, maxCount, expiry), in, committer, network);
     }
 
+    public CompletableFuture<Snapshot> removeSecretLink(Access access, Path p, long label, Snapshot in, Committer committer, NetworkAccess network) {
+        return applyAndCommit(p, current -> current.removeLink(access, getFilename(p), label), in, committer, network);
+    }
+
     public CompletableFuture<Snapshot> addSharedWith(Access access, Path p, Set<String> names, Snapshot in, Committer committer, NetworkAccess network) {
         return applyAndCommit(p, current -> current.add(access, getFilename(p), names), in, committer, network);
     }

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -336,6 +336,10 @@ public class SharedWithCache {
                                 .clear(initialFilename), in, committer, network));
     }
 
+    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, long label, String password, Snapshot in, Committer committer, NetworkAccess network) {
+        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, password), in, committer, network);
+    }
+
     public CompletableFuture<Snapshot> addSharedWith(Access access, Path p, Set<String> names, Snapshot in, Committer committer, NetworkAccess network) {
         return applyAndCommit(p, current -> current.add(access, getFilename(p), names), in, committer, network);
     }

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -8,6 +8,7 @@ import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.nio.file.*;
+import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
@@ -336,8 +337,10 @@ public class SharedWithCache {
                                 .clear(initialFilename), in, committer, network));
     }
 
-    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, long label, String password, Snapshot in, Committer committer, NetworkAccess network) {
-        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, password), in, committer, network);
+    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, long label, String password,
+                                                     Optional<Integer> maxCount, Optional<LocalDateTime> expiry,
+                                                     Snapshot in, Committer committer, NetworkAccess network) {
+        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, password, maxCount, expiry), in, committer, network);
     }
 
     public CompletableFuture<Snapshot> addSharedWith(Access access, Path p, Set<String> names, Snapshot in, Committer committer, NetworkAccess network) {

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -334,17 +334,17 @@ public class SharedWithCache {
                 .thenCompose(sharees -> applyAndCommit(after, current ->
                         current.add(Access.READ, newFilename, sharees.readAccess)
                                 .add(Access.WRITE, newFilename, sharees.writeAccess)
-                                .addLinks(newFilename, current.get(initialFilename).readLinks, current.get(initialFilename).writelinks)
+                                .addLinks(newFilename, current.get(initialFilename).links)
                                 .clear(initialFilename), in, committer, network));
     }
 
-    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, LinkProperties link,
+    public CompletableFuture<Snapshot> addSecretLink(Path p, LinkProperties link,
                                                      Snapshot in, Committer committer, NetworkAccess network) {
-        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), link), in, committer, network);
+        return applyAndCommit(p, current -> current.addLink(getFilename(p), link), in, committer, network);
     }
 
-    public CompletableFuture<Snapshot> removeSecretLink(Access access, Path p, long label, Snapshot in, Committer committer, NetworkAccess network) {
-        return applyAndCommit(p, current -> current.removeLink(access, getFilename(p), label), in, committer, network);
+    public CompletableFuture<Snapshot> removeSecretLink(Path p, long label, Snapshot in, Committer committer, NetworkAccess network) {
+        return applyAndCommit(p, current -> current.removeLink(getFilename(p), label), in, committer, network);
     }
 
     public CompletableFuture<Snapshot> addSharedWith(Access access, Path p, Set<String> names, Snapshot in, Committer committer, NetworkAccess network) {

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -338,10 +338,9 @@ public class SharedWithCache {
                                 .clear(initialFilename), in, committer, network));
     }
 
-    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, long label, String linkPassword, String userPassword,
-                                                     Optional<Integer> maxCount, Optional<LocalDateTime> expiry,
+    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, LinkProperties link,
                                                      Snapshot in, Committer committer, NetworkAccess network) {
-        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, linkPassword, userPassword, maxCount, expiry), in, committer, network);
+        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), link), in, committer, network);
     }
 
     public CompletableFuture<Snapshot> removeSecretLink(Access access, Path p, long label, Snapshot in, Committer committer, NetworkAccess network) {

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -338,10 +338,10 @@ public class SharedWithCache {
                                 .clear(initialFilename), in, committer, network));
     }
 
-    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, long label, String password,
+    public CompletableFuture<Snapshot> addSecretLink(Access access, Path p, long label, String linkPassword, String userPassword,
                                                      Optional<Integer> maxCount, Optional<LocalDateTime> expiry,
                                                      Snapshot in, Committer committer, NetworkAccess network) {
-        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, password, maxCount, expiry), in, committer, network);
+        return applyAndCommit(p, current -> current.addLink(access, getFilename(p), label, linkPassword, userPassword, maxCount, expiry), in, committer, network);
     }
 
     public CompletableFuture<Snapshot> removeSecretLink(Access access, Path p, long label, Snapshot in, Committer committer, NetworkAccess network) {

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -334,6 +334,7 @@ public class SharedWithCache {
                 .thenCompose(sharees -> applyAndCommit(after, current ->
                         current.add(Access.READ, newFilename, sharees.readAccess)
                                 .add(Access.WRITE, newFilename, sharees.writeAccess)
+                                .addLinks(newFilename, current.get(initialFilename).readLinks, current.get(initialFilename).writelinks)
                                 .clear(initialFilename), in, committer, network));
     }
 

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -104,6 +104,28 @@ public class SharedWithState implements Cborable {
         return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
     }
 
+    public SharedWithState addLinks(String filename, Set<LinkProperties> newFileReadLinks, Set<LinkProperties> newFileWritelinks) {
+        Map<String, Set<LinkProperties>> newReadLinks = new HashMap<>();
+        readLinks.forEach((k, v) -> {
+            newReadLinks.put(k, new HashSet<>(v));
+        });
+
+        Map<String, Set<LinkProperties>> newWriteLinks = new HashMap<>();
+        writeLinks.forEach((k, v) -> {
+            newWriteLinks.put(k, new HashSet<>(v));
+        });
+
+        if (! newFileReadLinks.isEmpty()) {
+            newReadLinks.putIfAbsent(filename, new HashSet<>());
+            newReadLinks.get(filename).addAll(newFileReadLinks);
+        }
+        if (! newFileWritelinks.isEmpty()) {
+            newWriteLinks.putIfAbsent(filename, new HashSet<>());
+            newWriteLinks.get(filename).addAll(newFileWritelinks);
+        }
+        return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
+    }
+
     public SharedWithState removeLink(SharedWithCache.Access access, String filename, long label) {
         Map<String, Set<LinkProperties>> newReadLinks = new HashMap<>();
         readLinks.forEach((k, v) -> {

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -241,8 +241,8 @@ public class SharedWithState implements Cborable {
         if (! m.containsKey("l"))
             return new SharedWithState(readShares, writehares, Collections.emptyMap());
 
-        CborObject.CborMap rl = m.get("l", c -> (CborObject.CborMap) c);
-        Map<String, Set<LinkProperties>> links = rl.toMap(
+        CborObject.CborMap l = m.get("l", c -> (CborObject.CborMap) c);
+        Map<String, Set<LinkProperties>> links = l.toMap(
                 getString,
                 c -> new HashSet<>(((CborObject.CborList)c).map(LinkProperties::fromCbor)));
 

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -83,7 +83,7 @@ public class SharedWithState implements Cborable {
         return Optional.of(new SharedWithState(newReads, newWrites, newReadLinks, newWriteLinks));
     }
 
-    public SharedWithState addLink(SharedWithCache.Access access, String filename, long label, String password, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
+    public SharedWithState addLink(SharedWithCache.Access access, String filename, long label, String linkPassword, String userPassword, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
         Map<String, Set<LinkProperties>> newReadLinks = new HashMap<>();
         readLinks.forEach((k, v) -> {
             newReadLinks.put(k, new HashSet<>(v));
@@ -96,10 +96,10 @@ public class SharedWithState implements Cborable {
 
         if (access == SharedWithCache.Access.READ) {
             newReadLinks.putIfAbsent(filename, new HashSet<>());
-            newReadLinks.get(filename).add(new LinkProperties(label, password, maxCount, expiry));
+            newReadLinks.get(filename).add(new LinkProperties(label, linkPassword, userPassword, maxCount, expiry));
         } else if (access == SharedWithCache.Access.WRITE) {
             newWriteLinks.putIfAbsent(filename, new HashSet<>());
-            newWriteLinks.get(filename).add(new LinkProperties(label, password, maxCount, expiry));
+            newWriteLinks.get(filename).add(new LinkProperties(label, linkPassword, userPassword, maxCount, expiry));
         }
         return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
     }

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -4,6 +4,7 @@ import jsinterop.annotations.*;
 import peergos.shared.cbor.*;
 import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
@@ -82,7 +83,7 @@ public class SharedWithState implements Cborable {
         return Optional.of(new SharedWithState(newReads, newWrites, newReadLinks, newWriteLinks));
     }
 
-    public SharedWithState addLink(SharedWithCache.Access access, String filename, long label, String password) {
+    public SharedWithState addLink(SharedWithCache.Access access, String filename, long label, String password, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
         Map<String, Set<LinkProperties>> newReadLinks = new HashMap<>();
         readLinks.forEach((k, v) -> {
             newReadLinks.put(k, new HashSet<>(v));
@@ -95,10 +96,10 @@ public class SharedWithState implements Cborable {
 
         if (access == SharedWithCache.Access.READ) {
             newReadLinks.putIfAbsent(filename, new HashSet<>());
-            newReadLinks.get(filename).add(new LinkProperties(label, password));
+            newReadLinks.get(filename).add(new LinkProperties(label, password, maxCount, expiry));
         } else if (access == SharedWithCache.Access.WRITE) {
             newWriteLinks.putIfAbsent(filename, new HashSet<>());
-            newWriteLinks.get(filename).add(new LinkProperties(label, password));
+            newWriteLinks.get(filename).add(new LinkProperties(label, password, maxCount, expiry));
         }
         return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
     }

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -238,6 +238,8 @@ public class SharedWithState implements Cborable {
         Map<String, Set<String>> writehares = w.toMap(
                 getString,
                 c -> new HashSet<>(((CborObject.CborList)c).map(getString)));
+        if (! m.containsKey("l"))
+            return new SharedWithState(readShares, writehares, Collections.emptyMap());
 
         CborObject.CborMap rl = m.get("l", c -> (CborObject.CborMap) c);
         Map<String, Set<LinkProperties>> links = rl.toMap(

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -40,6 +40,14 @@ public class SharedWithState implements Cborable {
         return readShares;
     }
 
+    public Map<String, Set<LinkProperties>> readLinks() {
+        return readLinks;
+    }
+
+    public Map<String, Set<LinkProperties>> writeLinks() {
+        return writeLinks;
+    }
+
     public Map<String, Set<String>> writeShares() {
         return writeShares;
     }
@@ -96,9 +104,11 @@ public class SharedWithState implements Cborable {
 
         if (access == SharedWithCache.Access.READ) {
             newReadLinks.putIfAbsent(filename, new HashSet<>());
+            newReadLinks.get(filename).removeIf(p -> p.label == link.label); // make sure we replace any old version
             newReadLinks.get(filename).add(link);
         } else if (access == SharedWithCache.Access.WRITE) {
             newWriteLinks.putIfAbsent(filename, new HashSet<>());
+            newWriteLinks.get(filename).removeIf(p -> p.label == link.label); // make sure we replace any old version
             newWriteLinks.get(filename).add(link);
         }
         return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -83,7 +83,7 @@ public class SharedWithState implements Cborable {
         return Optional.of(new SharedWithState(newReads, newWrites, newReadLinks, newWriteLinks));
     }
 
-    public SharedWithState addLink(SharedWithCache.Access access, String filename, long label, String linkPassword, String userPassword, Optional<Integer> maxCount, Optional<LocalDateTime> expiry) {
+    public SharedWithState addLink(SharedWithCache.Access access, String filename, LinkProperties link) {
         Map<String, Set<LinkProperties>> newReadLinks = new HashMap<>();
         readLinks.forEach((k, v) -> {
             newReadLinks.put(k, new HashSet<>(v));
@@ -96,10 +96,10 @@ public class SharedWithState implements Cborable {
 
         if (access == SharedWithCache.Access.READ) {
             newReadLinks.putIfAbsent(filename, new HashSet<>());
-            newReadLinks.get(filename).add(new LinkProperties(label, linkPassword, userPassword, maxCount, expiry));
+            newReadLinks.get(filename).add(link);
         } else if (access == SharedWithCache.Access.WRITE) {
             newWriteLinks.putIfAbsent(filename, new HashSet<>());
-            newWriteLinks.get(filename).add(new LinkProperties(label, linkPassword, userPassword, maxCount, expiry));
+            newWriteLinks.get(filename).add(link);
         }
         return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
     }

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -104,6 +104,35 @@ public class SharedWithState implements Cborable {
         return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
     }
 
+    public SharedWithState removeLink(SharedWithCache.Access access, String filename, long label) {
+        Map<String, Set<LinkProperties>> newReadLinks = new HashMap<>();
+        readLinks.forEach((k, v) -> {
+            newReadLinks.put(k, new HashSet<>(v));
+        });
+
+        Map<String, Set<LinkProperties>> newWriteLinks = new HashMap<>();
+        writeLinks.forEach((k, v) -> {
+            newWriteLinks.put(k, new HashSet<>(v));
+        });
+
+        if (access == SharedWithCache.Access.READ) {
+            Set<LinkProperties> val = newReadLinks.get(filename);
+            Set<LinkProperties> updated = val.stream().filter(lp -> lp.label != label).collect(Collectors.toSet());
+            if (updated.isEmpty())
+                newReadLinks.remove(filename);
+            else
+                newReadLinks.put(filename, updated);
+        } else if (access == SharedWithCache.Access.WRITE) {
+            Set<LinkProperties> val = newWriteLinks.get(filename);
+            Set<LinkProperties> updated = val.stream().filter(lp -> lp.label != label).collect(Collectors.toSet());
+            if (updated.isEmpty())
+                newWriteLinks.remove(filename);
+            else
+                newWriteLinks.put(filename, updated);
+        }
+        return new SharedWithState(readShares, writeShares, newReadLinks, newWriteLinks);
+    }
+
     public SharedWithState add(SharedWithCache.Access access, String filename, Set<String> names) {
         if (names.isEmpty())
             return this;

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -650,13 +650,10 @@ public class UserContext {
                                                           Optional<LocalDateTime> expiry,
                                                           Optional<Integer> maxRetrievals,
                                                           String userPassword) {
-        byte[] labelBytes = crypto.random.randomBytes(4);
-        long label = (labelBytes[0] & 0xFF) | ((labelBytes[1] & 0xFF) << 8) | ((labelBytes[2] & 0xFF) << 16) | ((labelBytes[3] & 0xFF) << 24);
-        String linkPassword = EncryptedCapability.createLinkPassword(crypto.random);
-        LinkProperties props = new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, Optional.empty());
+        SecretLink res = SecretLink.create(signer.publicKeyHash, crypto.random);
+        LinkProperties props = new LinkProperties(res.label, res.linkPassword, userPassword, maxRetrievals, expiry, Optional.empty());
         if (! isWritable)
             return updateSecretLink(toFile, isWritable, props);
-        SecretLink res = new SecretLink(signer.publicKeyHash, props.label, props.linkPassword);
         return getByPath(toFile.getParent())
                 .thenCompose(parent -> parent.get().getChild(toFile.getFileName().toString(), crypto.hasher, network)
                         .thenCompose(fopt -> shareWriteAccessWith(toFile, Collections.emptySet())))

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -652,6 +652,16 @@ public class UserContext {
     public CompletableFuture<LinkProperties> createSecretLink(String filePath,
                                                               boolean isWritable,
                                                               Optional<LocalDateTime> expiry,
+                                                              String maxRetrievals,
+                                                              String userPassword) {
+        return createSecretLink(filePath, isWritable, expiry,
+                maxRetrievals.isEmpty() ? Optional.empty() : Optional.of(Integer.parseInt(maxRetrievals)),
+                userPassword);
+    }
+
+    public CompletableFuture<LinkProperties> createSecretLink(String filePath,
+                                                              boolean isWritable,
+                                                              Optional<LocalDateTime> expiry,
                                                               Optional<Integer> maxRetrievals,
                                                               String userPassword) {
         SecretLink res = SecretLink.create(signer.publicKeyHash, crypto.random);

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -645,11 +645,10 @@ public class UserContext {
                 .thenCompose(value -> writeSynchronizer.applyComplexUpdate(id, signer,
                         (v, c) -> IpfsTransaction.call(id,
                                 tid -> v.get(id).props.get().addLink(signer, label, value, tid, network.dhtClient, network.hasher)
-                                        .thenCompose(wd -> c.commit(id, signer, wd, v.get(id), tid)), network.dhtClient)))
+                                        .thenCompose(wd -> c.commit(id, signer, wd, v.get(id), tid))
+                                        .thenCompose(s -> sharedWithCache.addSecretLink(isWritable ? SharedWithCache.Access.WRITE : SharedWithCache.Access.READ,
+                                                toFile, label, linkPassword, s, c, network)), network.dhtClient)))
                 .thenApply(s -> res);
-
-        // TODO put link in sharedWithCache
-//        sharedWithCache.addSecretLink()
     }
 
     public static CompletableFuture<AbsoluteCapability> getPublicCapability(Path originalPath, NetworkAccess network) {

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -640,6 +640,7 @@ public class UserContext {
                 }));
     }
 
+    @JsMethod
     public CompletableFuture<SecretLink> createSecretLink(Path toFile,
                                                           boolean isWritable,
                                                           Optional<LocalDateTime> expiry,

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -589,7 +589,7 @@ public class UserContext {
     public static CompletableFuture<UserContext> fromSecretLinkV2(String linkString, String userPassword, NetworkAccess network, Crypto crypto) {
         SecretLink link = SecretLink.fromLink(linkString);
         return network.getSecretLink(link)
-                .thenCompose(retrieved -> retrieved.decryptFromPassword(link.labelString(), userPassword, crypto))
+                .thenCompose(retrieved -> retrieved.decryptFromPassword(link.labelString(), link.linkPassword + userPassword, crypto))
                 .thenCompose(cap -> fromSecretLink(cap, network, crypto));
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -586,10 +586,10 @@ public class UserContext {
     }
 
     @JsMethod
-    public static CompletableFuture<UserContext> fromSecretLinkV2(String linkString, String linkPassword, NetworkAccess network, Crypto crypto) {
+    public static CompletableFuture<UserContext> fromSecretLinkV2(String linkString, String userPassword, NetworkAccess network, Crypto crypto) {
         SecretLink link = SecretLink.fromLink(linkString);
         return network.getSecretLink(link)
-                .thenCompose(retrieved -> retrieved.decryptFromPassword(link.labelString(), linkPassword, crypto))
+                .thenCompose(retrieved -> retrieved.decryptFromPassword(link.labelString(), userPassword, crypto))
                 .thenCompose(cap -> fromSecretLink(cap, network, crypto));
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -657,7 +657,7 @@ public class UserContext {
                 .thenApply(payload -> new SecretLinkTarget(payload, expiry, maxRetrievals))
                 .thenCompose(value -> writeSynchronizer.applyComplexUpdate(id, signer,
                         (v, c) -> IpfsTransaction.call(id,
-                                tid -> v.get(id).props.get().addLink(signer, label, value, tid, network.dhtClient, network.hasher)
+                                tid -> v.get(id).props.get().addLink(signer, label, value, mirrorBatId(), tid, network.dhtClient, network.hasher)
                                         .thenCompose(wd -> c.commit(id, signer, wd, v.get(id), tid))
                                         .thenCompose(s -> sharedWithCache.addSecretLink(isWritable ? SharedWithCache.Access.WRITE : SharedWithCache.Access.READ,
                                                 toFile, label, linkPassword, maxRetrievals, expiry, s, c, network)), network.dhtClient)))
@@ -669,7 +669,7 @@ public class UserContext {
         PublicKeyHash id = signer.publicKeyHash;
         return writeSynchronizer.applyComplexUpdate(id, signer,
                         (v, c) -> IpfsTransaction.call(id,
-                                tid -> v.get(id).props.get().removeLink(signer, label, tid, network.dhtClient, network.hasher)
+                                tid -> v.get(id).props.get().removeLink(signer, label, mirrorBatId(), tid, network.dhtClient, network.hasher)
                                         .thenCompose(wd -> c.commit(id, signer, wd, v.get(id), tid))
                                         .thenCompose(s -> sharedWithCache.removeSecretLink(isWritable ? SharedWithCache.Access.WRITE : SharedWithCache.Access.READ,
                                                 toFile, label, s, c, network)), network.dhtClient));

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -693,9 +693,9 @@ public class UserContext {
                 .thenApply(Optional::get)
                 .thenCompose(file -> {
                     boolean differentWriter = file.getPointer().getParentCap().writer.map(parentWriter -> ! parentWriter.equals(file.writer())).orElse(false);
-                    if (props.isWritable && ! differentWriter)
+                    if (props.isLinkWritable && ! differentWriter)
                         throw new IllegalStateException("To generate a writable secret link, the target must already be in a different writing space!");
-                    AbsoluteCapability cap = props.isWritable ? file.getPointer().capability : file.getPointer().capability.readOnly();
+                    AbsoluteCapability cap = props.isLinkWritable ? file.getPointer().capability : file.getPointer().capability.readOnly();
                     SecretLink res = new SecretLink(id, props.label, props.linkPassword);
                     String fullPassword = props.linkPassword + props.userPassword;
                     return EncryptedCapability.createFromPassword(cap, res.labelString(), fullPassword, !props.userPassword.isEmpty(), crypto)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1964,7 +1964,7 @@ public class UserContext {
         return Futures.reduceAll(file.readShares().entrySet(), in,
                 (s, e) -> shareReadAccessWith(start.resolve(e.getKey()), e.getValue(), s, c),
                 (a, b) -> b).thenCompose(s2 -> Futures.reduceAll(file.writeShares().entrySet(),
-                in,
+                s2,
                 (s, e) -> sendWriteCapToAll(start.resolve(e.getKey()), e.getValue(), s, c),
                 (a, b) -> b)); // TODO update links
     }

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -651,6 +651,16 @@ public class UserContext {
                 .thenApply(s -> res);
     }
 
+    public CompletableFuture<Snapshot> deleteSecretLink(long label, Path toFile, boolean isWritable) {
+        PublicKeyHash id = signer.publicKeyHash;
+        return writeSynchronizer.applyComplexUpdate(id, signer,
+                        (v, c) -> IpfsTransaction.call(id,
+                                tid -> v.get(id).props.get().removeLink(signer, label, tid, network.dhtClient, network.hasher)
+                                        .thenCompose(wd -> c.commit(id, signer, wd, v.get(id), tid))
+                                        .thenCompose(s -> sharedWithCache.removeSecretLink(isWritable ? SharedWithCache.Access.WRITE : SharedWithCache.Access.READ,
+                                                toFile, label, s, c, network)), network.dhtClient));
+    }
+
     public static CompletableFuture<AbsoluteCapability> getPublicCapability(Path originalPath, NetworkAccess network) {
         String ownerName = originalPath.getName(0).toString();
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -650,8 +650,8 @@ public class UserContext {
                                                           Optional<LocalDateTime> expiry,
                                                           Optional<Integer> maxRetrievals,
                                                           String userPassword) {
-        byte[] labelBytes = crypto.random.randomBytes(3);
-        long label = (labelBytes[0] & 0xFF) | ((labelBytes[1] & 0xFF) << 8) | ((labelBytes[2] & 0xFF) << 16);
+        byte[] labelBytes = crypto.random.randomBytes(4);
+        long label = (labelBytes[0] & 0xFF) | ((labelBytes[1] & 0xFF) << 8) | ((labelBytes[2] & 0xFF) << 16) | ((labelBytes[3] & 0xFF) << 24);
         String linkPassword = EncryptedCapability.createLinkPassword(crypto.random);
         LinkProperties props = new LinkProperties(label, linkPassword, userPassword, maxRetrievals, expiry, Optional.empty());
         if (! isWritable)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -647,7 +647,7 @@ public class UserContext {
                                 tid -> v.get(id).props.get().addLink(signer, label, value, tid, network.dhtClient, network.hasher)
                                         .thenCompose(wd -> c.commit(id, signer, wd, v.get(id), tid))
                                         .thenCompose(s -> sharedWithCache.addSecretLink(isWritable ? SharedWithCache.Access.WRITE : SharedWithCache.Access.READ,
-                                                toFile, label, linkPassword, s, c, network)), network.dhtClient)))
+                                                toFile, label, linkPassword, maxRetrievals, expiry, s, c, network)), network.dhtClient)))
                 .thenApply(s -> res);
     }
 

--- a/src/peergos/shared/user/UserSnapshot.java
+++ b/src/peergos/shared/user/UserSnapshot.java
@@ -1,13 +1,11 @@
 package peergos.shared.user;
 
-import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.social.*;
+import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
-import peergos.shared.util.*;
 
-import java.time.*;
 import java.util.*;
 import java.util.stream.*;
 
@@ -17,13 +15,13 @@ public class UserSnapshot implements Cborable {
     public final List<BlindFollowRequest> pendingFollowReqs;
     public final List<BatWithId> mirrorBats;
     public final Optional<LoginData> login;
-    public final LinkRetrievalCounter.LinkCounts linkCounts;
+    public final LinkCounts linkCounts;
 
     public UserSnapshot(Map<PublicKeyHash, byte[]> pointerState,
                         List<BlindFollowRequest> pendingFollowReqs,
                         List<BatWithId> mirrorBats,
                         Optional<LoginData> login,
-                        LinkRetrievalCounter.LinkCounts linkCounts) {
+                        LinkCounts linkCounts) {
         this.pointerState = pointerState;
         this.pendingFollowReqs = pendingFollowReqs;
         this.mirrorBats = mirrorBats;
@@ -59,12 +57,12 @@ public class UserSnapshot implements Cborable {
                 .getMap(PublicKeyHash::fromCbor, c -> ((CborObject.CborByteArray)c).value);
         List<BatWithId> mirrorBats = m.getList("b", BatWithId::fromCbor);
         Optional<LoginData> login = m.getOptional("l", LoginData::fromCbor);
-        LinkRetrievalCounter.LinkCounts lc = m.get("lc", LinkRetrievalCounter.LinkCounts::fromCbor);
+        LinkCounts lc = m.get("lc", LinkCounts::fromCbor);
         return new UserSnapshot(pointerState, pendingFollowReqs, mirrorBats, login, lc);
     }
 
     public static UserSnapshot empty() {
         return new UserSnapshot(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
-                Optional.empty(), new LinkRetrievalCounter.LinkCounts(Collections.emptyMap()));
+                Optional.empty(), new LinkCounts(Collections.emptyMap()));
     }
 }

--- a/src/peergos/shared/user/UserSnapshot.java
+++ b/src/peergos/shared/user/UserSnapshot.java
@@ -1,10 +1,13 @@
 package peergos.shared.user;
 
+import peergos.server.storage.*;
 import peergos.shared.cbor.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.social.*;
 import peergos.shared.storage.auth.*;
+import peergos.shared.util.*;
 
+import java.time.*;
 import java.util.*;
 import java.util.stream.*;
 
@@ -14,15 +17,18 @@ public class UserSnapshot implements Cborable {
     public final List<BlindFollowRequest> pendingFollowReqs;
     public final List<BatWithId> mirrorBats;
     public final Optional<LoginData> login;
+    public final LinkRetrievalCounter.LinkCounts linkCounts;
 
     public UserSnapshot(Map<PublicKeyHash, byte[]> pointerState,
                         List<BlindFollowRequest> pendingFollowReqs,
                         List<BatWithId> mirrorBats,
-                        Optional<LoginData> login) {
+                        Optional<LoginData> login,
+                        LinkRetrievalCounter.LinkCounts linkCounts) {
         this.pointerState = pointerState;
         this.pendingFollowReqs = pendingFollowReqs;
         this.mirrorBats = mirrorBats;
         this.login = login;
+        this.linkCounts = linkCounts;
     }
 
     @Override
@@ -40,6 +46,7 @@ public class UserSnapshot implements Cborable {
         state.put("p", new CborObject.CborList(pointerMap));
         state.put("b", new CborObject.CborList(mirrorBats));
         login.ifPresent(d -> state.put("l", d));
+        state.put("lc", linkCounts.toCbor());
         return CborObject.CborMap.build(state);
     }
 
@@ -52,10 +59,12 @@ public class UserSnapshot implements Cborable {
                 .getMap(PublicKeyHash::fromCbor, c -> ((CborObject.CborByteArray)c).value);
         List<BatWithId> mirrorBats = m.getList("b", BatWithId::fromCbor);
         Optional<LoginData> login = m.getOptional("l", LoginData::fromCbor);
-        return new UserSnapshot(pointerState, pendingFollowReqs, mirrorBats, login);
+        LinkRetrievalCounter.LinkCounts lc = m.get("lc", LinkRetrievalCounter.LinkCounts::fromCbor);
+        return new UserSnapshot(pointerState, pendingFollowReqs, mirrorBats, login, lc);
     }
 
     public static UserSnapshot empty() {
-        return new UserSnapshot(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(), Optional.empty());
+        return new UserSnapshot(Collections.emptyMap(), Collections.emptyList(), Collections.emptyList(),
+                Optional.empty(), new LinkRetrievalCounter.LinkCounts(Collections.emptyMap()));
     }
 }

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -56,6 +56,7 @@ public class WriteSynchronizer {
                 Optional.empty(),
                 Collections.emptyMap(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
         CommittedWriterData emptyUserData = new CommittedWriterData(MaybeMultihash.empty(), emptyWD, Optional.empty());
         put(owner, writer, emptyUserData);

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -121,6 +121,19 @@ public class WriterData implements Cborable {
                         ownedKeys, namedOwnedKeys, staticData, tree, Optional.of(newLinksRoot)));
     }
 
+    public CompletableFuture<WriterData> removeLink(SigningPrivateKeyAndPublicHash owner,
+                                                 long label,
+                                                    TransactionId tid,
+                                                    ContentAddressedStorage ipfs,
+                                                    Hasher hasher) {
+        if (secretLinks.isEmpty())
+            return Futures.of(this);
+        return getSecretLinkChamp(owner.publicKeyHash, ipfs, hasher)
+                .thenCompose(champ -> champ.remove(owner.publicKeyHash, owner, label, tid))
+                .thenApply(newLinksRoot -> new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver,
+                        ownedKeys, namedOwnedKeys, staticData, tree, Optional.of(newLinksRoot)));
+    }
+
     public CompletableFuture<Snapshot> addOwnedKeyAndCommit(PublicKeyHash owner,
                                                             SigningPrivateKeyAndPublicHash signer,
                                                             OwnerProof newOwned,

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -107,20 +107,21 @@ public class WriterData implements Cborable {
                                 Optional.of(newRoot), namedOwnedKeys, staticData, tree, secretLinks)), ipfs);
     }
 
-    public CompletableFuture<WriterData> addLink(SigningPrivateKeyAndPublicHash owner,
-                                                 long label,
-                                                 SecretLinkTarget value,
-                                                 Optional<BatWithId> mirrorBat,
-                                                 TransactionId tid,
-                                                 ContentAddressedStorage ipfs,
-                                                 Hasher hasher) {
+    public CompletableFuture<Pair<WriterData, Cid>> addLink(SigningPrivateKeyAndPublicHash owner,
+                                                            long label,
+                                                            SecretLinkTarget value,
+                                                            Optional<CborObject.CborMerkleLink> existing,
+                                                            Optional<BatWithId> mirrorBat,
+                                                            TransactionId tid,
+                                                            ContentAddressedStorage ipfs,
+                                                            Hasher hasher) {
         return (secretLinks.isEmpty() ?
                 SecretLinkChamp.createEmpty(owner.publicKeyHash, owner, mirrorBat.map(BatWithId::id), ipfs, hasher, tid)
                         .thenCompose(root -> SecretLinkChamp.build(owner.publicKeyHash, root, mirrorBat, ipfs, hasher)) :
                 getSecretLinkChamp(owner.publicKeyHash, mirrorBat, ipfs, hasher))
-                .thenCompose(champ -> champ.add(owner, label, value, mirrorBat.map(BatWithId::id), hasher, tid))
-                .thenApply(newLinksRoot -> new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver,
-                        ownedKeys, namedOwnedKeys, staticData, tree, Optional.of(newLinksRoot)));
+                .thenCompose(champ -> champ.add(owner, label, value, existing, mirrorBat.map(BatWithId::id), hasher, tid))
+                .thenApply(newLinksRoot -> new Pair<>(new WriterData(controller, generationAlgorithm, publicData, followRequestReceiver,
+                        ownedKeys, namedOwnedKeys, staticData, tree, Optional.of(newLinksRoot.left)), newLinksRoot.right));
     }
 
     public CompletableFuture<WriterData> removeLink(SigningPrivateKeyAndPublicHash owner,

--- a/src/peergos/shared/user/fs/EncryptedCapability.java
+++ b/src/peergos/shared/user/fs/EncryptedCapability.java
@@ -1,0 +1,49 @@
+package peergos.shared.user.fs;
+
+import jsinterop.annotations.*;
+import peergos.shared.*;
+import peergos.shared.crypto.*;
+import peergos.shared.crypto.symmetric.*;
+import peergos.shared.user.*;
+
+import java.util.concurrent.*;
+
+public class EncryptedCapability {
+    public static final ScryptGenerator LINK_KEY_GENERATOR = new ScryptGenerator(15, 8, 1, 32, "");
+
+    public final CipherText payload;
+
+    public EncryptedCapability(CipherText payload) {
+        this.payload = payload;
+    }
+
+    @JsMethod
+    public CompletableFuture<AbsoluteCapability> decryptFromPassword(String salt, String password, Crypto c) {
+        return deriveKey(salt, password, c)
+                .thenApply(this::decrypt);
+    }
+
+    private AbsoluteCapability decrypt(SymmetricKey k) {
+        return payload.decrypt(k, AbsoluteCapability::fromCbor);
+    }
+
+    private static CompletableFuture<SymmetricKey> deriveKey(String label, String password, Crypto c) {
+        return c.hasher.hashToKeyBytes(label, password, LINK_KEY_GENERATOR)
+                .thenApply(b -> new TweetNaClKey(b, false, c.symmetricProvider, c.random));
+    }
+
+    private static EncryptedCapability create(AbsoluteCapability raw, SymmetricKey k) {
+        return new EncryptedCapability(CipherText.build(k, raw));
+    }
+
+    public static EncryptedCapability create(AbsoluteCapability raw) {
+        SymmetricKey k = SymmetricKey.random();
+        return create(raw, k);
+    }
+
+    @JsMethod
+    public static CompletableFuture<EncryptedCapability> createFromPassword(AbsoluteCapability raw, String salt, String password, Crypto c) {
+        return deriveKey(salt, password, c)
+                .thenApply(k -> create(raw, k));
+    }
+}

--- a/src/peergos/shared/user/fs/EncryptedCapability.java
+++ b/src/peergos/shared/user/fs/EncryptedCapability.java
@@ -2,19 +2,25 @@ package peergos.shared.user.fs;
 
 import jsinterop.annotations.*;
 import peergos.shared.*;
+import peergos.shared.cbor.*;
 import peergos.shared.crypto.*;
+import peergos.shared.crypto.random.*;
 import peergos.shared.crypto.symmetric.*;
+import peergos.shared.io.ipfs.bases.*;
 import peergos.shared.user.*;
 
+import java.util.*;
 import java.util.concurrent.*;
 
-public class EncryptedCapability {
+public class EncryptedCapability implements Cborable {
     public static final ScryptGenerator LINK_KEY_GENERATOR = new ScryptGenerator(15, 8, 1, 32, "");
 
     public final CipherText payload;
+    public final boolean hasUserPassword;
 
-    public EncryptedCapability(CipherText payload) {
+    public EncryptedCapability(CipherText payload, boolean hasUserPassword) {
         this.payload = payload;
+        this.hasUserPassword = hasUserPassword;
     }
 
     @JsMethod
@@ -32,18 +38,48 @@ public class EncryptedCapability {
                 .thenApply(b -> new TweetNaClKey(b, false, c.symmetricProvider, c.random));
     }
 
-    private static EncryptedCapability create(AbsoluteCapability raw, SymmetricKey k) {
-        return new EncryptedCapability(CipherText.build(k, raw));
-    }
-
-    public static EncryptedCapability create(AbsoluteCapability raw) {
-        SymmetricKey k = SymmetricKey.random();
-        return create(raw, k);
+    private static EncryptedCapability create(AbsoluteCapability raw, SymmetricKey k, boolean hasUserPassword) {
+        return new EncryptedCapability(CipherText.build(k, raw), hasUserPassword);
     }
 
     @JsMethod
-    public static CompletableFuture<EncryptedCapability> createFromPassword(AbsoluteCapability raw, String salt, String password, Crypto c) {
+    public static CompletableFuture<EncryptedCapability> createFromPassword(AbsoluteCapability raw, String salt, String password, boolean hasUserPassword, Crypto c) {
         return deriveKey(salt, password, c)
-                .thenApply(k -> create(raw, k));
+                .thenApply(k -> create(raw, k, hasUserPassword));
+    }
+
+    private static int randomInt(int limit, SafeRandom r) {
+        if (limit > 256)
+            throw new IllegalStateException("Limit too large!");
+        int val = r.randomBytes(1)[0] & 0xFF;
+        if (val < limit)
+            return val;
+        return randomInt(limit, r);
+    }
+    private static final String passwordCharacters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    public static String createLinkPassword(SafeRandom r) {
+        // want 12 characters from a-zA-Z0-9, so 62^12 ~ 2^72 possibilities,
+        // or take 100 years to crack with 1M GPUs, each trying 1M scrypt hashes/S
+        // any user supplied password is in addition to this
+        String pw = "";
+        for (int i=0; i < 12; i++)
+            pw += passwordCharacters.charAt(randomInt(passwordCharacters.length(), r));
+        return pw;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("c", payload.toCbor());
+        if (hasUserPassword)
+            state.put("p", new CborObject.CborBoolean(hasUserPassword));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static EncryptedCapability fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for EncryptedCapability! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new EncryptedCapability(m.get("c", CipherText::fromCbor), m.getBoolean("p", false));
     }
 }

--- a/src/peergos/shared/user/fs/SecretLink.java
+++ b/src/peergos/shared/user/fs/SecretLink.java
@@ -28,12 +28,14 @@ public class SecretLink {
 
     @JsMethod
     public static SecretLink fromLink(String link) {
+        // e.g secret/z59vuwzfFDorjWRiEtcEu6BQWWsLYCAJpmkAcVkuV8P5b4ykYwm1NE6/8057131#moCvfdkPxWLb
         if (link.startsWith("/"))
             link = link.substring(1);
-        String fragment = link.substring(link.indexOf("#") + 1);
+        int hashIndex = link.indexOf("#");
+        String fragment = link.substring(hashIndex + 1);
         if (fragment.contains("?"))
             fragment = fragment.substring(0, fragment.indexOf("?"));
-        String[] parts = link.split("/");
+        String[] parts = link.substring(0, hashIndex).split("/");
         if (parts.length != 3)
             throw new IllegalStateException("Invalid secret link");
         PublicKeyHash owner = PublicKeyHash.fromString(parts[1]);

--- a/src/peergos/shared/user/fs/SecretLink.java
+++ b/src/peergos/shared/user/fs/SecretLink.java
@@ -2,6 +2,7 @@ package peergos.shared.user.fs;
 
 import jsinterop.annotations.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.crypto.random.*;
 import peergos.shared.io.ipfs.bases.*;
 
 public class SecretLink {
@@ -41,5 +42,12 @@ public class SecretLink {
         PublicKeyHash owner = PublicKeyHash.fromString(parts[1]);
         long ref = Long.parseLong(parts[2]);
         return new SecretLink(owner, ref, fragment);
+    }
+
+    public static SecretLink create(PublicKeyHash owner, SafeRandom r) {
+        byte[] labelBytes = r.randomBytes(4);
+        long label = (labelBytes[0] & 0xFF) | ((labelBytes[1] & 0xFF) << 8) | ((labelBytes[2] & 0xFF) << 16) | (((labelBytes[3] & 0xFF) << 24) & 0xFFFFFFFFL);
+        String linkPassword = EncryptedCapability.createLinkPassword(r);
+        return new SecretLink(owner, label, linkPassword);
     }
 }

--- a/src/peergos/shared/user/fs/SecretLink.java
+++ b/src/peergos/shared/user/fs/SecretLink.java
@@ -26,6 +26,8 @@ public class SecretLink {
 
     @JsMethod
     public static SecretLink fromLink(String link) {
+        if (link.startsWith("/"))
+            link = link.substring(1);
         String[] parts = link.split("/");
         if (parts.length != 3)
             throw new IllegalStateException("Invalid secret link");

--- a/src/peergos/shared/user/fs/SecretLink.java
+++ b/src/peergos/shared/user/fs/SecretLink.java
@@ -8,16 +8,18 @@ public class SecretLink {
 
     public final PublicKeyHash owner;
     public final long label;
+    public final String linkPassword;
 
-    public SecretLink(PublicKeyHash owner, long label) {
+    public SecretLink(PublicKeyHash owner, long label, String linkPassword) {
         if (label <= 0)
             throw new IllegalStateException("Link labels must be positive!");
         this.owner = owner;
         this.label = label;
+        this.linkPassword = linkPassword;
     }
 
     public String toLink() {
-        return "secret/" + Multibase.Base.Base58BTC.prefix + owner.toBase58() + "/" + labelString();
+        return "secret/" + Multibase.Base.Base58BTC.prefix + owner.toBase58() + "/" + labelString() + "#" + linkPassword;
     }
 
     public String labelString() {
@@ -28,11 +30,14 @@ public class SecretLink {
     public static SecretLink fromLink(String link) {
         if (link.startsWith("/"))
             link = link.substring(1);
+        String fragment = link.substring(link.indexOf("#") + 1);
+        if (fragment.contains("?"))
+            fragment = fragment.substring(0, fragment.indexOf("?"));
         String[] parts = link.split("/");
         if (parts.length != 3)
             throw new IllegalStateException("Invalid secret link");
         PublicKeyHash owner = PublicKeyHash.fromString(parts[1]);
         long ref = Long.parseLong(parts[2]);
-        return new SecretLink(owner, ref);
+        return new SecretLink(owner, ref, fragment);
     }
 }

--- a/src/peergos/shared/user/fs/SecretLink.java
+++ b/src/peergos/shared/user/fs/SecretLink.java
@@ -1,0 +1,36 @@
+package peergos.shared.user.fs;
+
+import jsinterop.annotations.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.bases.*;
+
+public class SecretLink {
+
+    public final PublicKeyHash owner;
+    public final long label;
+
+    public SecretLink(PublicKeyHash owner, long label) {
+        if (label <= 0)
+            throw new IllegalStateException("Link labels must be positive!");
+        this.owner = owner;
+        this.label = label;
+    }
+
+    public String toLink() {
+        return "secret/" + Multibase.Base.Base58BTC.prefix + owner.toBase58() + "/" + labelString();
+    }
+
+    public String labelString() {
+        return "" + label;
+    }
+
+    @JsMethod
+    public static SecretLink fromLink(String link) {
+        String[] parts = link.split("/");
+        if (parts.length != 3)
+            throw new IllegalStateException("Invalid secret link");
+        PublicKeyHash owner = PublicKeyHash.fromString(parts[1]);
+        long ref = Long.parseLong(parts[2]);
+        return new SecretLink(owner, ref);
+    }
+}

--- a/src/peergos/shared/user/fs/SecretLinkTarget.java
+++ b/src/peergos/shared/user/fs/SecretLinkTarget.java
@@ -27,7 +27,7 @@ public class SecretLinkTarget implements Cborable {
     @Override
     public CborObject toCbor() {
         SortedMap<String, Cborable> state = new TreeMap<>();
-        state.put("cap", cap.payload.toCbor());
+        state.put("cap", cap.toCbor());
         expiry.ifPresent(e -> state.put("expiry", new CborObject.CborLong(e.toEpochSecond(ZoneOffset.UTC))));
         maxRetrievals.ifPresent(m -> state.put("max", new CborObject.CborLong(m)));
         return CborObject.CborMap.build(state);
@@ -37,7 +37,7 @@ public class SecretLinkTarget implements Cborable {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Invalid cbor for SecretLinkTarget! " + cbor);
         CborObject.CborMap m = (CborObject.CborMap) cbor;
-        return new SecretLinkTarget(new EncryptedCapability(m.get("cap", CipherText::fromCbor)),
+        return new SecretLinkTarget(m.get("cap", EncryptedCapability::fromCbor),
                 m.getOptionalLong("expiry").map(l -> LocalDateTime.ofEpochSecond(l, 0, ZoneOffset.UTC)),
                 m.getOptionalLong("max").map(Long::intValue));
     }

--- a/src/peergos/shared/user/fs/SecretLinkTarget.java
+++ b/src/peergos/shared/user/fs/SecretLinkTarget.java
@@ -1,0 +1,44 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.*;
+import peergos.shared.cbor.*;
+import peergos.shared.crypto.*;
+
+import java.time.*;
+import java.util.*;
+import java.util.concurrent.*;
+
+public class SecretLinkTarget implements Cborable {
+
+    public final EncryptedCapability cap;
+    public final Optional<LocalDateTime> expiry;
+    public final Optional<Integer> maxRetrievals;
+
+    public SecretLinkTarget(EncryptedCapability cap, Optional<LocalDateTime> expiry, Optional<Integer> maxRetrievals) {
+        this.cap = cap;
+        this.expiry = expiry;
+        this.maxRetrievals = maxRetrievals;
+    }
+
+    public CompletableFuture<AbsoluteCapability> decrypt(String label, String password, Crypto c) {
+        return cap.decryptFromPassword(label, password, c);
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("cap", cap.payload.toCbor());
+        expiry.ifPresent(e -> state.put("expiry", new CborObject.CborLong(e.toEpochSecond(ZoneOffset.UTC))));
+        maxRetrievals.ifPresent(m -> state.put("max", new CborObject.CborLong(m)));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static SecretLinkTarget fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for SecretLinkTarget! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new SecretLinkTarget(new EncryptedCapability(m.get("cap", CipherText::fromCbor)),
+                m.getOptionalLong("expiry").map(l -> LocalDateTime.ofEpochSecond(l, 0, ZoneOffset.UTC)),
+                m.getOptionalLong("max").map(Long::intValue));
+    }
+}


### PR DESCRIPTION
This implements a brand new, much better design for secret links. 

Current secret links are pure capabilities in the URL. This means revoking them requires rotating all the keys which is expensive. They are also very long, e.g. https://peergos.net/#%7B%22secretLink%22:true%2c%22link%22:%22#6MDZhRRPT4ugkJuUfcWtaZodN5QYzkZKJtHpDHomFJrVhNSZysiFYimpgtcA2F/6MDZhRRPT4ugkJuUfcRzRbPpFimcBNJx2N9TJDnL4W3ETYhwdsWdvgCkXkwipF/FCYSFhpQ1xD2cydr6CFQ6UwFkgB82pWReAUzKVDxe4KA/5Pf7SvCG1mMtui2aPd9F3SH2wdwsPro1GxTa7VfxkWrj9XQGAUB%22%2c%22open%22:true%2c%22path%22:%22/demo/%22%7D

The new secret links require the assistance of your home server (or a mirror). The capability that was in the URL before is now encrypted and stored in a new champ on the identity writer data. There is a new server API to lookup a secret link and return the ciphertext. This is then decrypted locally using the hash in the URL and optionally an additional password supplied by the user. 

This means the URLs can be much shorter (4x), e.g. https://your-domain/secret/z59vuwzfFDoy1Mya69m7j1nZHL7hH4yLpAN7qKQusEUREveNVJifs9R/1368969#cWNWXq9jPahK

The new champ includes the mirror bat in its root block so the champ itself is not public, meaning the number of secret links you have is not revealed to anyone but your server and mirrors. 

Because we are using the server, we can get it to enforce expiry times or n-use links. Revoking these links is instant because you just need to delete the mapping from the champ. We also allow writable secret links, with a suitable warning that holders of the link could fill your space quota (until we implement [subquotas](https://github.com/Peergos/Peergos/issues/385)).

If you migrate to another server, your links come with you and all pre-existing secret links will continue to work. There is no limit to the number of links you can create, because they are just normal blocks that contribute to your space usage. 

The password based encryption on each link is designed to take 100 years to brute force if you have 1,000,000 GPUs, each of which can do 1M scrypt hashes per second.