### PR TITLE
Handle dangling caps in directory listing

### DIFF
--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -182,7 +182,7 @@ public class PeergosSyncFS implements SyncFilesystem {
     }
 
     private void applyToSubtree(Path basePath, FileWrapper base, Consumer<Path> onFile, Consumer<Path> onDir) {
-        Set<FileWrapper> children = base.getChildren(context.crypto.hasher, context.network).join();
+        Set<FileWrapper> children = base.getChildren(base.version, context.crypto.hasher, context.network, false).join();
         for (FileWrapper child : children) {
             Path childPath = basePath.resolve(child.getName());
             if (! child.isDirectory()) {

--- a/src/peergos/shared/user/TrieNodeImpl.java
+++ b/src/peergos/shared/user/TrieNodeImpl.java
@@ -158,7 +158,7 @@ public class TrieNodeImpl implements TrieNode {
             return network.getFile(value.get(), version)
                     .thenCompose(dir -> {
                         if (dir.isPresent())
-                            return dir.get().getChildren(version, hasher, network)
+                            return dir.get().getChildren(version, hasher, network, true)
                                     .thenCompose(kids -> {
                                         if (dir.get().isWritable())
                                             return Futures.of(kids);
@@ -178,7 +178,7 @@ public class TrieNodeImpl implements TrieNode {
         if (!children.containsKey(elements[0]))
             return network.getFile(value.get(), version)
                     .thenCompose(dir -> dir.get().getDescendentByPath(trimmedPath, hasher, network)
-                            .thenCompose(parent -> parent.map(p -> p.getChildren(version, hasher, network))
+                            .thenCompose(parent -> parent.map(p -> p.getChildren(version, hasher, network, true))
                                     .orElseGet(() -> Futures.of(Collections.emptySet()))));
         return children.get(elements[0]).getChildren(trimmedPath.substring(elements[0].length()), hasher, version, network);
     }

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -375,6 +375,16 @@ public class FileWrapper {
         throw new IllegalStateException("Unreadable FileWrapper!");
     }
 
+    /**
+     *
+     * @param owner
+     * @param caps
+     * @param entryWriter
+     * @param ownername
+     * @param network
+     * @param version
+     * @return the children, or the list of caps pointing to deleted files
+     */
     private static CompletableFuture<Set<FileWrapper>> getFiles(PublicKeyHash owner,
                                                                 Set<NamedAbsoluteCapability> caps,
                                                                 Optional<SigningPrivateKeyAndPublicHash> entryWriter,
@@ -386,6 +396,11 @@ public class FileWrapper {
                 .collect(Collectors.toSet());
         return version.withWriters(owner, childWriters, network)
                 .thenCompose(fullVersion -> network.retrieveAllMetadata(caps.stream().map(n -> n.cap).collect(Collectors.toList()), fullVersion)
+                        .thenApply(p -> {
+                            if (! p.right.isEmpty())
+                                System.out.println("Couldn't retrieve " + p.right.size() + " children listing dir.");
+                            return p.left;
+                        })
                         .thenCompose(rcs -> Futures.combineAll(rcs.stream()
                                 .map(rc -> {
                                     FileProperties props = rc.getProperties();

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -372,12 +372,15 @@ public class FileWrapper {
             return pointer.fileAccess.getAllChildrenCapabilities(version, pointer.capability, hasher, network)
                     .thenCompose(childCaps -> getFiles(owner(), childCaps, childsEntryWriter, ownername, network, version)
                             .thenApply(p -> {
-                                if (! allowDanglingLinks && ! p.right.isEmpty()) {
+                                if (! p.right.isEmpty()) {
                                     List<NamedAbsoluteCapability> dangling = p.right.stream()
                                             .map(c -> childCaps.stream().filter(nc -> nc.cap.equals(c)).findFirst().get())
                                             .collect(Collectors.toList());
-                                    throw new IllegalStateException("Couldn't retrieve children " +
-                                            dangling.stream().map(nc -> nc.name.name).collect(Collectors.toList()) + " in dir " + getName());
+                                    List<String> names = dangling.stream().map(nc -> nc.name.name).collect(Collectors.toList());
+                                    if (! allowDanglingLinks) {
+                                        throw new IllegalStateException("Couldn't retrieve children " + names + " in dir " + getName());
+                                    }
+                                    LOG.info("Couldn't retrieve children " + names + " in dir " + getName());
                                 }
                                 return p.left;
                             }));

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -365,8 +365,9 @@ public class CryptreeNode implements Cborable {
                                                                          Snapshot version) {
         return getDirectChildrenCapabilities(us, version, network)
                 .thenCompose(c -> network.retrieveAllMetadata(c.stream()
-                        .map(n -> n.cap)
-                        .collect(Collectors.toList()), version)
+                                .map(n -> n.cap)
+                                .collect(Collectors.toList()), version)
+                        .thenApply(p -> p.left)
                         .thenApply(HashSet::new));
     }
 


### PR DESCRIPTION
The sync client can't tolerate incomplete listings or it will delete things. Until now we have tolerated them, and they are likely present because of a just fixed bug in bulk delete in large directories (>500 children).

This still doesn't repair the dir (remove the dangling links), as we need to be confident that a transient error cannot cause a deletion!