### PR TITLE
Optimise file move

### DIFF
--- a/src/peergos/gwt/emu/java/nio/file/Path.java
+++ b/src/peergos/gwt/emu/java/nio/file/Path.java
@@ -53,6 +53,10 @@ public class Path {
         return new Path(pathString + "/" + other);
     }
 
+    public Path relativize(Path other) {
+        return new Path(pathString.substring(other.pathString.length()));
+    }
+
     public Path resolve(Path other) {
         return resolve(other.pathString);
     }

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -909,7 +909,7 @@ public class MultiUserTests {
         Path destSubdirPath = PathUtil.get(u1.username, destinationSubdirName);
         FileWrapper destSubdir = u1.getByPath(destSubdirPath).get().get();
 
-        theFile.moveTo(destSubdir, theParent, filePath, u1).join();
+        theFile.moveTo(destSubdir, theParent, filePath, u1, () -> Futures.of(true)).join();
 
         //old copy sharedWith entries should be removed
         Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(filePath).join().get(sharedWithAccess);
@@ -919,9 +919,9 @@ public class MultiUserTests {
         theFile = u1.getByPath(filePath).get().get();
         cap = theFile.getPointer().capability;
 
-        //new copy sharedWith entry should also be empty
+        //new copy sharedWith entry should not be empty
         Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(filePath).join().get(sharedWithAccess);
-        Assert.assertTrue("file shared", sharedWriteAccessWithNewCopy.isEmpty());
+        Assert.assertTrue("file shared", ! sharedWriteAccessWithNewCopy.isEmpty());
     }
 
     @Test
@@ -972,7 +972,7 @@ public class MultiUserTests {
         Path destSubdirPath = PathUtil.get(u1.username, destinationSubdirName);
         FileWrapper destSubdir = u1.getByPath(destSubdirPath).get().get();
 
-        theDir.moveTo(destSubdir, theParent, dirPath, u1);
+        theDir.moveTo(destSubdir, theParent, dirPath, u1, () -> Futures.of(true));
 
         //old copy sharedWith entries should be removed
         Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(dirPath).join().get(sharedWithAccess);
@@ -982,9 +982,9 @@ public class MultiUserTests {
         theDir = u1.getByPath(dirPath).get().get();
         cap = theDir.getPointer().capability;
 
-        //new copy sharedWith entry should also be empty
+        //new copy sharedWith entry should not be empty
         Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(dirPath).join().get(sharedWithAccess);
-        Assert.assertTrue("directory shared", sharedWriteAccessWithNewCopy.isEmpty());
+        Assert.assertTrue("directory shared", ! sharedWriteAccessWithNewCopy.isEmpty());
     }
 
     @Test

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -22,6 +22,7 @@ import java.io.*;
 import java.nio.file.*;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 import java.util.stream.*;
 
 import static org.junit.Assert.assertTrue;
@@ -927,21 +928,28 @@ public class MultiUserTests {
     @Test
     public void moveToDirectorySharedWith()
             throws Exception {
-        //read access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> readAccessSharingFunction =
+        // Secret link
+        TriFunction<UserContext, List<UserContext>, Path, Object> linkSharingFunction =
                 (u1, u2List, filePath) ->
-                        u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
+                        u1.createSecretLink(filePath.toString(), false, Optional.empty(), Optional.empty(), "", false).join();
 
-        moveToDirectorySharedWith(readAccessSharingFunction, SharedWithCache.Access.READ);
-        //write access
-        TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> writeAccessSharingFunction =
+        moveToDirectorySharedWith(linkSharingFunction, s -> ! s.links.isEmpty());
+
+        //read access
+        TriFunction<UserContext, List<UserContext>, Path, Object> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
-                        u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
-        moveToDirectorySharedWith(writeAccessSharingFunction, SharedWithCache.Access.WRITE);
+                        u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet())).join();
+
+        moveToDirectorySharedWith(readAccessSharingFunction, s -> ! s.readAccess.isEmpty());
+        //write access
+        TriFunction<UserContext, List<UserContext>, Path, Object> writeAccessSharingFunction =
+                (u1, u2List, filePath) ->
+                        u1.shareWriteAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet())).join();
+        moveToDirectorySharedWith(writeAccessSharingFunction, s -> ! s.writeAccess.isEmpty());
     }
 
-    private void moveToDirectorySharedWith(TriFunction<UserContext, List<UserContext>, Path, CompletableFuture<Snapshot>> shareFunction,
-                                      SharedWithCache.Access sharedWithAccess)
+    private void moveToDirectorySharedWith(TriFunction<UserContext, List<UserContext>, Path, Object> shareFunction,
+                                           Predicate<FileSharedWithState> isShared)
             throws Exception {
         UserContext u1 = PeergosNetworkUtils.ensureSignedUp(random(), "a", network.clear(), crypto);
 
@@ -964,9 +972,6 @@ public class MultiUserTests {
         FileWrapper theDir = u1.getByPath(dirPath).get().get();
         Path parentPath = PathUtil.get(u1.username);
         FileWrapper theParent = u1.getByPath(parentPath).get().get();
-        AbsoluteCapability cap = theDir.getPointer().capability;
-        Set<String> sharedWriteAccessWithBefore = u1.sharedWith(dirPath).join().get(sharedWithAccess);
-        Assert.assertTrue("directory shared", ! sharedWriteAccessWithBefore.isEmpty());
 
         //move directory
         Path destSubdirPath = PathUtil.get(u1.username, destinationSubdirName);
@@ -975,16 +980,14 @@ public class MultiUserTests {
         theDir.moveTo(destSubdir, theParent, dirPath, u1, () -> Futures.of(true)).join();
 
         //old copy sharedWith entries should be removed
-        Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(dirPath).join().get(sharedWithAccess);
-        Assert.assertTrue("directory shared", sharedWriteAccessWithOriginal.isEmpty());
+        FileSharedWithState shared = u1.sharedWith(dirPath).join();
+        Assert.assertTrue("original directory not shared", ! isShared.test(shared));
 
         dirPath = PathUtil.get(u1.username, destinationSubdirName, subdirName);
-        theDir = u1.getByPath(dirPath).get().get();
-        cap = theDir.getPointer().capability;
 
         //new copy sharedWith entry should not be empty
-        Set<String> sharedWriteAccessWithNewCopy = u1.sharedWith(dirPath).join().get(sharedWithAccess);
-        Assert.assertTrue("directory shared", ! sharedWriteAccessWithNewCopy.isEmpty());
+        FileSharedWithState newShare = u1.sharedWith(dirPath).join();
+        Assert.assertTrue("new directory shared", isShared.test(newShare));
     }
 
     @Test

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -972,7 +972,7 @@ public class MultiUserTests {
         Path destSubdirPath = PathUtil.get(u1.username, destinationSubdirName);
         FileWrapper destSubdir = u1.getByPath(destSubdirPath).get().get();
 
-        theDir.moveTo(destSubdir, theParent, dirPath, u1, () -> Futures.of(true));
+        theDir.moveTo(destSubdir, theParent, dirPath, u1, () -> Futures.of(true)).join();
 
         //old copy sharedWith entries should be removed
         Set<String> sharedWriteAccessWithOriginal = u1.sharedWith(dirPath).join().get(sharedWithAccess);

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -142,6 +142,37 @@ public class SharedWithState implements Cborable {
         return new SharedWithState(newReads, newWrites, links);
     }
 
+    public SharedWithState addAll(SharedWithState other) {
+        Map<String, Set<String>> newReads = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {
+            newReads.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+        for (Map.Entry<String, Set<String>> newRead : other.readShares.entrySet()) {
+            newReads.putIfAbsent(newRead.getKey(), new HashSet<>());
+            newReads.get(newRead.getKey()).addAll(newRead.getValue());
+        }
+
+        Map<String, Set<String>> newWrites = new HashMap<>();
+        for (Map.Entry<String, Set<String>> e : writeShares.entrySet()) {
+            newWrites.put(e.getKey(), new HashSet<>(e.getValue()));
+        }
+        for (Map.Entry<String, Set<String>> newWrite : other.writeShares.entrySet()) {
+            newWrites.putIfAbsent(newWrite.getKey(), new HashSet<>());
+            newWrites.get(newWrite.getKey()).addAll(newWrite.getValue());
+        }
+
+        Map<String, Set<LinkProperties>> newLinks = new HashMap<>();
+        links.forEach((k, v) -> {
+            newLinks.put(k, new HashSet<>(v));
+        });
+        for (Map.Entry<String, Set<LinkProperties>> newLink : other.links.entrySet()) {
+            newLinks.putIfAbsent(newLink.getKey(),  new HashSet<>());
+            newLinks.get(newLink.getKey()).addAll(newLink.getValue());
+        }
+
+        return new SharedWithState(newReads, newWrites, newLinks);
+    }
+
     public SharedWithState remove(SharedWithCache.Access access, String filename, Set<String> names) {
         Map<String, Set<String>> newReads = new HashMap<>();
         for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {

--- a/src/peergos/shared/user/SharedWithState.java
+++ b/src/peergos/shared/user/SharedWithState.java
@@ -55,7 +55,7 @@ public class SharedWithState implements Cborable {
     }
 
     public Optional<SharedWithState> filter(String childName) {
-        if (! readShares.containsKey(childName) && ! writeShares.containsKey(childName))
+        if (! readShares.containsKey(childName) && ! writeShares.containsKey(childName) && ! links.containsKey(childName))
             return Optional.empty();
         Map<String, Set<String>> newReads = new HashMap<>();
         for (Map.Entry<String, Set<String>> e : readShares.entrySet()) {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1712,10 +1712,73 @@ public class FileWrapper {
     }
 
     @JsMethod
-    public CompletableFuture<Boolean> moveTo(FileWrapper target, FileWrapper parent, Path ourPath, UserContext context) {
-        return copyTo(target, context)
-                .thenCompose(fw -> remove(parent, ourPath, context))
-                .thenApply(newAccess -> true);
+    public CompletableFuture<Boolean> moveTo(FileWrapper target, FileWrapper parent, Path ourPath, UserContext context, Supplier<CompletableFuture<Boolean>> preserveAccess) {
+        ensureUnmodified();
+
+        if (! parent.isWritable())
+            return Futures.errored(new IllegalStateException("Cannot move file without write access to parent"));
+        if (! target.isDirectory()) {
+            return Futures.errored(new IllegalStateException("CopyTo target " + target + " must be a directory"));
+        }
+
+        Optional<BatId> targetMirrorBatId = target.mirrorBatId()
+                .or(() -> target.owner().equals(context.signer.publicKeyHash) ?
+                        context.mirrorBatId() :
+                        Optional.empty());
+
+        NetworkAccess net = context.network;
+        Hasher hasher = context.crypto.hasher;
+
+        return net.synchronizer.applyComplexUpdate(owner(), signingPair(),
+                (v, c) -> context.getPublicFile(ourPath).thenApply(opt ->  opt.isPresent())
+                        .thenCompose(isPublic -> context.sharedWithCache.getAllDescendantShares(ourPath, v)
+                                .thenCompose(shared -> {
+                                    return (isPublic || ! owner().equals(target.owner()) ?
+                                            Futures.of(false) :
+                                            shared.isEmpty() // fast path
+                                                    ? Futures.of(true) : preserveAccess.get())
+                                            .thenCompose(keepAccess -> {
+                                                if (keepAccess) {
+                                                    // just update parent and child pointers, no need to re-upload, rotate keys etc.
+                                                    boolean differentWriter = !target.writer().equals(writer());
+                                                    RelativeCapability newParentLink = new RelativeCapability(differentWriter ?
+                                                            Optional.of(parent.writer()) :
+                                                            Optional.empty(),
+                                                            parent.getLocation().getMapKey(), parent.writableFilePointer().bat, parent.getParentKey(), Optional.empty());
+                                                    CryptreeNode newMetadata = pointer.fileAccess.withParentLink(getParentKey(), newParentLink);
+                                                    RelativeCapability ourNewcap = target.writableFilePointer().relativise(pointer.capability);
+                                                    return IpfsTransaction.call(owner(),
+                                                            tid -> target.getPath(net).thenCompose(newPath -> v.withWriter(owner(), target.writer(), net)
+                                                                    .thenCompose(w -> net.uploadChunk(w, c, newMetadata, owner(), pointer.capability.getMapKey(), signingPair(), tid))
+                                                                    .thenCompose(v2 -> target.pointer.fileAccess.addChildrenAndCommit(v2, c,
+                                                                            Arrays.asList(new NamedRelativeCapability(getName(), ourNewcap)),
+                                                                            target.writableFilePointer(), target.signingPair(), targetMirrorBatId, net, context.crypto))
+                                                                    .thenCompose(v3 -> parent.pointer.fileAccess
+                                                                            .removeChildren(v3, c, Arrays.asList(getPointer().capability), parent.writableFilePointer(),
+                                                                                    parent.entryWriter, net, context.crypto.random, hasher))
+                                                                    .thenCompose(v4 -> shared.isEmpty() ? Futures.of(v4) : context.sharedWithCache.clearSharedWith(ourPath, v4, c, net))
+                                                                    .thenCompose(v5 -> shared.isEmpty() ? Futures.of(v5) : context.sharedWithCache.addAllSharedWith(shared.entrySet().stream()
+                                                                            .collect(Collectors.toMap(e ->  PathUtil.get(newPath).resolve(e.getKey().relativize(ourPath)), e -> e.getValue())), v5, c, net))),
+                                                            net.dhtClient);
+
+                                                }
+                                                return version.withWriter(owner(), writer(), net)
+                                                        .thenCompose(both -> copyTo(target, this.props.thumbnail, targetMirrorBatId, net, context.crypto, both, c))
+                                                        .thenCompose(v2 -> version.withWriter(owner(), parent.writer(), net)
+                                                                .thenCompose(v3 -> parent.pointer.fileAccess
+                                                                        .removeChildren(v2, c, Arrays.asList(getPointer().capability), parent.writableFilePointer(),
+                                                                                parent.entryWriter, net, context.crypto.random, hasher))
+                                                                .thenCompose(v4 -> IpfsTransaction.call(owner(),
+                                                                                tid -> FileWrapper.deleteAllChunks(
+                                                                                        isLink() ?
+                                                                                                (WritableAbsoluteCapability) getLinkPointer().capability :
+                                                                                                writableFilePointer(),
+                                                                                        parent.signingPair(), tid, hasher, net, v4, c), net.dhtClient)
+                                                                        .thenCompose(v5 -> context.isSecretLink() ? Futures.of(v5) :
+                                                                                context.sharedWithCache.clearSharedWith(ourPath, v5, c, net)))
+                                                        );
+                                            });
+                                }))).thenApply(s -> true);
     }
 
     @JsMethod

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1742,12 +1742,12 @@ public class FileWrapper {
                                                 // TODO optimise different parent writer case by correcting owned keys
                                                 if (keepAccess && ! differentParentWriter) {
                                                     // just update parent and child pointers, no need to re-upload, rotate keys etc.
-                                                    boolean differentWriter = !target.writer().equals(writer());
+                                                    boolean differentWriter = ! target.writer().equals(writer());
                                                     boolean ourFile = target.owner().equals(context.signer.publicKeyHash);
                                                     RelativeCapability newParentLink = new RelativeCapability(differentWriter ?
-                                                            Optional.of(parent.writer()) :
+                                                            Optional.of(target.writer()) :
                                                             Optional.empty(),
-                                                            parent.getLocation().getMapKey(), parent.writableFilePointer().bat, parent.getParentKey(), Optional.empty());
+                                                            target.getLocation().getMapKey(), target.writableFilePointer().bat, target.getParentKey(), Optional.empty());
                                                     CryptreeNode newMetadata = pointer.fileAccess.withParentLink(getParentKey(), newParentLink);
                                                     RelativeCapability ourNewcap = target.writableFilePointer().relativise(pointer.capability);
                                                     return IpfsTransaction.call(owner(),


### PR DESCRIPTION
Currently moving a file first copies it then deletes the original. This  means downloading the file, re-encrypting it and uploading it, then deleting the original. This is to ensure no one with access to original keeps access to the new version. This is no longer necessary given that we track secret links. 

We  can check if a file/dir has been shared (or confirm that maintain access is ok) and then just update the parent pointers without touching the data blocks  at all. 

This makes moving a 1gb  file on localhost drop from >5.5  minutes to <1s, or >300x faster.