### PR TITLE
Local S3 block buffer for small blocks

### DIFF
--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -227,8 +227,9 @@ public class Builder {
                 TransactionalIpfs p2pBlockRetriever = new TransactionalIpfs(ipfs, transactions, authoriser, ipfs.id().join(), hasher);
 
                 FileBlockCache cborCache = new FileBlockCache(a.fromPeergosDir("block-cache-dir", "block-cache"), 1024 * 1024 * 1024L);
+                FileBlockBuffer blockBuffer = new FileBlockBuffer(a.fromPeergosDir("s3-block-buffer-dir", "block-buffer"));
                 S3BlockStorage s3 = new S3BlockStorage(config, ipfs.ids().join(), props, transactions, authoriser,
-                        meta, cborCache, hasher, p2pBlockRetriever, ipfs);
+                        meta, cborCache, blockBuffer, hasher, p2pBlockRetriever, ipfs);
                 s3.updateMetadataStoreIfEmpty();
                 return new LocalIpnsStorage(s3, ids);
             } else if (enableGC) {
@@ -255,8 +256,9 @@ public class Builder {
                 DeletableContentAddressedStorage.HTTP bloomTarget = new DeletableContentAddressedStorage.HTTP(bloomApiTarget, false, hasher);
 
                 FileBlockCache cborCache = new FileBlockCache(a.fromPeergosDir("block-cache-dir", "block-cache"), 10 * 1024 * 1024 * 1024L);
+                FileBlockBuffer blockBuffer = new FileBlockBuffer(a.fromPeergosDir("s3-block-buffer-dir", "block-buffer"));
                 S3BlockStorage s3 = new S3BlockStorage(config, ipfs.ids().join(), props, transactions, authoriser,
-                        meta, cborCache, hasher, p2pBlockRetriever, bloomTarget);
+                        meta, cborCache, blockBuffer, hasher, p2pBlockRetriever, bloomTarget);
                 s3.updateMetadataStoreIfEmpty();
                 return new LocalIpnsStorage(s3, ids);
             } else {

--- a/src/peergos/server/storage/BlockBuffer.java
+++ b/src/peergos/server/storage/BlockBuffer.java
@@ -1,0 +1,21 @@
+package peergos.server.storage;
+
+import peergos.shared.io.ipfs.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.function.*;
+
+public interface BlockBuffer {
+
+    CompletableFuture<Boolean> put(Cid hash, byte[] data);
+
+    CompletableFuture<Optional<byte[]>> get(Cid hash);
+
+    boolean hasBlock(Cid hash);
+
+    CompletableFuture<Boolean> delete(Cid hash);
+
+    void applyToAll(Consumer<Cid> action);
+
+}

--- a/src/peergos/server/storage/FileBlockBuffer.java
+++ b/src/peergos/server/storage/FileBlockBuffer.java
@@ -1,0 +1,112 @@
+package peergos.server.storage;
+
+import peergos.server.util.Logging;
+import peergos.shared.io.ipfs.*;
+import peergos.shared.storage.*;
+import peergos.shared.util.*;
+
+import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.*;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
+import java.util.logging.*;
+
+/** A local file based block cache LRU
+ *
+ */
+public class FileBlockBuffer implements BlockBuffer {
+    private static final Logger LOG = Logging.LOG();
+    private final Path root;
+    public FileBlockBuffer(Path root) {
+        this.root = root;
+        File rootDir = root.toFile();
+        if (!rootDir.exists()) {
+            final boolean mkdirs = root.toFile().mkdirs();
+            if (!mkdirs)
+                throw new IllegalStateException("Unable to create directory " + root);
+        }
+        if (!rootDir.isDirectory())
+            throw new IllegalStateException("File store path must be a directory! " + root);
+    }
+
+    private Path getFilePath(Cid h) {
+        String key = DirectS3BlockStore.hashToKey(h);
+
+        Path path = PathUtil.get("")
+                .resolve(key.substring(key.length() - 3, key.length() - 1))
+                .resolve(key + ".data");
+        return path;
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> get(Cid hash) {
+        try {
+            if (hash.isIdentity())
+                return Futures.of(Optional.of(hash.getHash()));
+            Path path = getFilePath(hash);
+            File file = root.resolve(path).toFile();
+            if (! file.exists()){
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+            try (DataInputStream din = new DataInputStream(new BufferedInputStream(new FileInputStream(file)))) {
+                byte[] block = Serialize.readFully(din);
+                return CompletableFuture.completedFuture(Optional.of(block));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean hasBlock(Cid hash) {
+        Path path = getFilePath(hash);
+        File file = root.resolve(path).toFile();
+        return file.exists();
+    }
+
+    public CompletableFuture<Boolean> put(Cid hash, byte[] data) {
+        try {
+            Path filePath = getFilePath(hash);
+            Path target = root.resolve(filePath);
+            Path parent = target.getParent();
+            File parentDir = parent.toFile();
+
+            if (! parentDir.exists())
+                Files.createDirectories(parent);
+
+            for (Path someParent = parent; !someParent.equals(root); someParent = someParent.getParent()) {
+                File someParentFile = someParent.toFile();
+                if (! someParentFile.canWrite()) {
+                    final boolean b = someParentFile.setWritable(true, false);
+                    if (!b)
+                        throw new IllegalStateException("Could not make " + someParent + ", ancestor of " + parentDir + " writable");
+                }
+            }
+            Files.write(target, data, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+            return Futures.of(true);
+        } catch (IOException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    public CompletableFuture<Optional<Integer>> getSize(Multihash h) {
+        Path path = getFilePath((Cid)h);
+        File file = root.resolve(path).toFile();
+        return CompletableFuture.completedFuture(file.exists() ? Optional.of((int) file.length()) : Optional.empty());
+    }
+
+    public CompletableFuture<Boolean> delete(Cid h) {
+        Path path = getFilePath(h);
+        File file = root.resolve(path).toFile();
+        if (file.exists())
+            file.delete();
+        return Futures.of(true);
+    }
+
+    public void applyToAll(Consumer<Cid> processor) {
+        FileContentAddressedStorage.getFilesRecursive(root, processor);
+    }
+}

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -266,7 +266,7 @@ public class BufferedStorage extends DelegatingStorage {
         List<List<OpLog.BlockWrite>> smallRawBatches = new ArrayList<>();
 
         int cborCount = 0, rawcount = 0, smallRawCount = 0;
-        int smallBlockMax = DirectS3BlockStore.MIN_SMALL_BLOCK_SIZE;
+        int smallBlockMax = DirectS3BlockStore.MAX_SMALL_BLOCK_SIZE;
         if (! cborBatches.isEmpty() && ! cborBatches.get(cborBatches.size() - 1).isEmpty())
             cborBatches.add(new ArrayList<>());
         if (! rawBatches.isEmpty() && ! rawBatches.get(rawBatches.size() - 1).isEmpty())

--- a/src/peergos/shared/storage/DirectS3BlockStore.java
+++ b/src/peergos/shared/storage/DirectS3BlockStore.java
@@ -20,7 +20,7 @@ import java.util.stream.*;
 
 public class DirectS3BlockStore implements ContentAddressedStorage {
 
-    public static final int MIN_SMALL_BLOCK_SIZE = 100 * 1024;
+    public static final int MAX_SMALL_BLOCK_SIZE = 100 * 1024;
 
     private final boolean directWrites, publicReads, authedReads;
     private final Optional<String> basePublicReadUrl;
@@ -128,7 +128,7 @@ public class DirectS3BlockStore implements ContentAddressedStorage {
                                                ProgressConsumer<Long> progressCounter) {
         //  raw blocks smaller than 100 KiB are written directly to server rather than S3 (if S3 blockstore)
         // otherwise we suffer disproportionally from latency to S3 from the client
-        if (blocks.stream().allMatch(b -> b.length < MIN_SMALL_BLOCK_SIZE))
+        if (blocks.stream().allMatch(b -> b.length < MAX_SMALL_BLOCK_SIZE))
             return fallback.putRaw(owner, writer, signatures, blocks, tid, progressCounter);
         return onOwnersNode(owner).thenCompose(ownersNode -> {
             if (ownersNode && directWrites) {


### PR DESCRIPTION
Currently small S3 writes are frequently taking >4s from the server. This is ridiculous.

Use a local disk based buffer to persist blocks before flushing to S3 in the background. This should make small block writes 100x faster.