### PR TITLE
Fix deleting a write shared folder with a sub folder

### DIFF
--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -570,6 +570,7 @@ public class MultiUserTests {
         FileWrapper subdir = u1.getByPath(subdirPath).get().get();
         FileWrapper uploaded = subdir.uploadOrReplaceFile(filename, file1Reader, data1.length,
                 u1.network, u1.crypto, l -> {}).get();
+        u1.getByPath(subdirPath).get().get().mkdir("another-dir",  u1.network,false, u1.mirrorBatId(), crypto).join();
 
         Path dirPath = PathUtil.get(u1.username, subdirName);
         u1.shareWriteAccessWith(dirPath, userContexts.stream().map(u -> u.username).collect(Collectors.toSet())).join();
@@ -600,7 +601,7 @@ public class MultiUserTests {
 
         Set<String> sharedWriteAccessWithBefore = u1.sharedWith(dirPath).join().get(SharedWithCache.Access.WRITE);
         Assert.assertTrue("file shared", ! sharedWriteAccessWithBefore.isEmpty());
-
+        System.out.println("Start DELETE");
         theDir.remove(parentFolder, dirPath, u1).get();
         Optional<FileWrapper> removedFile = u1.getByPath(dirPath).get();
         Assert.assertTrue("dir removed", removedFile.isEmpty());

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -239,6 +239,11 @@ public class MultiUserTests {
     }
 
     @Test
+    public void deleteEmailApp() {
+        PeergosNetworkUtils.deleteEmailApp(network, random);
+    }
+
+    @Test
     public void chatMultipleInvites() {
         PeergosNetworkUtils.chatMultipleInvites(network, random);
     }

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -1871,6 +1871,24 @@ public class PeergosNetworkUtils {
         controllerA = msgA.sendMessage(controllerA, msg2).join();
     }
 
+    public static void deleteEmailApp(NetworkAccess network, Random random) {
+        CryptreeNode.setMaxChildLinkPerBlob(10);
+
+        String password = "notagoodone";
+        UserContext user = PeergosNetworkUtils.ensureSignedUp("a-" + generateUsername(random), password, network, crypto);
+        UserContext email = PeergosNetworkUtils.ensureSignedUp("email-"+ generateUsername(random), password, network, crypto);
+
+        App emailApp = App.init(user, "email").join();
+        EmailClient client = EmailClient.load(emailApp, crypto).join();
+        client.connectToBridge(user, email.username).join();
+
+        Path path = new File(user.username + "/.apps/email").toPath();
+        FileWrapper parentDir = user.getByPath(path.getParent().toString()).join().get();
+        FileWrapper appDir = user.getByPath(path.toString()).join().get();
+        FileWrapper parent = appDir.remove(parentDir, path, user).join();
+        Assert.assertTrue("App removal worked", parent != null);
+    }
+
     public static void email(NetworkAccess network, Random random) {
         CryptreeNode.setMaxChildLinkPerBlob(10);
 

--- a/src/peergos/shared/hamt/Champ.java
+++ b/src/peergos/shared/hamt/Champ.java
@@ -518,7 +518,9 @@ public class Champ<V extends Cborable> implements Cborable {
                     }
                 }
             }
-            return CompletableFuture.completedFuture(new Pair<>(this, ourHash));
+            CompletableFuture<Pair<Champ<V>, Multihash>> err = new CompletableFuture<>();
+            err.completeExceptionally(new CasException(Optional.empty(), expected));
+            return err;
         } else if (nodeMap.get(bitpos)) { // node (not value)
             return getChild(owner, hash, depth, bitWidth, storage)
                     .thenCompose(child -> child.right.get().remove(owner, writer, key, hash, depth + 1, expected,

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -53,7 +53,7 @@ public class MutableTreeImpl implements MutableTree {
                 ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c) :
                 ChampWrapper.create(owner, writer, hasher, tid, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
         ).thenCompose(tree -> tree.put(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), new CborObject.CborMerkleLink(value), Optional.empty(), tid))
-                .thenApply(newRoot -> LOGGING ? log(newRoot, "TREE.put (" + ArrayOps.bytesToHex(mapKey)
+                .thenApply(newRoot -> LOGGING ? log(newRoot, "TREE.put " + writer.publicKeyHash + " :== (" + ArrayOps.bytesToHex(mapKey)
                         + ", " + value + ") => CAS(" + base.tree + ", " + newRoot + ")") : newRoot)
                 .thenApply(base::withChamp);
     }
@@ -80,8 +80,8 @@ public class MutableTreeImpl implements MutableTree {
             throw new IllegalStateException("Tree root not present!");
         return ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
                 .thenCompose(tree -> tree.remove(owner, writer, mapKey, existing.map(CborObject.CborMerkleLink::new), Optional.empty(), tid))
-                .thenApply(pair -> LOGGING ? log(pair, "TREE.rm ("
-                        + ArrayOps.bytesToHex(mapKey) + "  => " + pair) : pair)
+                .thenApply(root -> LOGGING ? log(root, "TREE.rm " + writer.publicKeyHash + " :== ("
+                        + ArrayOps.bytesToHex(mapKey) + ", " + existing + ") CAS(" + base.tree.get() + ", " + root + ")") : root)
                 .thenApply(newTreeRoot -> base.withChamp(newTreeRoot));
     }
 }

--- a/src/peergos/shared/user/OwnedKeyChamp.java
+++ b/src/peergos/shared/user/OwnedKeyChamp.java
@@ -77,7 +77,9 @@ public class OwnedKeyChamp {
                                                TransactionId tid) {
         byte[] keyBytes = keyToBytes(key);
         return champ.get(keyBytes)
-                .thenCompose(existing -> champ.remove(owner, writer, keyBytes, existing, Optional.empty(), tid));
+                .thenCompose(existing -> existing.isPresent() ?
+                        champ.remove(owner, writer, keyBytes, existing, Optional.empty(), tid) :
+                        Futures.of(champ.getRoot()));
     }
 
     public CompletableFuture<Boolean> contains(PublicKeyHash ownedKey) {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1989,7 +1989,7 @@ public class FileWrapper {
                                             .thenCompose(deletedVersion -> {
                                                 return chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
                                                         currentCap.getMapKey(), currentCap.bat, hasher).thenCompose(nextChunkMapKeyAndBat ->
-                                                        deleteAllChunks(currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right), signer, tid, hasher,
+                                                        deleteAllChunks(currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right), ourSigner, tid, hasher,
                                                                 network, deletedVersion, committer));
                                             }))
                                     .thenCompose(updatedVersion -> {
@@ -1998,7 +1998,7 @@ public class FileWrapper {
                                         return chunk.getDirectChildrenCapabilities(currentCap, updatedVersion, network).thenCompose(childCaps ->
                                                 Futures.reduceAll(childCaps,
                                                         updatedVersion,
-                                                        (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, signer,
+                                                        (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, ourSigner,
                                                                 tid, hasher, network, v, committer),
                                                         (x, y) -> y));
                                     })


### PR DESCRIPTION
The parent signer rather than the new signer was passed to the recursive delete of a write shared folder. 

Also make deleting an absent value from a champ an error. 