### PR TITLE
Peergos sync client

### DIFF
--- a/src/peergos/server/DirectorySync.java
+++ b/src/peergos/server/DirectorySync.java
@@ -109,7 +109,18 @@ public class DirectorySync {
                     copyFileDiffAndTruncate(localDir.toPath().resolve(local.relPath).toFile(), local, remoteDir.toPath().resolve(local.relPath).toFile(), remote);
                     return List.of(local);
                 }
-            } else { // concurrent change, rename one
+            } else { // concurrent change/deletion
+                if (local == null && remote == null) // concurrent deletes
+                    return Collections.emptyList();
+                if (local == null) { // local delete, copy changed remote
+                    copyFileDiffAndTruncate(remoteDir.toPath().resolve(remote.relPath).toFile(), remote, localDir.toPath().resolve(remote.relPath).toFile(), local);
+                    return List.of(remote);
+                }
+                if (remote == null) { // remote delete, copy changed local
+                    copyFileDiffAndTruncate(localDir.toPath().resolve(local.relPath).toFile(), local, remoteDir.toPath().resolve(local.relPath).toFile(), remote);
+                    return List.of(local);
+                }
+                // concurrent change, rename one sync the other
                 FileState renamed = renameOnConflict(localDir.toPath().resolve(local.relPath).toFile(), local);
                 copyFileDiffAndTruncate(remoteDir.toPath().resolve(remote.relPath).toFile(), remote, localDir.toPath().resolve(remote.relPath).toFile(), local);
                 copyFileDiffAndTruncate(localDir.toPath().resolve(renamed.relPath).toFile(), local, remoteDir.toPath().resolve(renamed.relPath).toFile(), remote);

--- a/src/peergos/server/DirectorySync.java
+++ b/src/peergos/server/DirectorySync.java
@@ -129,13 +129,24 @@ public class DirectorySync {
             int start = name.lastIndexOf("[conflict-");
             int end = name.indexOf("]", start);
             int version = Integer.parseInt(name.substring(start + "[conflict-".length(), end));
-            newName = name.substring(0, start) + "[conflict-" + (version + 1) + "]" + name.substring(end + 1);
+            while (true) {
+                newName = name.substring(0, start) + "[conflict-" + (version + 1) + "]" + name.substring(end + 1);
+                if (! f.toPath().getParent().resolve(newName).toFile().exists())
+                    break;
+                version++;
+            }
         } else {
-            if (name.contains(".")) {
-                int dot = name.lastIndexOf(".");
-                newName = name.substring(0, dot) + "[conflict-0]" + name.substring(dot);
-            } else
-                newName = name + "[conflict-0]";
+            int version = 0;
+            while (true) {
+                if (name.contains(".")) {
+                    int dot = name.lastIndexOf(".");
+                    newName = name.substring(0, dot) + "[conflict-" + version + "]" + name.substring(dot);
+                } else
+                    newName = name + "[conflict-" + version + "]";
+                if (! f.toPath().getParent().resolve(newName).toFile().exists())
+                    break;
+                version++;
+            }
         }
         f.renameTo(f.toPath().getParent().resolve(newName).toFile());
         return new FileState(s.relPath.substring(0, s.relPath.length() - name.length()) + newName, s.modificationTime, s.size, s.hash);

--- a/src/peergos/server/DirectorySync.java
+++ b/src/peergos/server/DirectorySync.java
@@ -1,0 +1,268 @@
+package peergos.server;
+
+import peergos.server.crypto.hash.Blake3;
+import peergos.shared.util.ArrayOps;
+import peergos.shared.util.Pair;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.util.*;
+
+public class DirectorySync {
+
+    public static void main(String[] args) throws Exception {
+        File local = new File("sync/local");
+        File remote = new File("sync/remote");
+        TreeState syncedState = new TreeState();
+        while (true) {
+            syncedState = syncDirs(local, remote, syncedState);
+            Thread.sleep(30_000);
+        }
+    }
+
+    public static TreeState syncDirs(File localDir, File remoteDir, TreeState syncedVersions) throws IOException {
+        TreeState localState = new TreeState();
+        buildDirState("", localDir, localState, syncedVersions);
+
+        TreeState remoteState = new TreeState();
+        buildDirState("", remoteDir, remoteState, syncedVersions);
+
+        TreeState finalSyncedState = new TreeState();
+        for (FileState local : localState.filesByPath.values()) {
+
+            FileState synced = syncedVersions.filesByPath.get(local.relPath);
+            FileState remote = remoteState.filesByPath.get(local.relPath);
+            List<FileState> syncedResults = syncFile(localDir, remoteDir, synced, local, remote);
+            syncedResults.forEach(finalSyncedState::add);
+        }
+        for (FileState remote : remoteState.filesByPath.values()) {
+            if (! finalSyncedState.filesByPath.containsKey(remote.relPath)) {
+
+                FileState synced = syncedVersions.filesByPath.get(remote.relPath);
+                List<FileState> syncedResults = syncFile(localDir, remoteDir, synced, null, remote);
+                syncedResults.forEach(finalSyncedState::add);
+            }
+        }
+        return finalSyncedState;
+    }
+
+    public static List<FileState> syncFile(File localDir, File remoteDir, FileState synced, FileState local, FileState remote) throws IOException {
+        if (synced == null) {
+            if (local == null) { // remotely added
+                copyFileDiffAndTruncate(remoteDir.toPath().resolve(remote.relPath).toFile(), remote, localDir.toPath().resolve(remote.relPath).toFile(), null);
+                return List.of(remote);
+            } else if (remote == null) { // locally added
+                copyFileDiffAndTruncate(localDir.toPath().resolve(local.relPath).toFile(), local, remoteDir.toPath().resolve(local.relPath).toFile(), null);
+                return List.of(local);
+            } else {
+                // concurrent addition, rename 1 if contents are different
+                if (remote.hash.equals(local.hash)) {
+                    if (local.modificationTime >= remote.modificationTime) {
+                        setModificationTime(remoteDir.toPath().resolve(local.relPath).toFile(), local.modificationTime);
+                        return List.of(local);
+                    } else {
+                        setModificationTime(localDir.toPath().resolve(local.relPath).toFile(), remote.modificationTime);
+                        return List.of(remote);
+                    }
+                } else {
+                    FileState renamed = renameOnConflict(localDir.toPath().resolve(local.relPath).toFile(), local);
+                    copyFileDiffAndTruncate(remoteDir.toPath().resolve(remote.relPath).toFile(), remote, localDir.toPath().resolve(remote.relPath).toFile(), null);
+                    copyFileDiffAndTruncate(localDir.toPath().resolve(renamed.relPath).toFile(), renamed, remoteDir.toPath().resolve(renamed.relPath).toFile(), null);
+                    return List.of(renamed, remote);
+                }
+            }
+        } else {
+            if (synced.equals(local)) { // remote change only
+                if (remote == null) { // deletion
+                    deleteFile(localDir.toPath().resolve(local.relPath).toFile());
+                    return Collections.emptyList();
+                } else {
+                    copyFileDiffAndTruncate(remoteDir.toPath().resolve(remote.relPath).toFile(), remote, localDir.toPath().resolve(remote.relPath).toFile(), local);
+                    return List.of(remote);
+                }
+            } else if (synced.equals(remote)) { // local only change
+                if (local == null) { // deletion
+                    deleteFile(remoteDir.toPath().resolve(remote.relPath).toFile());
+                    return Collections.emptyList();
+                } else {
+                    copyFileDiffAndTruncate(localDir.toPath().resolve(local.relPath).toFile(), local, remoteDir.toPath().resolve(local.relPath).toFile(), remote);
+                    return List.of(local);
+                }
+            } else { // concurrent change, rename one
+                FileState renamed = renameOnConflict(localDir.toPath().resolve(local.relPath).toFile(), local);
+                copyFileDiffAndTruncate(remoteDir.toPath().resolve(remote.relPath).toFile(), remote, localDir.toPath().resolve(remote.relPath).toFile(), local);
+                copyFileDiffAndTruncate(localDir.toPath().resolve(renamed.relPath).toFile(), local, remoteDir.toPath().resolve(renamed.relPath).toFile(), remote);
+                return List.of(renamed, remote);
+            }
+        }
+    }
+
+    public static void deleteFile(File f) {
+        f.delete();
+    }
+
+    public static FileState renameOnConflict(File f, FileState s) {
+        String name = f.getName();
+        String newName;
+        if (name.contains("[conflict-")) {
+            int start = name.lastIndexOf("[conflict-");
+            int end = name.indexOf("]", start);
+            int version = Integer.parseInt(name.substring(start + "[conflict-".length(), end));
+            newName = name.substring(0, start) + "[conflict-" + (version + 1) + "]" + name.substring(end + 1);
+        } else {
+            if (name.contains(".")) {
+                int dot = name.lastIndexOf(".");
+                newName = name.substring(0, dot) + "[conflict-0]" + name.substring(dot);
+            } else
+                newName = name + "[conflict-0]";
+        }
+        f.renameTo(f.toPath().getParent().resolve(newName).toFile());
+        return new FileState(s.relPath.substring(0, s.relPath.length() - name.length()) + newName, s.modificationTime, s.size, s.hash);
+    }
+
+    public static void setModificationTime(File f, long modificationTime) {
+        f.setLastModified(modificationTime);
+    }
+
+    public static void copyFileDiffAndTruncate(File source, FileState sourceState, File target, FileState targetState) throws IOException {
+        target.getParentFile().mkdirs();
+        long priorSize = target.length();
+        long size = source.length();
+
+        List<Pair<Long, Long>> diffRanges = sourceState.diffRanges(targetState);
+
+        byte[] buf = new byte[4096];
+
+        try (FileInputStream fin = new FileInputStream(source);
+             FileOutputStream fout = new FileOutputStream(target);
+             FileChannel channel = fout.getChannel()) {
+            for (Pair<Long, Long> range : diffRanges) {
+                long start = range.left;
+                long end = range.right;
+                fin.getChannel().position(start);
+                channel.position(start);
+                long done = 0;
+                while (done < end - start) {
+                    int read = fin.read(buf);
+                    fout.write(buf, 0, read);
+                    done += read;
+                }
+                if (priorSize > size)
+                    channel.truncate(size);
+            }
+        }
+        setModificationTime(target, source.lastModified());
+    }
+
+    static class Blake3state {
+        public final byte[] hash;
+
+        public Blake3state(byte[] hash) {
+            this.hash = hash;
+        }
+
+        @Override
+        public String toString() {
+            return ArrayOps.bytesToHex(hash);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Blake3state that = (Blake3state) o;
+            return Objects.deepEquals(hash, that.hash);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(hash);
+        }
+    }
+
+    static class FileState {
+        public final String relPath;
+        public final long modificationTime;
+        public final long size;
+        public final Blake3state hash;
+
+        public FileState(String relPath, long modificationTime, long size, Blake3state hash) {
+            this.relPath = relPath;
+            this.modificationTime = modificationTime;
+            this.size = size;
+            this.hash = hash;
+        }
+
+        public List<Pair<Long, Long>> diffRanges(FileState other) {
+            if (other == null)
+                return List.of(new Pair<>(0L, size));
+            // TODO use bao tree to extract small diff ranges
+            return List.of(new Pair<>(0L, size));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            FileState fileState = (FileState) o;
+            return modificationTime == fileState.modificationTime && Objects.equals(relPath, fileState.relPath) && Objects.equals(hash, fileState.hash);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(relPath, modificationTime, hash);
+        }
+    }
+
+    static class TreeState {
+        public final Map<String, FileState> filesByPath = new HashMap<>();
+        public final Map<Blake3state, FileState> fileByHash = new HashMap<>();
+
+        public void add(FileState fs) {
+            filesByPath.put(fs.relPath, fs);
+            fileByHash.put(fs.hash, fs);
+        }
+    }
+
+    public static void buildDirState(String pathPrefix, File localDir, TreeState res, TreeState synced) {
+        for (File file : localDir.listFiles()) {
+            if (file.isFile()) {
+                String relPath = pathPrefix + file.getName();
+                FileState atSync = synced.filesByPath.get(relPath);
+                long modified = file.lastModified();
+                if (atSync != null && atSync.modificationTime == modified) {
+                    res.add(atSync);
+                } else {
+                    Blake3state b3 = hashFile(file);
+                    FileState fstat = new FileState(relPath, modified, file.length(), b3);
+                    res.add(fstat);
+                }
+            } else if (file.isDirectory()) {
+                buildDirState(pathPrefix + file.getName() + "/", file, res, synced);
+            }
+        }
+    }
+
+    public static Blake3state hashFile(File f) {
+        byte[] buf = new byte[4*1024];
+        long size = f.length();
+        Blake3 state = Blake3.initHash();
+
+        try {
+            FileInputStream fin = new FileInputStream(f);
+            for (long i = 0; i < size; ) {
+                int read = fin.read(buf);
+                state.update(buf, 0, read);
+                i+= read;
+            }
+
+            byte[] hash = state.doFinalize(32);
+            return new Blake3state(hash);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -9,6 +9,7 @@ import peergos.server.space.*;
 import peergos.server.sql.*;
 import peergos.server.storage.admin.*;
 import peergos.server.storage.auth.*;
+import peergos.server.sync.DirectorySync;
 import peergos.shared.*;
 import peergos.server.corenode.*;
 import peergos.server.fuse.*;
@@ -417,6 +418,34 @@ public class Main extends Builder {
                     new Command.Arg("webdav.port", "The listen port for the webdav endpoint", false, "8090"),
                     new Command.Arg("peergos-url", "Peergos service address", false, "https://peergos.net")
             ).collect(Collectors.toList())
+    );
+
+    public static final Command<Boolean> SYNC_DIR = new Command<>("dir",
+            "Sync a local folder to and from a Peergos folder",
+            DirectorySync::syncDir,
+            Stream.of(
+                    new Command.Arg("link", "Writable link (path only) to a Peergos directory", true),
+                    new Command.Arg("peergos-url", "Peergos service address", false, "https://peergos.net"),
+                    new Command.Arg("local-dir", "The directory to sync to and from Peergos", true)
+            ).collect(Collectors.toList())
+    );
+
+    public static final Command<Boolean> SYNC_INIT = new Command<>("init",
+            "Setup a peergos folder for syncing and get required arguments for 'sync dir' command",
+            DirectorySync::init,
+            Stream.of(
+                    new Command.Arg("peergos-url", "Peergos service address", false, "https://peergos.net")
+            ).collect(Collectors.toList())
+    );
+
+    public static final Command<Boolean> SYNC = new Command<>("sync",
+            "Sync a local folder to a Peergos folder",
+            args -> {
+                System.out.println("Run sync init first, then sync dir with the resulting arguments");
+                return null;
+            },
+            Collections.emptyList(),
+            Arrays.asList(SYNC_INIT, SYNC_DIR)
     );
 
     public static final Command<InstanceAdmin.VersionInfo> VERSION = new Command<>("version",
@@ -920,6 +949,7 @@ public class Main extends Builder {
             Arrays.asList(
                     PEERGOS,
                     SHELL,
+                    SYNC,
                     FUSE,
                     WEBDAV,
                     QuotaCLI.QUOTA,

--- a/src/peergos/server/crypto/hash/Blake3.java
+++ b/src/peergos/server/crypto/hash/Blake3.java
@@ -1,0 +1,536 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package peergos.server.crypto.hash;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Implements the Blake3 algorithm providing a {@linkplain #initHash() hash function} with extensible output (XOF), a
+ * {@linkplain #initKeyedHash(byte[]) keyed hash function} (MAC, PRF), and a
+ * {@linkplain #initKeyDerivationFunction(byte[]) key derivation function} (KDF). Blake3 has a 128-bit security level
+ * and a default output length of 256 bits (32 bytes) which can extended up to 2<sup>64</sup> bytes.
+ * <h2>Hashing</h2>
+ * <p>Hash mode calculates the same output hash given the same input bytes and can be used as both a message digest and
+ * and extensible output function.</p>
+ * <pre>{@code
+ *      Blake3 hasher = Blake3.initHash();
+ *      hasher.update("Hello, world!".getBytes(StandardCharsets.UTF_8));
+ *      byte[] hash = new byte[32];
+ *      hasher.doFinalize(hash);
+ * }</pre>
+ * <h2>Keyed Hashing</h2>
+ * <p>Keyed hashes take a 32-byte secret key and calculates a message authentication code on some input bytes. These
+ * also work as pseudo-random functions (PRFs) with extensible output similar to the extensible hash output. Note that
+ * Blake3 keyed hashes have the same performance as plain hashes; the key is used in initialization in place of a
+ * standard initialization vector used for plain hashing.</p>
+ * <pre>{@code
+ *      SecureRandom random = SecureRandom.getInstanceStrong();
+ *      byte[] key = new byte[32];
+ *      random.nextBytes(key);
+ *      Blake3 hasher = Blake3.initKeyedHash(key);
+ *      hasher.update("Hello, Alice!".getBytes(StandardCharsets.UTF_8));
+ *      byte[] mac = new byte[32];
+ *      hasher.doFinalize(mac);
+ * }</pre>
+ * <h2>Key Derivation</h2>
+ * <p>A specific hash mode for deriving session keys and other derived keys in a unique key derivation context
+ * identified by some sequence of bytes. These context strings should be unique but do not need to be kept secret.
+ * Additional input data is hashed for key material which can be finalized to derive subkeys.</p>
+ * <pre>{@code
+ *      String context = "org.apache.commons.codec.digest.Blake3Example";
+ *      byte[] sharedSecret = ...;
+ *      byte[] senderId = ...;
+ *      byte[] recipientId = ...;
+ *      Blake3 kdf = Blake3.initKeyDerivationFunction(context.getBytes(StandardCharsets.UTF_8));
+ *      kdf.update(sharedSecret);
+ *      kdf.update(senderId);
+ *      kdf.update(recipientId);
+ *      byte[] txKey = new byte[32];
+ *      byte[] rxKey = new byte[32];
+ *      kdf.doFinalize(txKey);
+ *      kdf.doFinalize(rxKey);
+ * }</pre>
+ * <p>
+ * Adapted from the ISC-licensed O(1) Cryptography library by Matt Sicker and ported from the reference public domain
+ * implementation by Jack O'Connor.
+ * </p>
+ *
+ * @see <a href="https://github.com/BLAKE3-team/BLAKE3">BLAKE3 hash function</a>
+ * @since 1.16
+ */
+public final class Blake3 {
+
+    private static final class ChunkState {
+
+        private int[] chainingValue;
+        private final long chunkCounter;
+        private final int flags;
+
+        private final byte[] block = new byte[BLOCK_LEN];
+        private int blockLength;
+        private int blocksCompressed;
+
+        private ChunkState(final int[] key, final long chunkCounter, final int flags) {
+            chainingValue = key;
+            this.chunkCounter = chunkCounter;
+            this.flags = flags;
+        }
+
+        private int length() {
+            return BLOCK_LEN * blocksCompressed + blockLength;
+        }
+
+        private Output output() {
+            final int[] blockWords = unpackInts(block, BLOCK_INTS);
+            final int outputFlags = flags | startFlag() | CHUNK_END;
+            return new Output(chainingValue, blockWords, chunkCounter, blockLength, outputFlags);
+        }
+
+        private int startFlag() {
+            return blocksCompressed == 0 ? CHUNK_START : 0;
+        }
+
+        private void update(final byte[] input, int offset, int length) {
+            while (length > 0) {
+                if (blockLength == BLOCK_LEN) {
+                    // If the block buffer is full, compress it and clear it. More
+                    // input is coming, so this compression is not CHUNK_END.
+                    final int[] blockWords = unpackInts(block, BLOCK_INTS);
+                    chainingValue = Arrays.copyOf(
+                            compress(chainingValue, blockWords, BLOCK_LEN, chunkCounter, flags | startFlag()),
+                            CHAINING_VALUE_INTS);
+                    blocksCompressed++;
+                    blockLength = 0;
+                    Arrays.fill(block, (byte) 0);
+                }
+
+                final int want = BLOCK_LEN - blockLength;
+                final int take = Math.min(want, length);
+                System.arraycopy(input, offset, block, blockLength, take);
+                blockLength += take;
+                offset += take;
+                length -= take;
+            }
+        }
+    }
+    private static final class EngineState {
+        private final int[] key;
+        private final int flags;
+        // Space for 54 subtree chaining values: 2^54 * CHUNK_LEN = 2^64
+        // No more than 54 entries can ever be added to this stack (after updating 2^64 bytes and not finalizing any)
+        // so we preallocate the stack here. This can be smaller in environments where the data limit is expected to
+        // be much lower.
+        private final int[][] cvStack = new int[54][];
+        private int stackLen;
+        private ChunkState state;
+
+        private EngineState(final int[] key, final int flags) {
+            this.key = key;
+            this.flags = flags;
+            state = new ChunkState(key, 0, flags);
+        }
+
+        // Section 5.1.2 of the BLAKE3 spec explains this algorithm in more detail.
+        private void addChunkCV(final int[] firstCV, final long totalChunks) {
+            // This chunk might complete some subtrees. For each completed subtree,
+            // its left child will be the current top entry in the CV stack, and
+            // its right child will be the current value of `newCV`. Pop each left
+            // child off the stack, merge it with `newCV`, and overwrite `newCV`
+            // with the result. After all these merges, push the final value of
+            // `newCV` onto the stack. The number of completed subtrees is given
+            // by the number of trailing 0-bits in the new total number of chunks.
+            int[] newCV = firstCV;
+            long chunkCounter = totalChunks;
+            while ((chunkCounter & 1) == 0) {
+                newCV = parentChainingValue(popCV(), newCV, key, flags);
+                chunkCounter >>= 1;
+            }
+            pushCV(newCV);
+        }
+
+        private void inputData(final byte[] in, int offset, int length) {
+            while (length > 0) {
+                // If the current chunk is complete, finalize it and reset the
+                // chunk state. More input is coming, so this chunk is not ROOT.
+                if (state.length() == CHUNK_LEN) {
+                    final int[] chunkCV = state.output().chainingValue();
+                    final long totalChunks = state.chunkCounter + 1;
+                    addChunkCV(chunkCV, totalChunks);
+                    state = new ChunkState(key, totalChunks, flags);
+                }
+
+                // Compress input bytes into the current chunk state.
+                final int want = CHUNK_LEN - state.length();
+                final int take = Math.min(want, length);
+                state.update(in, offset, take);
+                offset += take;
+                length -= take;
+            }
+        }
+
+        private void outputHash(final byte[] out, final int offset, final int length) {
+            // Starting with the Output from the current chunk, compute all the
+            // parent chaining values along the right edge of the tree, until we
+            // have the root Output.
+            Output output = state.output();
+            int parentNodesRemaining = stackLen;
+            while (parentNodesRemaining-- > 0) {
+                final int[] parentCV = cvStack[parentNodesRemaining];
+                output = parentOutput(parentCV, output.chainingValue(), key, flags);
+            }
+            output.rootOutputBytes(out, offset, length);
+        }
+
+        private int[] popCV() {
+            return cvStack[--stackLen];
+        }
+
+        private void pushCV(final int[] cv) {
+            cvStack[stackLen++] = cv;
+        }
+
+        private void reset() {
+            stackLen = 0;
+            Arrays.fill(cvStack, null);
+            state = new ChunkState(key, 0, flags);
+        }
+    }
+
+    /**
+     * Represents the state just prior to either producing an eight word chaining value or any number of output bytes
+     * when the ROOT flag is set.
+     */
+    private static final class Output {
+
+        private final int[] inputChainingValue;
+        private final int[] blockWords;
+        private final long counter;
+        private final int blockLength;
+        private final int flags;
+
+        private Output(final int[] inputChainingValue, final int[] blockWords, final long counter, final int blockLength, final int flags) {
+            this.inputChainingValue = inputChainingValue;
+            this.blockWords = blockWords;
+            this.counter = counter;
+            this.blockLength = blockLength;
+            this.flags = flags;
+        }
+
+        private int[] chainingValue() {
+            return Arrays.copyOf(compress(inputChainingValue, blockWords, blockLength, counter, flags), CHAINING_VALUE_INTS);
+        }
+
+        private void rootOutputBytes(final byte[] out, int offset, int length) {
+            int outputBlockCounter = 0;
+            while (length > 0) {
+                int chunkLength = Math.min(OUT_LEN * 2, length);
+                length -= chunkLength;
+                final int[] words = compress(inputChainingValue, blockWords, blockLength, outputBlockCounter++, flags | ROOT);
+                int wordCounter = 0;
+                while (chunkLength > 0) {
+                    final int wordLength = Math.min(Integer.BYTES, chunkLength);
+                    packInt(words[wordCounter++], out, offset, wordLength);
+                    offset += wordLength;
+                    chunkLength -= wordLength;
+                }
+            }
+        }
+    }
+
+    private static final int BLOCK_LEN = 64;
+    private static final int BLOCK_INTS = BLOCK_LEN / Integer.BYTES;
+    private static final int KEY_LEN = 32;
+    private static final int KEY_INTS = KEY_LEN / Integer.BYTES;
+    private static final int OUT_LEN = 32;
+    private static final int CHUNK_LEN = 1024;
+    private static final int CHAINING_VALUE_INTS = 8;
+
+    /**
+     * Standard hash key used for plain hashes; same initialization vector as Blake2s.
+     */
+    private static final int[] IV = { 0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19 };
+
+    // domain flags
+    private static final int CHUNK_START = 1;
+    private static final int CHUNK_END = 1 << 1;
+    private static final int PARENT = 1 << 2;
+    private static final int ROOT = 1 << 3;
+    private static final int KEYED_HASH = 1 << 4;
+    private static final int DERIVE_KEY_CONTEXT = 1 << 5;
+    private static final int DERIVE_KEY_MATERIAL = 1 << 6;
+
+    /**
+     * Pre-permuted for all 7 rounds; the second row (2,6,3,...) indicates the base permutation.
+     */
+    // @formatter:off
+    private static final byte[][] MSG_SCHEDULE = {
+            { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+            { 2, 6, 3, 10, 7, 0, 4, 13, 1, 11, 12, 5, 9, 14, 15, 8 },
+            { 3, 4, 10, 12, 13, 2, 7, 14, 6, 5, 9, 0, 11, 15, 8, 1 },
+            { 10, 7, 12, 9, 14, 3, 13, 15, 4, 0, 11, 2, 5, 8, 1, 6 },
+            { 12, 13, 9, 11, 15, 10, 14, 8, 7, 2, 5, 3, 0, 1, 6, 4 },
+            { 9, 14, 11, 5, 8, 12, 15, 1, 13, 3, 0, 10, 2, 6, 4, 7 },
+            { 11, 15, 5, 0, 1, 9, 8, 6, 14, 10, 2, 12, 3, 4, 7, 13 }
+    };
+    // @formatter:on
+
+    private static void checkBufferArgs(final byte[] buffer, final int offset, final int length) {
+        Objects.requireNonNull(buffer);
+        if (offset < 0) {
+            throw new IndexOutOfBoundsException("Offset must be non-negative");
+        }
+        if (length < 0) {
+            throw new IndexOutOfBoundsException("Length must be non-negative");
+        }
+        final int bufferLength = buffer.length;
+        if (offset > bufferLength - length) {
+            throw new IndexOutOfBoundsException("Offset " + offset + " and length " + length + " out of bounds with buffer length " + bufferLength);
+        }
+    }
+
+    private static int[] compress(final int[] chainingValue, final int[] blockWords, final int blockLength, final long counter, final int flags) {
+        final int[] state = Arrays.copyOf(chainingValue, BLOCK_INTS);
+        System.arraycopy(IV, 0, state, 8, 4);
+        state[12] = (int) counter;
+        state[13] = (int) (counter >> Integer.SIZE);
+        state[14] = blockLength;
+        state[15] = flags;
+        for (int i = 0; i < 7; i++) {
+            final byte[] schedule = MSG_SCHEDULE[i];
+            round(state, blockWords, schedule);
+        }
+        for (int i = 0; i < state.length / 2; i++) {
+            state[i] ^= state[i + 8];
+            state[i + 8] ^= chainingValue[i];
+        }
+        return state;
+    }
+
+    /**
+     * The mixing function, G, which mixes either a column or a diagonal.
+     */
+    private static void g(final int[] state, final int a, final int b, final int c, final int d, final int mx, final int my) {
+        state[a] += state[b] + mx;
+        state[d] = Integer.rotateRight(state[d] ^ state[a], 16);
+        state[c] += state[d];
+        state[b] = Integer.rotateRight(state[b] ^ state[c], 12);
+        state[a] += state[b] + my;
+        state[d] = Integer.rotateRight(state[d] ^ state[a], 8);
+        state[c] += state[d];
+        state[b] = Integer.rotateRight(state[b] ^ state[c], 7);
+    }
+
+    /**
+     * Calculates the Blake3 hash of the provided data.
+     *
+     * @param data source array to absorb data from
+     * @return 32-byte hash squeezed from the provided data
+     * @throws NullPointerException if data is null
+     */
+    public static byte[] hash(final byte[] data) {
+        return Blake3.initHash().update(data).doFinalize(OUT_LEN);
+    }
+
+    /**
+     * Constructs a fresh Blake3 hash function. The instance returned functions as an arbitrary length message digest.
+     *
+     * @return fresh Blake3 instance in hashed mode
+     */
+    public static Blake3 initHash() {
+        return new Blake3(IV, 0);
+    }
+
+    /**
+     * Constructs a fresh Blake3 key derivation function using the provided key derivation context byte string.
+     * The instance returned functions as a key-derivation function which can further absorb additional context data
+     * before squeezing derived key data.
+     *
+     * @param kdfContext a globally unique key-derivation context byte string to separate key derivation contexts from each other
+     * @return fresh Blake3 instance in key derivation mode
+     * @throws NullPointerException if kdfContext is null
+     */
+    public static Blake3 initKeyDerivationFunction(final byte[] kdfContext) {
+        Objects.requireNonNull(kdfContext);
+        final EngineState kdf = new EngineState(IV, DERIVE_KEY_CONTEXT);
+        kdf.inputData(kdfContext, 0, kdfContext.length);
+        final byte[] key = new byte[KEY_LEN];
+        kdf.outputHash(key, 0, key.length);
+        return new Blake3(unpackInts(key, KEY_INTS), DERIVE_KEY_MATERIAL);
+    }
+
+    /**
+     * Constructs a fresh Blake3 keyed hash function. The instance returned functions as a pseudorandom function (PRF) or as a
+     * message authentication code (MAC).
+     *
+     * @param key 32-byte secret key
+     * @return fresh Blake3 instance in keyed mode using the provided key
+     * @throws NullPointerException     if key is null
+     * @throws IllegalArgumentException if key is not 32 bytes
+     */
+    public static Blake3 initKeyedHash(final byte[] key) {
+        Objects.requireNonNull(key);
+        if (key.length != KEY_LEN) {
+            throw new IllegalArgumentException("Blake3 keys must be 32 bytes");
+        }
+        return new Blake3(unpackInts(key, KEY_INTS), KEYED_HASH);
+    }
+
+    /**
+     * Calculates the Blake3 keyed hash (MAC) of the provided data.
+     *
+     * @param key  32-byte secret key
+     * @param data source array to absorb data from
+     * @return 32-byte mac squeezed from the provided data
+     * @throws NullPointerException if key or data are null
+     */
+    public static byte[] keyedHash(final byte[] key, final byte[] data) {
+        return Blake3.initKeyedHash(key).update(data).doFinalize(OUT_LEN);
+    }
+
+    private static void packInt(final int value, final byte[] dst, final int off, final int len) {
+        for (int i = 0; i < len; i++) {
+            dst[off + i] = (byte) (value >>> i * Byte.SIZE);
+        }
+    }
+
+    private static int[] parentChainingValue(final int[] leftChildCV, final int[] rightChildCV, final int[] key, final int flags) {
+        return parentOutput(leftChildCV, rightChildCV, key, flags).chainingValue();
+    }
+
+    private static Output parentOutput(final int[] leftChildCV, final int[] rightChildCV, final int[] key, final int flags) {
+        final int[] blockWords = Arrays.copyOf(leftChildCV, BLOCK_INTS);
+        System.arraycopy(rightChildCV, 0, blockWords, 8, CHAINING_VALUE_INTS);
+        return new Output(key.clone(), blockWords, 0, BLOCK_LEN, flags | PARENT);
+    }
+
+    private static void round(final int[] state, final int[] msg, final byte[] schedule) {
+        // Mix the columns.
+        g(state, 0, 4, 8, 12, msg[schedule[0]], msg[schedule[1]]);
+        g(state, 1, 5, 9, 13, msg[schedule[2]], msg[schedule[3]]);
+        g(state, 2, 6, 10, 14, msg[schedule[4]], msg[schedule[5]]);
+        g(state, 3, 7, 11, 15, msg[schedule[6]], msg[schedule[7]]);
+
+        // Mix the diagonals.
+        g(state, 0, 5, 10, 15, msg[schedule[8]], msg[schedule[9]]);
+        g(state, 1, 6, 11, 12, msg[schedule[10]], msg[schedule[11]]);
+        g(state, 2, 7, 8, 13, msg[schedule[12]], msg[schedule[13]]);
+        g(state, 3, 4, 9, 14, msg[schedule[14]], msg[schedule[15]]);
+    }
+
+    private static int unpackInt(final byte[] buf, final int off) {
+        return buf[off] & 0xFF | (buf[off + 1] & 0xFF) << 8 | (buf[off + 2] & 0xFF) << 16 | (buf[off + 3] & 0xFF) << 24;
+    }
+
+    private static int[] unpackInts(final byte[] buf, final int nrInts) {
+        final int[] values = new int[nrInts];
+        for (int i = 0, off = 0; i < nrInts; i++, off += Integer.BYTES) {
+            values[i] = unpackInt(buf, off);
+        }
+        return values;
+    }
+
+    private final EngineState engineState;
+
+    private Blake3(final int[] key, final int flags) {
+        engineState = new EngineState(key, flags);
+    }
+
+    /**
+     * Finalizes hash output data that depends on the sequence of updated bytes preceding this invocation and any
+     * previously finalized bytes. Note that this can finalize up to 2<sup>64</sup> bytes per instance.
+     *
+     * @param out destination array to finalize bytes into
+     * @return {@code this} instance.
+     * @throws NullPointerException if out is null
+     */
+    public Blake3 doFinalize(final byte[] out) {
+        return doFinalize(out, 0, out.length);
+    }
+
+    /**
+     * Finalizes an arbitrary number of bytes into the provided output array that depends on the sequence of previously
+     * updated and finalized bytes. Note that this can finalize up to 2<sup>64</sup> bytes per instance.
+     *
+     * @param out    destination array to finalize bytes into
+     * @param offset where in the array to begin writing bytes to
+     * @param length number of bytes to finalize
+     * @return {@code this} instance.
+     * @throws NullPointerException      if out is null
+     * @throws IndexOutOfBoundsException if offset or length are negative or if offset + length is greater than the
+     *                                   length of the provided array
+     */
+    public Blake3 doFinalize(final byte[] out, final int offset, final int length) {
+        checkBufferArgs(out, offset, length);
+        engineState.outputHash(out, offset, length);
+        return this;
+    }
+
+    /**
+     * Squeezes and returns an arbitrary number of bytes dependent on the sequence of previously absorbed and squeezed bytes.
+     *
+     * @param nrBytes number of bytes to finalize
+     * @return requested number of finalized bytes
+     * @throws IllegalArgumentException if nrBytes is negative
+     */
+    public byte[] doFinalize(final int nrBytes) {
+        if (nrBytes < 0) {
+            throw new IllegalArgumentException("Requested bytes must be non-negative");
+        }
+        final byte[] hash = new byte[nrBytes];
+        doFinalize(hash);
+        return hash;
+    }
+
+    /**
+     * Resets this instance back to its initial state when it was first constructed.
+     * @return {@code this} instance.
+     */
+    public Blake3 reset() {
+        engineState.reset();
+        return this;
+    }
+
+    /**
+     * Updates this hash state using the provided bytes.
+     *
+     * @param in source array to update data from
+     * @return {@code this} instance.
+     * @throws NullPointerException if in is null
+     */
+    public Blake3 update(final byte[] in) {
+        return update(in, 0, in.length);
+    }
+
+    /**
+     * Updates this hash state using the provided bytes at an offset.
+     *
+     * @param in     source array to update data from
+     * @param offset where in the array to begin reading bytes
+     * @param length number of bytes to update
+     * @return {@code this} instance.
+     * @throws NullPointerException      if in is null
+     * @throws IndexOutOfBoundsException if offset or length are negative or if offset + length is greater than the
+     *                                   length of the provided array
+     */
+    public Blake3 update(final byte[] in, final int offset, final int length) {
+        checkBufferArgs(in, offset, length);
+        engineState.inputData(in, offset, length);
+        return this;
+    }
+
+}

--- a/src/peergos/server/sync/Blake3state.java
+++ b/src/peergos/server/sync/Blake3state.java
@@ -1,0 +1,32 @@
+package peergos.server.sync;
+
+import peergos.shared.util.ArrayOps;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+class Blake3state {
+    public final byte[] hash;
+
+    public Blake3state(byte[] hash) {
+        this.hash = hash;
+    }
+
+    @Override
+    public String toString() {
+        return ArrayOps.bytesToHex(hash);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Blake3state that = (Blake3state) o;
+        return Objects.deepEquals(hash, that.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(hash);
+    }
+}

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -38,16 +38,20 @@ import java.util.logging.Logger;
 public class DirectorySync {
     private static final Logger LOG = Logging.LOG();
 
+    private static void disableLogSpam() {
+        // disable log spam
+        TrieNodeImpl.disableLog();
+        HttpMutablePointers.disableLog();
+        NetworkAccess.disableLog();
+        HTTPCoreNode.disableLog();
+        HttpSocialNetwork.disableLog();
+        HttpSpaceUsage.disableLog();
+        FileUploader.disableLog();
+    }
+
     public static boolean syncDir(Args args) {
         try {
-            // disable log spam
-            TrieNodeImpl.disableLog();
-            HttpMutablePointers.disableLog();
-            NetworkAccess.disableLog();
-            HTTPCoreNode.disableLog();
-            HttpSocialNetwork.disableLog();
-            HttpSpaceUsage.disableLog();
-            FileUploader.disableLog();
+            disableLogSpam();
 
             String address = args.getArg("peergos-url");
             URL serverURL = new URL(address);
@@ -69,7 +73,10 @@ public class DirectorySync {
                     Path localDir = PathUtil.get(args.getArg("local-dir"));
                     Path remoteDir = PathUtil.get(linkPath);
                     LOG.info("Syncing " + localDir + " to+from " + remoteDir);
+                    long t0 = System.currentTimeMillis();
                     syncedState = syncDirs(local, localDir, remote, remoteDir, syncedState);
+                    long t1 = System.currentTimeMillis();
+                    LOG.info("Dir sync took " + (t1-t0)/1000 + "s");
                     Thread.sleep(30_000);
                 } catch (Exception e) {
                     LOG.log(Level.WARNING, e, e::getMessage);
@@ -77,11 +84,13 @@ public class DirectorySync {
                 }
             }
         } catch (Exception e) {
+            LOG.log(Level.SEVERE, e, e::getMessage);
             throw new RuntimeException(e);
         }
     }
 
     public static boolean init(Args args) {
+        disableLogSpam();
         Console console = System.console();
         String username = new String(console.readLine("Enter username:"));
         String password = new String(console.readPassword("Enter password:"));

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -9,6 +9,7 @@ import java.io.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class DirectorySync {
@@ -19,8 +20,13 @@ public class DirectorySync {
         LocalFileSystem local = new LocalFileSystem();
         LocalFileSystem remote = new LocalFileSystem();
         while (true) {
-            syncedState = syncDirs(local, Paths.get("sync/local"), remote, Paths.get("sync/remote"), syncedState);
+            try {
+                syncedState = syncDirs(local, Paths.get("sync/local"), remote, Paths.get("sync/remote"), syncedState);
 //            Thread.sleep(30_000);
+            } catch (Exception e) {
+                LOG.log(Level.WARNING, e, e::getMessage);
+                Thread.sleep(30_000);
+            }
         }
     }
 

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -1,5 +1,6 @@
 package peergos.server.sync;
 
+import peergos.shared.user.fs.AsyncReader;
 import peergos.shared.util.ArrayOps;
 import peergos.shared.util.Pair;
 
@@ -165,12 +166,10 @@ public class DirectorySync {
 
         List<Pair<Long, Long>> diffRanges = sourceState.diffRanges(targetState);
 
-        byte[] buf = new byte[4096];
-
         for (Pair<Long, Long> range : diffRanges) {
             long start = range.left;
             long end = range.right;
-            try (InputStream fin = srcFs.getBytes(source, start)) {
+            try (AsyncReader fin = srcFs.getBytes(source, start)) {
                 targetFs.setBytes(target, start, fin, end - start);
             }
             if (priorSize > size)

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -106,6 +106,9 @@ public class DirectorySync {
                         localFs.delete(localDir.resolve(local.relPath));
                     }
                     return Collections.emptyList();
+                } else if (remote.hash.equals(local.hash)) {
+                    // already synced
+                    return List.of(local);
                 } else {
                     LOG.info("Local: Copying changes to " + remote.relPath);
                     copyFileDiffAndTruncate(remoteFs, remoteDir.resolve(remote.relPath), remote, localFs, localDir.resolve(remote.relPath), local);
@@ -121,6 +124,9 @@ public class DirectorySync {
                         remoteFs.delete(remoteDir.resolve(remote.relPath));
                     }
                     return Collections.emptyList();
+                } else if (remote.hash.equals(local.hash)) {
+                    // already synced
+                    return List.of(local);
                 } else {
                     LOG.info("Remote: Copying changes to " + local.relPath);
                     copyFileDiffAndTruncate(localFs, localDir.resolve(local.relPath), local, remoteFs, remoteDir.resolve(local.relPath), remote);

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -7,16 +7,17 @@ import peergos.server.util.Args;
 import peergos.server.util.Logging;
 import peergos.shared.Crypto;
 import peergos.shared.NetworkAccess;
+import peergos.shared.corenode.HTTPCoreNode;
 import peergos.shared.login.mfa.MultiFactorAuthMethod;
 import peergos.shared.login.mfa.MultiFactorAuthRequest;
 import peergos.shared.login.mfa.MultiFactorAuthResponse;
+import peergos.shared.mutable.HttpMutablePointers;
+import peergos.shared.social.HttpSocialNetwork;
+import peergos.shared.storage.HttpSpaceUsage;
 import peergos.shared.user.LinkProperties;
 import peergos.shared.user.TrieNodeImpl;
 import peergos.shared.user.UserContext;
-import peergos.shared.user.fs.AsyncReader;
-import peergos.shared.user.fs.Blake3state;
-import peergos.shared.user.fs.FileWrapper;
-import peergos.shared.user.fs.ThumbnailGenerator;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.Either;
 import peergos.shared.util.Futures;
 import peergos.shared.util.Pair;
@@ -29,7 +30,6 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
 import java.util.logging.Logger;
 
 public class DirectorySync {
@@ -37,6 +37,15 @@ public class DirectorySync {
 
     public static boolean syncDir(Args args) {
         try {
+            // disable log spam
+            TrieNodeImpl.disableLog();
+            HttpMutablePointers.disableLog();
+            NetworkAccess.disableLog();
+            HTTPCoreNode.disableLog();
+            HttpSocialNetwork.disableLog();
+            HttpSpaceUsage.disableLog();
+            FileUploader.disableLog();
+
             String address = args.getArg("peergos-url");
             URL serverURL = new URL(address);
             NetworkAccess network = Builder.buildJavaNetworkAccess(serverURL, address.startsWith("https")).join();
@@ -45,7 +54,6 @@ public class DirectorySync {
             String link = args.getArg("link");
             UserContext context = UserContext.fromSecretLinkV2(link, () -> Futures.of(""), network, crypto).join();
             String linkPath = context.getEntryPath().join();
-            LogManager.getLogManager().getLogger(TrieNodeImpl.class.getName()).setLevel(Level.OFF);
 
             PeergosSyncFS remote = new PeergosSyncFS(context);
             LocalFileSystem local = new LocalFileSystem();

--- a/src/peergos/server/sync/FileState.java
+++ b/src/peergos/server/sync/FileState.java
@@ -1,0 +1,40 @@
+package peergos.server.sync;
+
+import peergos.shared.util.Pair;
+
+import java.util.List;
+import java.util.Objects;
+
+class FileState {
+    public final String relPath;
+    public final long modificationTime;
+    public final long size;
+    public final Blake3state hash;
+
+    public FileState(String relPath, long modificationTime, long size, Blake3state hash) {
+        this.relPath = relPath;
+        this.modificationTime = modificationTime;
+        this.size = size;
+        this.hash = hash;
+    }
+
+    public List<Pair<Long, Long>> diffRanges(FileState other) {
+        if (other == null)
+            return List.of(new Pair<>(0L, size));
+        // TODO use bao tree to extract small diff ranges
+        return List.of(new Pair<>(0L, size));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FileState fileState = (FileState) o;
+        return modificationTime == fileState.modificationTime && Objects.equals(relPath, fileState.relPath) && Objects.equals(hash, fileState.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(relPath, modificationTime, hash);
+    }
+}

--- a/src/peergos/server/sync/FileState.java
+++ b/src/peergos/server/sync/FileState.java
@@ -1,5 +1,6 @@
 package peergos.server.sync;
 
+import peergos.shared.user.fs.Blake3state;
 import peergos.shared.util.Pair;
 
 import java.util.List;

--- a/src/peergos/server/sync/JdbcTreeState.java
+++ b/src/peergos/server/sync/JdbcTreeState.java
@@ -1,0 +1,100 @@
+package peergos.server.sync;
+
+import peergos.server.sql.SqlSupplier;
+import peergos.server.sql.SqliteCommands;
+import peergos.server.util.Sqlite;
+import peergos.shared.user.fs.Blake3state;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class JdbcTreeState implements SyncState {
+    private static final String INSERT_SUFFIX = "INTO syncstate (path, b3, modtime, size) VALUES(?, ?, ?, ?)";
+    private static final String GET_BY_PATH = "SELECT path, b3, modtime, size FROM syncstate WHERE path = ?;";
+    private static final String GET_BY_HASH = "SELECT path, b3, modtime, size FROM syncstate WHERE b3 = ?;";
+
+    private final Supplier<Connection> conn;
+    private final SqlSupplier cmds = new SqliteCommands();
+
+    public JdbcTreeState() {
+        try {
+            Connection memory = Sqlite.build("dir-sync-state.sql");
+            // We need a connection that ignores close
+            Connection instance = new Sqlite.UncloseableConnection(memory);
+            this.conn = () -> instance;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        init();
+    }
+
+    private Connection getConnection() {
+        Connection connection = conn.get();
+        try {
+            connection.setAutoCommit(true);
+            connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            return connection;
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private synchronized void init() {
+        try (Connection conn = getConnection()) {
+            cmds.createTable("CREATE TABLE IF NOT EXISTS syncstate (path text primary key not null, b3 blob, modtime bigint not null, size bigint not null); " +
+                    "CREATE UNIQUE INDEX IF NOT EXISTS sync_hash_index ON syncstate (b3);", conn);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public FileState byPath(String path) {
+        try (Connection conn = getConnection();
+             PreparedStatement select = conn.prepareStatement(GET_BY_PATH)) {
+            select.setString(1, path);
+            ResultSet rs = select.executeQuery();
+            if (rs.next())
+                return new FileState(rs.getString(1), rs.getLong(3), rs.getLong(4), new Blake3state(rs.getBytes(2)));
+
+            return null;
+        } catch (SQLException sqe) {
+            throw new IllegalStateException(sqe);
+        }
+    }
+
+    @Override
+    public void add(FileState fs) {
+        try (Connection conn = getConnection();
+             PreparedStatement insert = conn.prepareStatement(cmds.insertOrIgnoreCommand("INSERT ", INSERT_SUFFIX))) {
+            insert.setString(1, fs.relPath);
+            insert.setBytes(2, fs.hash.hash);
+            insert.setLong(3, fs.modificationTime);
+            insert.setLong(4, fs.size);
+            insert.executeUpdate();
+        } catch (SQLException sqe) {
+            throw new IllegalStateException(sqe);
+        }
+    }
+
+    @Override
+    public List<FileState> byHash(Blake3state b3) {
+        try (Connection conn = getConnection();
+             PreparedStatement select = conn.prepareStatement(GET_BY_HASH)) {
+            select.setBytes(1, b3.serialize());
+            ResultSet rs = select.executeQuery();
+            List<FileState> res = new ArrayList<>();
+            while (rs.next())
+                res.add(new FileState(rs.getString(1), rs.getLong(3), rs.getLong(4), new Blake3state(rs.getBytes(2))));
+
+            return res;
+        } catch (SQLException sqe) {
+            throw new IllegalStateException(sqe);
+        }
+    }
+}

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -38,12 +38,13 @@ class LocalFileSystem implements SyncFilesystem {
 
     @Override
     public long getLastModified(Path p) {
-        return p.toFile().lastModified();
+        long millis = p.toFile().lastModified();
+        return millis / 1000 * 1000;
     }
 
     @Override
     public void setModificationTime(Path p, long modificationTime) {
-        p.toFile().setLastModified(modificationTime);
+        p.toFile().setLastModified(modificationTime / 1000 * 1000);
     }
 
     @Override
@@ -53,8 +54,8 @@ class LocalFileSystem implements SyncFilesystem {
 
     @Override
     public void truncate(Path p, long size) throws IOException {
-        try (FileChannel channel = new FileOutputStream(p.toFile()).getChannel()) {
-            channel.truncate(size);
+        try (RandomAccessFile raf = new RandomAccessFile(p.toFile(), "rw")) {
+            raf.setLength(size);
         }
     }
 

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -80,7 +80,7 @@ class LocalFileSystem implements SyncFilesystem {
     }
 
     @Override
-    public DirectorySync.Blake3state hashFile(Path p) {
+    public Blake3state hashFile(Path p) {
         byte[] buf = new byte[4 * 1024];
         long size = p.toFile().length();
         Blake3 state = Blake3.initHash();
@@ -94,7 +94,7 @@ class LocalFileSystem implements SyncFilesystem {
             }
 
             byte[] hash = state.doFinalize(32);
-            return new DirectorySync.Blake3state(hash);
+            return new Blake3state(hash);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -1,0 +1,112 @@
+package peergos.server.sync;
+
+import peergos.server.crypto.hash.Blake3;
+
+import java.io.*;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+class LocalFileSystem implements SyncFilesystem {
+
+    @Override
+    public boolean exists(Path p) {
+        return p.toFile().exists();
+    }
+
+    @Override
+    public void mkdirs(Path p) {
+        File f = p.toFile();
+        if (f.exists() && f.isDirectory())
+            return;
+        if (!f.mkdirs())
+            throw new IllegalStateException("Couldn't create " + p);
+    }
+
+    @Override
+    public void delete(Path p) {
+        p.toFile().delete();
+    }
+
+    @Override
+    public void moveTo(Path src, Path target) {
+        target.getParent().toFile().mkdirs();
+        src.toFile().renameTo(target.toFile());
+    }
+
+    @Override
+    public long getLastModified(Path p) {
+        return p.toFile().lastModified();
+    }
+
+    @Override
+    public void setModificationTime(Path p, long modificationTime) {
+        p.toFile().setLastModified(modificationTime);
+    }
+
+    @Override
+    public long size(Path p) {
+        return p.toFile().length();
+    }
+
+    @Override
+    public void truncate(Path p, long size) throws IOException {
+        try (FileChannel channel = new FileOutputStream(p.toFile()).getChannel()) {
+            channel.truncate(size);
+        }
+    }
+
+    @Override
+    public void setBytes(Path p, long fileOffset, InputStream fin, long size) throws IOException {
+        try (FileOutputStream fout = new FileOutputStream(p.toFile());
+             FileChannel channel = fout.getChannel()) {
+            channel.position(fileOffset);
+            byte[] buf = new byte[4096];
+            long done = 0;
+            while (done < size) {
+                int read = fin.read(buf);
+                fout.write(buf, 0, read);
+                done += read;
+            }
+        }
+    }
+
+    @Override
+    public InputStream getBytes(Path p, long fileOffset) throws IOException {
+        FileInputStream fin = new FileInputStream(p.toFile());
+        fin.getChannel().position(fileOffset);
+        return fin;
+    }
+
+    @Override
+    public DirectorySync.Blake3state hashFile(Path p) {
+        byte[] buf = new byte[4 * 1024];
+        long size = p.toFile().length();
+        Blake3 state = Blake3.initHash();
+
+        try {
+            FileInputStream fin = new FileInputStream(p.toFile());
+            for (long i = 0; i < size; ) {
+                int read = fin.read(buf);
+                state.update(buf, 0, read);
+                i += read;
+            }
+
+            byte[] hash = state.doFinalize(32);
+            return new DirectorySync.Blake3state(hash);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void applyToSubtree(Path start, Consumer<Path> file, Consumer<Path> dir) {
+        for (File f : start.toFile().listFiles()) {
+            if (f.isFile()) {
+                file.accept(f.toPath());
+            } else if (f.isDirectory()) {
+                applyToSubtree(start.resolve(f.getName()), file, dir);
+            }
+        }
+    }
+}

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -1,0 +1,135 @@
+package peergos.server.sync;
+
+import peergos.server.crypto.hash.Blake3;
+import peergos.shared.storage.auth.BatId;
+import peergos.shared.user.UserContext;
+import peergos.shared.user.fs.AsyncReader;
+import peergos.shared.user.fs.FileWrapper;
+import peergos.shared.util.Futures;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class PeergosSyncFS implements SyncFilesystem {
+
+    private final UserContext context;
+
+    public PeergosSyncFS(UserContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public boolean exists(Path p) {
+        return context.getByPath(p).join().isPresent();
+    }
+
+    @Override
+    public void mkdirs(Path p) {
+        int depth = p.getNameCount();
+        Optional<BatId> mirrorBat = context.mirrorBatId();
+        for (int i=1; i < depth; i++) {
+            Optional<FileWrapper> current = context.getByPath(p.subpath(0, i)).join();
+            if (current.isEmpty()) {
+                FileWrapper parent = context.getByPath(p.subpath(0, i - 1)).join().get();
+                parent.mkdir(p.getName(i).toString(), context.network, false, mirrorBat, context.crypto).join();
+            }
+        }
+    }
+
+    @Override
+    public void delete(Path p) {
+        FileWrapper f = context.getByPath(p).join().get();
+        FileWrapper parent = context.getByPath(p.getParent()).join().get();
+        f.remove(parent, p, context).join();
+    }
+
+    @Override
+    public void moveTo(Path src, Path target) {
+        FileWrapper from = context.getByPath(src).join().get();
+        FileWrapper newParent = context.getByPath(target.getParent()).join().get();
+        FileWrapper parent = context.getByPath(src.getParent()).join().get();
+        from.moveTo(newParent, parent, src, context, () -> Futures.of(true));
+    }
+
+    @Override
+    public long getLastModified(Path p) {
+        LocalDateTime modified = context.getByPath(p).join().get().getFileProperties().modified;
+        return modified.toInstant(ZoneOffset.UTC).toEpochMilli();
+    }
+
+    @Override
+    public void setModificationTime(Path p, long t) {
+        FileWrapper f = context.getByPath(p).join().get();
+        LocalDateTime newModified = LocalDateTime.ofInstant(Instant.ofEpochSecond(t / 1000, t % 1000), ZoneOffset.UTC);
+        Optional<FileWrapper> parent = context.getByPath(p.getParent()).join();
+        f.setProperties(f.getFileProperties().withModified(newModified), context.crypto.hasher, context.network, parent).join();
+    }
+
+    @Override
+    public long size(Path p) {
+        return context.getByPath(p).join().get().getFileProperties().size;
+    }
+
+    @Override
+    public void truncate(Path p, long size) throws IOException {
+        FileWrapper f = context.getByPath(p).join().get();
+        f.truncate(size, context.network, context.crypto).join();
+    }
+
+    @Override
+    public void setBytes(Path p, long fileOffset, AsyncReader data, long size) throws IOException {
+        FileWrapper f = context.getByPath(p).join().get();
+        long end = fileOffset + size;
+        f.overwriteSectionJS(data, (int)(fileOffset >>> 32), (int)fileOffset, (int) (end >>> 32), (int)end, context.network, context.crypto, x -> {}).join();
+    }
+
+    @Override
+    public AsyncReader getBytes(Path p, long fileOffset) throws IOException {
+        FileWrapper f = context.getByPath(p).join().get();
+        return f.getInputStream(context.network, context.crypto, x -> {}).join();
+    }
+
+    @Override
+    public DirectorySync.Blake3state hashFile(Path p) {
+        byte[] buf = new byte[4 * 1024];
+        Blake3 state = Blake3.initHash();
+
+        FileWrapper f = context.getByPath(p).join().get();
+        long size = f.getSize();
+        AsyncReader reader = f.getInputStream(context.network, context.crypto, x -> {}).join();
+        for (long i = 0; i < size; ) {
+            int read = reader.readIntoArray(buf, 0, (int)Math.min(buf.length, size - i)).join();
+            state.update(buf, 0, read);
+            i += read;
+        }
+
+        byte[] hash = state.doFinalize(32);
+        return new DirectorySync.Blake3state(hash);
+    }
+
+    @Override
+    public void applyToSubtree(Path start, Consumer<Path> onFile, Consumer<Path> onDir) {
+        FileWrapper base = context.getByPath(start).join().get();
+        applyToSubtree(start, base, onFile, onDir);
+
+    }
+
+    private void applyToSubtree(Path basePath, FileWrapper base, Consumer<Path> onFile, Consumer<Path> onDir) {
+        Set<FileWrapper> children = base.getChildren(context.crypto.hasher, context.network).join();
+        for (FileWrapper child : children) {
+            Path childPath = basePath.resolve(child.getName());
+            if (! child.isDirectory()) {
+                onFile.accept(childPath);
+            } else {
+                onDir.accept(childPath);
+                applyToSubtree(childPath, child, onFile, onDir);
+            }
+        }
+    }
+}

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -60,13 +60,13 @@ public class PeergosSyncFS implements SyncFilesystem {
     @Override
     public long getLastModified(Path p) {
         LocalDateTime modified = context.getByPath(p).join().get().getFileProperties().modified;
-        return modified.toInstant(ZoneOffset.UTC).toEpochMilli();
+        return modified.toInstant(ZoneOffset.UTC).toEpochMilli() / 1000 * 1000;
     }
 
     @Override
     public void setModificationTime(Path p, long t) {
         FileWrapper f = context.getByPath(p).join().get();
-        LocalDateTime newModified = LocalDateTime.ofInstant(Instant.ofEpochSecond(t / 1000, t % 1000), ZoneOffset.UTC);
+        LocalDateTime newModified = LocalDateTime.ofInstant(Instant.ofEpochSecond(t / 1000, 0), ZoneOffset.UTC);
         Optional<FileWrapper> parent = context.getByPath(p.getParent()).join();
         f.setProperties(f.getFileProperties().withModified(newModified), context.crypto.hasher, context.network, parent).join();
     }

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -54,9 +54,13 @@ public class PeergosSyncFS implements SyncFilesystem {
     @Override
     public void moveTo(Path src, Path target) {
         FileWrapper from = context.getByPath(src).join().get();
-        FileWrapper newParent = context.getByPath(target.getParent()).join().get();
         FileWrapper parent = context.getByPath(src.getParent()).join().get();
-        from.moveTo(newParent, parent, src, context, () -> Futures.of(true));
+        if (target.getParent().equals(src.getParent())) { // rename
+            from.rename(target.getFileName().toString(), parent, src, context).join();
+        } else {
+            FileWrapper newParent = context.getByPath(target.getParent()).join().get();
+            from.moveTo(newParent, parent, src, context, () -> Futures.of(true));
+        }
     }
 
     @Override

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -96,7 +96,7 @@ public class PeergosSyncFS implements SyncFilesystem {
     }
 
     @Override
-    public DirectorySync.Blake3state hashFile(Path p) {
+    public Blake3state hashFile(Path p) {
         byte[] buf = new byte[4 * 1024];
         Blake3 state = Blake3.initHash();
 
@@ -110,7 +110,7 @@ public class PeergosSyncFS implements SyncFilesystem {
         }
 
         byte[] hash = state.doFinalize(32);
-        return new DirectorySync.Blake3state(hash);
+        return new Blake3state(hash);
     }
 
     @Override

--- a/src/peergos/server/sync/RamTreeState.java
+++ b/src/peergos/server/sync/RamTreeState.java
@@ -1,0 +1,18 @@
+package peergos.server.sync;
+
+import java.util.*;
+
+class RamTreeState {
+    public final Map<String, FileState> filesByPath = new HashMap<>();
+    public final Map<Blake3state, List<FileState>> fileByHash = new HashMap<>();
+
+    public void add(FileState fs) {
+        filesByPath.put(fs.relPath, fs);
+        fileByHash.putIfAbsent(fs.hash, new ArrayList<>());
+        fileByHash.get(fs.hash).add(fs);
+    }
+
+    public List<FileState> byHash(Blake3state b3) {
+        return fileByHash.getOrDefault(b3, Collections.emptyList());
+    }
+}

--- a/src/peergos/server/sync/RamTreeState.java
+++ b/src/peergos/server/sync/RamTreeState.java
@@ -4,7 +4,7 @@ import peergos.shared.user.fs.Blake3state;
 
 import java.util.*;
 
-class RamTreeState {
+class RamTreeState implements SyncState {
     public final Map<String, FileState> filesByPath = new HashMap<>();
     public final Map<Blake3state, List<FileState>> fileByHash = new HashMap<>();
 
@@ -12,6 +12,11 @@ class RamTreeState {
         filesByPath.put(fs.relPath, fs);
         fileByHash.putIfAbsent(fs.hash, new ArrayList<>());
         fileByHash.get(fs.hash).add(fs);
+    }
+
+    @Override
+    public FileState byPath(String path) {
+        return filesByPath.get(path);
     }
 
     public List<FileState> byHash(Blake3state b3) {

--- a/src/peergos/server/sync/RamTreeState.java
+++ b/src/peergos/server/sync/RamTreeState.java
@@ -1,5 +1,7 @@
 package peergos.server.sync;
 
+import peergos.shared.user.fs.Blake3state;
+
 import java.util.*;
 
 class RamTreeState {

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -3,7 +3,6 @@ package peergos.server.sync;
 import peergos.shared.user.fs.AsyncReader;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
@@ -29,7 +28,7 @@ interface SyncFilesystem {
 
     AsyncReader getBytes(Path p, long fileOffset) throws IOException;
 
-    DirectorySync.Blake3state hashFile(Path p);
+    Blake3state hashFile(Path p);
 
     void applyToSubtree(Path start, Consumer<Path> file, Consumer<Path> dir);
 }

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -1,5 +1,7 @@
 package peergos.server.sync;
 
+import peergos.shared.user.fs.AsyncReader;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -23,9 +25,9 @@ interface SyncFilesystem {
 
     void truncate(Path p, long size) throws IOException;
 
-    void setBytes(Path p, long fileOffset, InputStream data, long size) throws IOException;
+    void setBytes(Path p, long fileOffset, AsyncReader data, long size) throws IOException;
 
-    InputStream getBytes(Path p, long fileOffset) throws IOException;
+    AsyncReader getBytes(Path p, long fileOffset) throws IOException;
 
     DirectorySync.Blake3state hashFile(Path p);
 

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -1,0 +1,33 @@
+package peergos.server.sync;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+interface SyncFilesystem {
+
+    boolean exists(Path p);
+
+    void mkdirs(Path p);
+
+    void delete(Path p);
+
+    void moveTo(Path src, Path target);
+
+    long getLastModified(Path p);
+
+    void setModificationTime(Path p, long t);
+
+    long size(Path p);
+
+    void truncate(Path p, long size) throws IOException;
+
+    void setBytes(Path p, long fileOffset, InputStream data, long size) throws IOException;
+
+    InputStream getBytes(Path p, long fileOffset) throws IOException;
+
+    DirectorySync.Blake3state hashFile(Path p);
+
+    void applyToSubtree(Path start, Consumer<Path> file, Consumer<Path> dir);
+}

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -1,6 +1,7 @@
 package peergos.server.sync;
 
 import peergos.shared.user.fs.AsyncReader;
+import peergos.shared.user.fs.Blake3state;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -19,6 +20,8 @@ interface SyncFilesystem {
     long getLastModified(Path p);
 
     void setModificationTime(Path p, long t);
+
+    void setHash(Path p, Blake3state hash);
 
     long size(Path p);
 

--- a/src/peergos/server/sync/SyncState.java
+++ b/src/peergos/server/sync/SyncState.java
@@ -1,0 +1,14 @@
+package peergos.server.sync;
+
+import peergos.shared.user.fs.Blake3state;
+
+import java.util.List;
+
+public interface SyncState {
+
+    void add(FileState fs);
+
+    FileState byPath(String path);
+
+    List<FileState> byHash(Blake3state b3);
+}

--- a/src/peergos/server/tests/Blake3Tests.java
+++ b/src/peergos/server/tests/Blake3Tests.java
@@ -1,0 +1,21 @@
+package peergos.server.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import peergos.server.crypto.hash.Blake3;
+import peergos.shared.util.ArrayOps;
+
+import java.util.Random;
+
+public class Blake3Tests {
+
+    @Test
+    public void correct() {
+        Blake3 b3 = Blake3.initHash();
+        byte[] data = new byte[4096];
+        new Random(42).nextBytes(data);
+        b3.update(data);
+        byte[] hash = b3.doFinalize(32);
+        Assert.assertEquals(ArrayOps.bytesToHex(hash), "3393625f68437730188ea2f582ac38f9ec6ead68ea6351caf36030d4a7b94ac5");
+    }
+}

--- a/src/peergos/server/tests/BlockSizeTests.java
+++ b/src/peergos/server/tests/BlockSizeTests.java
@@ -25,7 +25,7 @@ public class BlockSizeTests {
         SymmetricKey parentParent = SymmetricKey.random();
         Optional<BatId> mirrorBatId = Optional.of(BatId.sha256(Bat.random(crypto.random), crypto.hasher).join());
         FileProperties props = new FileProperties("a-directory", true, false, "", 0, 0,
-                LocalDateTime.now(), LocalDateTime.now(), false, Optional.empty(), Optional.empty());
+                LocalDateTime.now(), LocalDateTime.now(), false, Optional.empty(), Optional.empty(), Optional.empty());
         SigningPrivateKeyAndPublicHash signingPair = ChampTests.createUser(new RAMStorage(crypto.hasher), crypto);
 
         Optional<RelativeCapability> parentCap = Optional.of(new RelativeCapability(Optional.empty(), crypto.random.randomBytes(32), Optional.of(Bat.random(crypto.random)), parentParent, Optional.empty()));

--- a/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
+++ b/src/peergos/server/tests/simulation/NativeFileSystemImpl.java
@@ -180,7 +180,7 @@ public class NativeFileSystemImpl implements FileSystem {
                 //TODO make files use the new format with a stream secret
                 Optional<byte[]> streamSecret = file.isDirectory() ? Optional.empty() : Optional.empty();
                 return new FileProperties(file.getName(), file.isDirectory(), false, mimeType, sizeHi, sizeLo, lastModified,
-                        created, isHidden, thumbnail, streamSecret);
+                        created, isHidden, thumbnail, streamSecret, Optional.empty());
 
             }
 

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -30,7 +30,10 @@ import java.util.stream.*;
  *  This class is unprivileged - doesn't have any private keys
  */
 public class NetworkAccess {
-    private static final Logger LOG = Logger.getGlobal();
+    private static final Logger LOG = Logger.getLogger(NetworkAccess.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
 
     public final Hasher hasher;
     public final CoreNode coreNode;

--- a/src/peergos/shared/corenode/HTTPCoreNode.java
+++ b/src/peergos/shared/corenode/HTTPCoreNode.java
@@ -19,7 +19,10 @@ import java.util.concurrent.*;
 import java.util.stream.*;
 
 public class HTTPCoreNode implements CoreNode {
-	private static final Logger LOG = Logger.getGlobal();
+	private static final Logger LOG = Logger.getLogger(HTTPCoreNode.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
 	private static final String P2P_PROXY_PROTOCOL = "/http";
 
     private final HttpPoster poster;

--- a/src/peergos/shared/mutable/HttpMutablePointers.java
+++ b/src/peergos/shared/mutable/HttpMutablePointers.java
@@ -12,8 +12,11 @@ import java.util.*;
 import java.util.concurrent.*;
 
 public class HttpMutablePointers implements MutablePointersProxy {
-	private static final Logger LOG = Logger.getGlobal();
-	private static final String P2P_PROXY_PROTOCOL = "/http";
+	private static final Logger LOG = Logger.getLogger(HttpMutablePointers.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
+    private static final String P2P_PROXY_PROTOCOL = "/http";
 
     private static final boolean LOGGING = true;
     private final HttpPoster direct, p2p;

--- a/src/peergos/shared/social/HttpSocialNetwork.java
+++ b/src/peergos/shared/social/HttpSocialNetwork.java
@@ -12,8 +12,11 @@ import java.net.*;
 import java.util.concurrent.*;
 
 public class HttpSocialNetwork implements SocialNetworkProxy {
+	private static final Logger LOG = Logger.getLogger(HttpSocialNetwork.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
     private static final String P2P_PROXY_PROTOCOL = "/http";
-	private static final Logger LOG = Logger.getGlobal();
 
     private final HttpPoster direct, p2p;
 

--- a/src/peergos/shared/storage/HttpSpaceUsage.java
+++ b/src/peergos/shared/storage/HttpSpaceUsage.java
@@ -12,8 +12,11 @@ import java.util.concurrent.*;
 import java.util.logging.*;
 
 public class HttpSpaceUsage implements SpaceUsageProxy {
+	private static final Logger LOG = Logger.getLogger(HttpSpaceUsage.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
     private static final String P2P_PROXY_PROTOCOL = "/http";
-	private static final Logger LOG = Logger.getGlobal();
 
     private final HttpPoster direct, p2p;
 

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 @JsType
 public class TrieNodeImpl implements TrieNode {
-	private static final Logger LOG = Logger.getGlobal();
+	private static final Logger LOG = Logger.getLogger(TrieNodeImpl.class.getName());
     private final Map<String, TrieNode> children;
     private final Optional<EntryPoint> value;
 
@@ -36,7 +36,7 @@ public class TrieNodeImpl implements TrieNode {
     @Override
     public CompletableFuture<Optional<FileWrapper>> getByPath(String path, Hasher hasher, NetworkAccess network) {
         FileProperties.ensureValidPath(path);
-        LOG.info("GetByPath: " + path);
+//        LOG.info("GetByPath: " + path);
         String finalPath = TrieNode.canonicalise(path);
         if (finalPath.length() == 0) {
             if (! value.isPresent()) { // find a valid child entry and traverse parent links

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -8,12 +8,16 @@ import peergos.shared.util.Futures;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 @JsType
 public class TrieNodeImpl implements TrieNode {
 	private static final Logger LOG = Logger.getLogger(TrieNodeImpl.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
     private final Map<String, TrieNode> children;
     private final Optional<EntryPoint> value;
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -1238,7 +1238,7 @@ public class UserContext {
                                 LocalDateTime timestamp = LocalDateTime.now();
                                 return CryptreeNode.createEmptyDir(MaybeMultihash.empty(), rootRKey, rootWKey, Optional.of(writerPair),
                                                 new FileProperties(directoryName, true, false, "", 0, timestamp, timestamp,
-                                                        false, Optional.empty(), Optional.empty()),
+                                                        false, Optional.empty(), Optional.empty(), Optional.empty()),
                                                 Optional.empty(), SymmetricKey.random(), nextChunk, rootBat, mirrorBatId, crypto.random, crypto.hasher)
                                         .thenCompose(root -> {
                                             LOG.info("Uploading entry point directory");

--- a/src/peergos/shared/user/fs/Blake3state.java
+++ b/src/peergos/shared/user/fs/Blake3state.java
@@ -1,15 +1,32 @@
-package peergos.server.sync;
+package peergos.shared.user.fs;
 
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
 import peergos.shared.util.ArrayOps;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
-class Blake3state {
+public class Blake3state implements Cborable {
     public final byte[] hash;
 
     public Blake3state(byte[] hash) {
         this.hash = hash;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("h", new CborObject.CborByteArray(hash));
+
+        return CborObject.CborMap.build(state);
+    }
+
+    public static Blake3state fromCbor(Cborable c) {
+        byte[] hash = ((CborObject.CborMap) c).getByteArray("h");
+        return new Blake3state(hash);
     }
 
     @Override

--- a/src/peergos/shared/user/fs/FileProperties.java
+++ b/src/peergos/shared/user/fs/FileProperties.java
@@ -21,7 +21,8 @@ import java.util.stream.*;
 public class FileProperties implements Cborable {
     public static final int MAX_FILE_NAME_SIZE = 255;
     public static final int MAX_PATH_SIZE = 4096;
-    public static final FileProperties EMPTY = new FileProperties(".subsequent-dir-chunk", true, false, "", 0, LocalDateTime.MIN, LocalDateTime.MIN, false, Optional.empty(), Optional.empty());
+    public static final FileProperties EMPTY = new FileProperties(".subsequent-dir-chunk", true, false, "", 0,
+            LocalDateTime.MIN, LocalDateTime.MIN, false, Optional.empty(), Optional.empty(), Optional.empty());
 
     public final String name;
     public final boolean isDirectory;
@@ -34,6 +35,7 @@ public class FileProperties implements Cborable {
     public final boolean isHidden;
     public final Optional<Thumbnail> thumbnail;
     public final Optional<byte[]> streamSecret;
+    public final Optional<Blake3state> hash;
 
     public FileProperties(String name,
                           boolean isDirectory,
@@ -44,7 +46,8 @@ public class FileProperties implements Cborable {
                           LocalDateTime created,
                           boolean isHidden,
                           Optional<Thumbnail> thumbnail,
-                          Optional<byte[]> streamSecret) {
+                          Optional<byte[]> streamSecret,
+                          Optional<Blake3state> hash) {
         if (name.length() > MAX_FILE_NAME_SIZE)
             throw new IllegalStateException("File and directory names must be less than 256 characters.");
         if (isDirectory && streamSecret.isPresent())
@@ -63,6 +66,7 @@ public class FileProperties implements Cborable {
         this.isHidden = isHidden;
         this.thumbnail = thumbnail;
         this.streamSecret = streamSecret;
+        this.hash = hash;
     }
 
     @JsIgnore
@@ -75,8 +79,9 @@ public class FileProperties implements Cborable {
                           LocalDateTime created,
                           boolean isHidden,
                           Optional<Thumbnail> thumbnail,
-                          Optional<byte[]> streamSecret) {
-        this(name, isDirectory, isLink, mimeType, (int)(size >> 32), (int) size, modified, created, isHidden, thumbnail, streamSecret);
+                          Optional<byte[]> streamSecret,
+                          Optional<Blake3state> hash) {
+        this(name, isDirectory, isLink, mimeType, (int)(size >> 32), (int) size, modified, created, isHidden, thumbnail, streamSecret, hash);
     }
 
     /** Override this properties name with the link's name
@@ -85,7 +90,7 @@ public class FileProperties implements Cborable {
      * @return
      */
     public FileProperties withLink(FileProperties link) {
-        return new FileProperties(link.name, isDirectory, false, mimeType, size, modified, created, isHidden, thumbnail, streamSecret);
+        return new FileProperties(link.name, isDirectory, false, mimeType, size, modified, created, isHidden, thumbnail, streamSecret, hash);
     }
 
     public static void ensureValidParsedPath(Path path) {
@@ -181,6 +186,7 @@ public class FileProperties implements Cborable {
         state.put("c", new CborObject.CborLong(created.toEpochSecond(ZoneOffset.UTC)));
         state.put("cn", new CborObject.CborLong(created.getNano()));
         state.put("h", new CborObject.CborBoolean(isHidden));
+        hash.ifPresent(b -> state.put("b", b.toCbor()));
         thumbnail.ifPresent(thumb -> state.put("i", new CborObject.CborByteArray(thumb.data)));
         thumbnail.ifPresent(thumb -> state.put("im", new CborObject.CborString(thumb.mimeType)));
         streamSecret.ifPresent(secret -> state.put("p", new CborObject.CborByteArray(secret)));
@@ -205,34 +211,39 @@ public class FileProperties implements Cborable {
         Optional<byte[]> thumbnailData = m.getOptionalByteArray("i");
         Optional<Thumbnail> thumbnail = thumbnailData.map(d -> new Thumbnail(m.getString("im", "image/png"), d));
         Optional<byte[]> streamSecret = m.getOptionalByteArray("p");
+        Optional<Blake3state> b3 = m.getOptional("b", Blake3state::fromCbor);
 
         LocalDateTime modified = LocalDateTime.ofEpochSecond(modifiedEpochSeconds, modifiedNano, ZoneOffset.UTC);
         LocalDateTime created = LocalDateTime.ofEpochSecond(createdEpochSeconds, createdNano, ZoneOffset.UTC);
-        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, streamSecret);
+        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, streamSecret, b3);
     }
 
     @JsIgnore
     public FileProperties withSize(long newSize) {
-        return new FileProperties(name, isDirectory, isLink, mimeType, newSize, modified, created, isHidden, thumbnail, streamSecret);
+        return new FileProperties(name, isDirectory, isLink, mimeType, newSize, modified, created, isHidden, thumbnail, streamSecret, Optional.empty());
+    }
+
+    public FileProperties withHash(Optional<Blake3state> hash) {
+        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, streamSecret, hash);
     }
 
     public FileProperties withNoThumbnail() {
-        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, Optional.empty(), streamSecret);
+        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, Optional.empty(), streamSecret, hash);
     }
     public FileProperties withThumbnail(Optional<Thumbnail> newThumbnail) {
-        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, newThumbnail, streamSecret);
+        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, newThumbnail, streamSecret, hash);
     }
 
     public FileProperties withModified(LocalDateTime modified) {
-        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, streamSecret);
+        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, streamSecret, hash);
     }
 
     public FileProperties withNewStreamSecret(byte[] streamSecret) {
-        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, Optional.of(streamSecret));
+        return new FileProperties(name, isDirectory, isLink, mimeType, size, modified, created, isHidden, thumbnail, Optional.of(streamSecret), hash);
     }
 
     public FileProperties asLink() {
-        return new FileProperties(name, isDirectory, true, mimeType, size, modified, created, isHidden, thumbnail, streamSecret);
+        return new FileProperties(name, isDirectory, true, mimeType, size, modified, created, isHidden, thumbnail, streamSecret, hash);
     }
 
     public String getType() {

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -19,7 +19,10 @@ import java.util.concurrent.*;
 import java.util.stream.*;
 
 public class FileUploader implements AutoCloseable {
-	private static final Logger LOG = Logger.getGlobal();
+	private static final Logger LOG = Logger.getLogger(FileUploader.class.getName());
+    public static void disableLog() {
+        LOG.setLevel(Level.OFF);
+    }
 
     private final String name;
     private final long offset, length;
@@ -176,7 +179,7 @@ public class FileUploader implements AutoCloseable {
             SafeRandom random,
             Hasher hasher,
             boolean isJS) {
-        Logger.getGlobal().info("encrypting chunk: "+chunkIndex + " of "+name);
+        LOG.info("encrypting chunk: "+chunkIndex + " of "+name);
         long position = chunkIndex * Chunk.MAX_SIZE;
 
         long fileLength = length;
@@ -222,7 +225,7 @@ public class FileUploader implements AutoCloseable {
         CappedProgressConsumer progress = new CappedProgressConsumer(monitor, chunk.chunk.length());
         if (fragments.size() < file.fragments.size() || fragments.isEmpty())
             progress.accept((long) chunk.chunk.length());
-        Logger.getGlobal().info("Uploading chunk with " + fragments.size() + " fragments to mapkey " + chunk.location.toString() + "\n");
+        LOG.info("Uploading chunk with " + fragments.size() + " fragments to mapkey " + chunk.location.toString() + "\n");
         return IpfsTransaction.call(chunk.location.owner,
                 tid -> network.uploadFragments(fragments, chunk.location.owner, writer, progress, tid)
                         .thenCompose(hashes -> network.uploadChunk(current, committer, metadata, chunk.location.owner,

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -1012,7 +1012,7 @@ public class CryptreeNode implements Cborable {
         LocalDateTime timestamp = LocalDateTime.now();
         return CryptreeNode.createEmptyDir(MaybeMultihash.empty(), dirReadKey, dirWriteKey, Optional.empty(),
                 new FileProperties(name, true, false, "", 0, timestamp, timestamp, isSystemFolder,
-                        Optional.empty(), Optional.empty()), Optional.of(ourCap), SymmetricKey.random(), nextChunk, dirBat, mirrorBat, crypto.random, crypto.hasher)
+                        Optional.empty(), Optional.empty(), Optional.empty()), Optional.of(ourCap), SymmetricKey.random(), nextChunk, dirBat, mirrorBat, crypto.random, crypto.hasher)
                 .thenCompose(child -> {
 
                     SymmetricLink toChildWriteKey = SymmetricLink.fromPair(us.wBaseKey.get(), dirWriteKey);


### PR DESCRIPTION
This adds a new command which allows you to bi-directionally sync a native folder to a peergos folder. 

For the remote and local dir it builds a path lookup to {file hash, size, modified time} and uses this to compare corresponding paths, or, in the case of renames or moves, files with the same hash. 

To facilitate this efficiently from Peergos, we store the blake3 hash of the plaintext of a file in the encrypted file metadata (FileProperties). Currently any modification in the web-ui will remove this field, forcing the sync client to download the file. Eventually we would like to switch to 4 MiB chunks, store each chunk hash in the FileProperties (up to 64KiB total) and keep the blake3 hash up-to-date even in the browser with a browser implementation of blake3 + its merkle tree. 

Currently it only syncs whole files. We can add diff calculation later using the blake3 merkle tree.