### PR TITLE
Implement diff sync

### DIFF
--- a/src/peergos/server/cli/CLI.java
+++ b/src/peergos/server/cli/CLI.java
@@ -272,7 +272,7 @@ public class CLI implements Runnable {
                         long fileSize = p.toFile().length();
                         LocalDateTime modified = LocalDateTime.ofInstant(Instant.ofEpochSecond(p.toFile().lastModified() / 1000, 0), ZoneOffset.UTC);
                         return new FileWrapper.FileUploadProperties(p.getFileName().toString(), () -> reader(p.toFile()),
-                                (int) (fileSize >> 32), (int) fileSize, Optional.of(modified), Optional.of(ScryptJava.hashFile(p)), skipExisting, true,
+                                (int) (fileSize >> 32), (int) fileSize, Optional.of(modified), Optional.of(ScryptJava.hashFile(p, cliContext.userContext.crypto.hasher)), skipExisting, true,
                                 progressCreator.create(remoteRelativeDir, p.getFileName().toString(), Math.max(4096, fileSize)));
                     })
                     .collect(Collectors.toList());

--- a/src/peergos/server/sync/FileState.java
+++ b/src/peergos/server/sync/FileState.java
@@ -9,7 +9,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-class FileState implements Cborable {
+public class FileState implements Cborable {
     public final String relPath;
     public final long modificationTime;
     public final long size;

--- a/src/peergos/server/sync/JdbcTreeState.java
+++ b/src/peergos/server/sync/JdbcTreeState.java
@@ -138,10 +138,11 @@ public class JdbcTreeState implements SyncState {
         if (existing != null) {
             try (Connection conn = getConnection();
                  PreparedStatement update = conn.prepareStatement(UPDATE)) {
-                update.setBytes(1, fs.hashTree.serialize());
-                update.setLong(2, fs.modificationTime);
-                update.setLong(3, fs.size);
-                update.setString(4, fs.relPath);
+                update.setBytes(1, fs.hashTree.rootHash.serialize());
+                update.setBytes(2, fs.hashTree.serialize());
+                update.setLong(3, fs.modificationTime);
+                update.setLong(4, fs.size);
+                update.setString(5, fs.relPath);
                 update.executeUpdate();
             } catch (SQLException sqe) {
                 throw new IllegalStateException(sqe);
@@ -150,7 +151,7 @@ public class JdbcTreeState implements SyncState {
             try (Connection conn = getConnection();
                  PreparedStatement insert = conn.prepareStatement(INSERT)) {
                 insert.setString(1, fs.relPath);
-                insert.setBytes(2, fs.hashTree.serialize());
+                insert.setBytes(2, fs.hashTree.rootHash.serialize());
                 insert.setLong(3, fs.modificationTime);
                 insert.setLong(4, fs.size);
                 insert.setBytes(5, fs.hashTree.serialize());

--- a/src/peergos/server/sync/JdbcTreeState.java
+++ b/src/peergos/server/sync/JdbcTreeState.java
@@ -5,8 +5,8 @@ import peergos.server.sql.SqliteCommands;
 import peergos.server.util.Sqlite;
 import peergos.shared.cbor.CborObject;
 import peergos.shared.cbor.Cborable;
-import peergos.shared.user.fs.Blake3state;
-import peergos.shared.util.PathUtil;
+import peergos.shared.user.fs.HashTree;
+import peergos.shared.user.fs.RootHash;
 
 import java.nio.file.Paths;
 import java.sql.Connection;
@@ -17,13 +17,13 @@ import java.util.*;
 import java.util.function.Supplier;
 
 public class JdbcTreeState implements SyncState {
-    private static final String INSERT = "INSERT INTO syncstate (path, b3, modtime, size) VALUES(?, ?, ?, ?);";
+    private static final String INSERT = "INSERT INTO syncstate (path, roothash, modtime, size, hashtree) VALUES(?, ?, ?, ?, ?);";
     private static final String INSERT_DIR_SUFFIX = "INTO syncdirs (path) VALUES(?);";
-    private static final String UPDATE = "UPDATE syncstate SET b3=?, modtime=?, size=? WHERE path=?;";
+    private static final String UPDATE = "UPDATE syncstate SET roothash=?, hashtree=?, modtime=?, size=? WHERE path=?;";
     private static final String DELETE = "DELETE from syncstate WHERE path = ?;";
     private static final String DELETE_DIR = "DELETE from syncdirs WHERE path = ?;";
-    private static final String GET_BY_PATH = "SELECT path, b3, modtime, size FROM syncstate WHERE path = ?;";
-    private static final String GET_BY_HASH = "SELECT path, b3, modtime, size FROM syncstate WHERE b3 = ?;";
+    private static final String GET_BY_PATH = "SELECT path, modtime, size, hashtree FROM syncstate WHERE path = ?;";
+    private static final String GET_BY_HASH = "SELECT path, modtime, size, hashtree FROM syncstate WHERE roothash = ?;";
     private static final String GET_DIRS = "SELECT path FROM syncdirs;";
     private static final String HAS_DIR = "SELECT path FROM syncdirs WHERE path=?;";
     private static final String INSERT_COPY_OP = "INSERT INTO copyops (islocal, source, target, start, end, sourcestate, targetstate) VALUES(?, ?, ?, ?, ?, ?, ?);";
@@ -58,8 +58,8 @@ public class JdbcTreeState implements SyncState {
 
     private synchronized void init() {
         try (Connection conn = getConnection()) {
-            cmds.createTable("CREATE TABLE IF NOT EXISTS syncstate (path text primary key not null, b3 blob, modtime bigint not null, size bigint not null); " +
-                    "CREATE INDEX IF NOT EXISTS sync_hash_index ON syncstate (b3);", conn);
+            cmds.createTable("CREATE TABLE IF NOT EXISTS syncstate (path text primary key not null, roothash blob, modtime bigint not null, size bigint not null, hashtree blob); " +
+                    "CREATE INDEX IF NOT EXISTS sync_hash_index ON syncstate (roothash);", conn);
             cmds.createTable("CREATE TABLE IF NOT EXISTS syncdirs (path text primary key not null);", conn);
             cmds.createTable("CREATE TABLE IF NOT EXISTS copyops (islocal bool not null, source text not null, target text not null, " +
                     "start "+cmds.sqlInteger()+" not null, end " + cmds.sqlInteger() + " not null, sourcestate blob, targetstate blob);", conn);
@@ -124,7 +124,7 @@ public class JdbcTreeState implements SyncState {
             select.setString(1, path);
             ResultSet rs = select.executeQuery();
             if (rs.next())
-                return new FileState(rs.getString(1), rs.getLong(3), rs.getLong(4), new Blake3state(rs.getBytes(2)));
+                return new FileState(rs.getString(1), rs.getLong(2), rs.getLong(3), HashTree.fromCbor(CborObject.fromByteArray(rs.getBytes(4))));
 
             return null;
         } catch (SQLException sqe) {
@@ -138,7 +138,7 @@ public class JdbcTreeState implements SyncState {
         if (existing != null) {
             try (Connection conn = getConnection();
                  PreparedStatement update = conn.prepareStatement(UPDATE)) {
-                update.setBytes(1, fs.hash.hash);
+                update.setBytes(1, fs.hashTree.serialize());
                 update.setLong(2, fs.modificationTime);
                 update.setLong(3, fs.size);
                 update.setString(4, fs.relPath);
@@ -150,9 +150,10 @@ public class JdbcTreeState implements SyncState {
             try (Connection conn = getConnection();
                  PreparedStatement insert = conn.prepareStatement(INSERT)) {
                 insert.setString(1, fs.relPath);
-                insert.setBytes(2, fs.hash.hash);
+                insert.setBytes(2, fs.hashTree.serialize());
                 insert.setLong(3, fs.modificationTime);
                 insert.setLong(4, fs.size);
+                insert.setBytes(5, fs.hashTree.serialize());
                 insert.executeUpdate();
             } catch (SQLException sqe) {
                 throw new IllegalStateException(sqe);
@@ -171,14 +172,14 @@ public class JdbcTreeState implements SyncState {
     }
 
     @Override
-    public List<FileState> byHash(Blake3state b3) {
+    public List<FileState> byHash(RootHash hash) {
         try (Connection conn = getConnection();
              PreparedStatement select = conn.prepareStatement(GET_BY_HASH)) {
-            select.setBytes(1, b3.serialize());
+            select.setBytes(1, hash.serialize());
             ResultSet rs = select.executeQuery();
             List<FileState> res = new ArrayList<>();
             while (rs.next())
-                res.add(new FileState(rs.getString(1), rs.getLong(3), rs.getLong(4), new Blake3state(rs.getBytes(2))));
+                res.add(new FileState(rs.getString(1), rs.getLong(2), rs.getLong(3), HashTree.fromCbor(CborObject.fromByteArray(rs.getBytes(4)))));
 
             return res;
         } catch (SQLException sqe) {

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -2,12 +2,10 @@ package peergos.server.sync;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import peergos.server.crypto.hash.Blake3;
 import peergos.server.crypto.hash.ScryptJava;
 import peergos.server.simulation.FileAsyncReader;
-import peergos.shared.user.fs.AsyncReader;
-import peergos.shared.user.fs.Blake3state;
-import peergos.shared.user.fs.FileWrapper;
+import peergos.shared.crypto.hash.Hasher;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.Pair;
 
 import java.io.*;
@@ -22,6 +20,11 @@ import java.util.stream.Stream;
 public class LocalFileSystem implements SyncFilesystem {
 
     private static final Logger LOG = LoggerFactory.getLogger(LocalFileSystem.class);
+    private final Hasher hasher;
+
+    public LocalFileSystem(Hasher hasher) {
+        this.hasher = hasher;
+    }
 
     @Override
     public boolean exists(Path p) {
@@ -71,10 +74,10 @@ public class LocalFileSystem implements SyncFilesystem {
     }
 
     @Override
-    public void setHash(Path p, Blake3state hash) {}
+    public void setHash(Path p, HashTree hashTree, long fileSize) {}
 
     @Override
-    public void setHashes(List<Pair<FileWrapper, Blake3state>> toUpdate) {}
+    public void setHashes(List<Pair<FileWrapper, HashTree>> toUpdate) {}
 
     @Override
     public long size(Path p) {
@@ -113,8 +116,8 @@ public class LocalFileSystem implements SyncFilesystem {
     }
 
     @Override
-    public Blake3state hashFile(Path p, Optional<FileWrapper> meta) {
-        return ScryptJava.hashFile(p);
+    public HashTree hashFile(Path p, Optional<FileWrapper> meta, String relPath, SyncState syncedVersions) {
+        return ScryptJava.hashFile(p, hasher);
     }
 
     @Override

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -1,8 +1,6 @@
 package peergos.server.sync;
 
-import peergos.shared.user.fs.AsyncReader;
-import peergos.shared.user.fs.Blake3state;
-import peergos.shared.user.fs.FileWrapper;
+import peergos.shared.user.fs.*;
 import peergos.shared.util.Pair;
 
 import java.io.IOException;
@@ -29,9 +27,9 @@ interface SyncFilesystem {
 
     void setModificationTime(Path p, long t);
 
-    void setHash(Path p, Blake3state hash);
+    void setHash(Path p, HashTree hashTree, long fileSize);
 
-    void setHashes(List<Pair<FileWrapper, Blake3state>> toUpdate);
+    void setHashes(List<Pair<FileWrapper, HashTree>> toUpdate);
 
     long size(Path p);
 
@@ -43,7 +41,7 @@ interface SyncFilesystem {
 
     void uploadSubtree(Path baseDir, Stream<FileWrapper.FolderUploadProperties> directories);
 
-    Blake3state hashFile(Path p, Optional<FileWrapper> meta);
+    HashTree hashFile(Path p, Optional<FileWrapper> meta, String relativePath, SyncState syncedState);
 
     void applyToSubtree(Path start, Consumer<FileProps> file, Consumer<Path> dir) throws IOException;
 

--- a/src/peergos/server/sync/SyncState.java
+++ b/src/peergos/server/sync/SyncState.java
@@ -1,6 +1,6 @@
 package peergos.server.sync;
 
-import peergos.shared.user.fs.Blake3state;
+import peergos.shared.user.fs.RootHash;
 
 import java.util.List;
 import java.util.Set;
@@ -13,7 +13,7 @@ public interface SyncState {
 
     FileState byPath(String path);
 
-    List<FileState> byHash(Blake3state b3);
+    List<FileState> byHash(RootHash b3);
 
     void addDir(String path);
 

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -2,6 +2,7 @@ package peergos.server.tests;
 
 import org.junit.Assert;
 import org.junit.Test;
+import peergos.server.Main;
 import peergos.server.sync.DirectorySync;
 import peergos.server.sync.JdbcTreeState;
 import peergos.server.sync.LocalFileSystem;
@@ -19,7 +20,7 @@ public class SyncTests {
         Path base1 = Files.createTempDirectory("peergos-sync");
         Path base2 = Files.createTempDirectory("peergos-sync");
 
-        LocalFileSystem localFs = new LocalFileSystem();
+        LocalFileSystem localFs = new LocalFileSystem(Main.initCrypto().hasher);
         SyncState syncedState = new JdbcTreeState(":memory:");
 
         DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);

--- a/src/peergos/server/tests/util/HashTreeTests.java
+++ b/src/peergos/server/tests/util/HashTreeTests.java
@@ -1,0 +1,66 @@
+package peergos.server.tests.util;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import peergos.server.Main;
+import peergos.shared.Crypto;
+import peergos.shared.user.fs.HashTree;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class HashTreeTests {
+    private static Crypto crypto = Main.initCrypto();
+
+    @Test
+    public void chunks1K() {
+        List<byte[]> chunkHashes = IntStream.range(0, 1024).mapToObj(i -> new byte[32]).collect(Collectors.toList());
+        HashTree tree = HashTree.build(chunkHashes, crypto.hasher).join();
+        Assert.assertTrue(tree.level1.size() == 1);
+        Assert.assertTrue(tree.level2.size() == 0);
+        Assert.assertTrue(tree.level3.size() == 0);
+        Assert.assertTrue(tree.level1.get(0).chunkHashes.length == 1024*32);
+    }
+
+    @Test
+    public void chunks2K() {
+        List<byte[]> chunkHashes = IntStream.range(0, 2*1024).mapToObj(i -> new byte[32]).collect(Collectors.toList());
+        HashTree tree = HashTree.build(chunkHashes, crypto.hasher).join();
+        Assert.assertTrue(tree.level1.size() == 2);
+        Assert.assertTrue(tree.level2.size() == 1);
+        Assert.assertTrue(tree.level3.size() == 0);
+        Assert.assertTrue(tree.level1.get(0).chunkHashes.length == 1024*32);
+    }
+
+    @Test
+    public void chunks1M() {
+        List<byte[]> chunkHashes = IntStream.range(0, 1024*1024).mapToObj(i -> new byte[32]).collect(Collectors.toList());
+        HashTree tree = HashTree.build(chunkHashes, crypto.hasher).join();
+        Assert.assertTrue(tree.level1.size() == 1024);
+        Assert.assertTrue(tree.level2.size() == 1);
+        Assert.assertTrue(tree.level3.size() == 0);
+        Assert.assertTrue(tree.level1.get(0).chunkHashes.length == 1024*32);
+    }
+
+    @Test
+    public void chunks2M() { // A 2 TiB file
+        List<byte[]> chunkHashes = IntStream.range(0, 2*1024*1024).mapToObj(i -> new byte[32]).collect(Collectors.toList());
+        HashTree tree = HashTree.build(chunkHashes, crypto.hasher).join();
+        Assert.assertTrue(tree.level1.size() == 2*1024);
+        Assert.assertTrue(tree.level2.size() == 2);
+        Assert.assertTrue(tree.level3.size() == 1);
+        Assert.assertTrue(tree.level1.get(0).chunkHashes.length == 1024*32);
+    }
+
+    @Test
+    public void chunks7M() { // A 7 TiB file
+        List<byte[]> chunkHashes = IntStream.range(0, 7*1024*1024).mapToObj(i -> new byte[32]).collect(Collectors.toList());
+        HashTree tree = HashTree.build(chunkHashes, crypto.hasher).join();
+        Assert.assertTrue(tree.level1.size() == 7*1024);
+        Assert.assertTrue(tree.level2.size() == 7);
+        Assert.assertTrue(tree.level3.size() == 1);
+        Assert.assertTrue(tree.level1.get(0).chunkHashes.length == 1024*32);
+    }
+}

--- a/src/peergos/shared/user/fs/ChunkHashList.java
+++ b/src/peergos/shared/user/fs/ChunkHashList.java
@@ -1,0 +1,45 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+import peergos.shared.util.Pair;
+
+import java.util.*;
+
+public class ChunkHashList implements Cborable {
+
+    public final byte[] chunkHashes;
+
+    public ChunkHashList(byte[] chunkHashes) {
+        if (chunkHashes.length > 32*1024)
+            throw new IllegalStateException("Chunk hash list too large! " + chunkHashes.length);
+        this.chunkHashes = chunkHashes;
+    }
+
+    public int nChunks() {
+        return chunkHashes.length/32;
+    }
+
+    public boolean equalAt(int chunkIndex, ChunkHashList other) {
+        if (other.chunkHashes.length < (chunkIndex + 1) * 32)
+            return false;
+        for (int i= chunkIndex* 32; i < (chunkIndex + 1) * 32; i++)
+            if (chunkHashes[i] != other.chunkHashes[i])
+                return false;
+        return true;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("h", new CborObject.CborByteArray(chunkHashes));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static ChunkHashList fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for ChunkHashList! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new ChunkHashList(m.getByteArray("h"));
+    }
+}

--- a/src/peergos/shared/user/fs/HashBranch.java
+++ b/src/peergos/shared/user/fs/HashBranch.java
@@ -1,0 +1,50 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+
+import java.util.*;
+
+/** A branch of a hash tree using sha256
+ *
+ */
+public class HashBranch implements Cborable {
+
+    public final RootHash rootHash;
+    public final Optional<ChunkHashList> level1; // This is present on the first chunk of every 1024 chunks (5 GiB with 5 MiB chunks)
+    public final Optional<ChunkHashList> level2; // This is present on the first chunk of every 1024*1024 chunks (5 TiB with 5 MiB chunks)
+    public final Optional<ChunkHashList> level3; // This is present on the first chunk of every 1024*1024*1024 chunks (5 PiB with 5 MiB chunks)
+
+    public HashBranch(RootHash rootHash, Optional<ChunkHashList> level1, Optional<ChunkHashList> level2, Optional<ChunkHashList> level3) {
+        if (level2.isPresent() && level1.isEmpty())
+            throw new IllegalArgumentException("Invalid chunk hash tree state!");
+        if (level3.isPresent() && level2.isEmpty())
+            throw new IllegalArgumentException("Invalid chunk hash tree state!");
+        this.rootHash = rootHash;
+        this.level1 = level1;
+        this.level2 = level2;
+        this.level3 = level3;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("r", rootHash.toCbor());
+        level1.ifPresent(b -> state.put("l1", b.toCbor()));
+        level2.ifPresent(b -> state.put("l2", b.toCbor()));
+        level3.ifPresent(b -> state.put("l3", b.toCbor()));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static HashBranch fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for HashBranch! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        RootHash hash = m.get("r", RootHash::fromCbor);
+        Optional<ChunkHashList> level1 = m.getOptional("l1", ChunkHashList::fromCbor);
+        Optional<ChunkHashList> level2 = m.getOptional("l2", ChunkHashList::fromCbor);
+        Optional<ChunkHashList> level3 = m.getOptional("l3", ChunkHashList::fromCbor);
+        return new HashBranch(hash, level1, level2, level3);
+    }
+
+}

--- a/src/peergos/shared/user/fs/HashTree.java
+++ b/src/peergos/shared/user/fs/HashTree.java
@@ -1,0 +1,117 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+import peergos.shared.crypto.hash.Hasher;
+import peergos.shared.util.Futures;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class HashTree implements Cborable {
+
+    public final RootHash rootHash;
+    public final List<ChunkHashList> level1;
+    public final List<ChunkHashList> level2;
+    public final List<ChunkHashList> level3;
+
+    public HashTree(RootHash rootHash, List<ChunkHashList> level1, List<ChunkHashList> level2, List<ChunkHashList> level3) {
+        this.rootHash = rootHash;
+        this.level1 = level1;
+        this.level2 = level2;
+        this.level3 = level3;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("r", rootHash.toCbor());
+        state.put("ll1", new CborObject.CborList(level1));
+        state.put("ll2", new CborObject.CborList(level2));
+        state.put("ll3", new CborObject.CborList(level3));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static HashTree fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for HashTree! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        RootHash root = m.get("r", RootHash::fromCbor);
+        List<ChunkHashList> level1 = m.getList("ll1", ChunkHashList::fromCbor);
+        List<ChunkHashList> level2 = m.getList("ll2", ChunkHashList::fromCbor);
+        List<ChunkHashList> level3 = m.getList("ll3", ChunkHashList::fromCbor);
+        return new HashTree(root, level1, level2, level3);
+    }
+
+    public HashBranch branch(long chunkIndex) {
+        return new HashBranch(rootHash,
+                level1.stream().skip(chunkIndex / 1024).findFirst(),
+                level2.stream().skip(chunkIndex / 1024 / 1024).findFirst(),
+                level3.stream().skip(chunkIndex / 1024 / 1024 / 1024).findFirst());
+    }
+
+    public static HashTree fromBranches(List<HashBranch> branches) {
+        List<ChunkHashList> level1 = branches.stream().flatMap(b -> b.level1.stream()).collect(Collectors.toList());
+        List<ChunkHashList> level2 = branches.stream().flatMap(b -> b.level2.stream()).collect(Collectors.toList());
+        List<ChunkHashList> level3 = branches.stream().flatMap(b -> b.level3.stream()).collect(Collectors.toList());
+        return new HashTree(branches.get(0).rootHash, level1, level2, level3);
+    }
+
+    public static CompletableFuture<HashTree> build(List<byte[]> chunkHashes,
+                                                    Hasher hasher) {
+        if (chunkHashes.isEmpty())
+            throw new IllegalStateException("A file cannot have no chunk hashes.");
+        List<ChunkHashList> level1 = buildLevel(chunkHashes);
+        if (level1.size() == 1) {
+            return hasher.sha256(new CborObject.CborList(level1).serialize())
+                    .thenApply(RootHash::new)
+                    .thenApply(r -> new HashTree(r, level1, Collections.emptyList(), Collections.emptyList()));
+        }
+        return buildLevel(level1, hasher)
+                .thenCompose(level2 -> {
+                    if (level2.size() == 1) {
+                        return hasher.sha256(new CborObject.CborList(level2).serialize())
+                                .thenApply(RootHash::new)
+                                .thenApply(r -> new HashTree(r, level1, level2, Collections.emptyList()));
+                    }
+                    return buildLevel(level2, hasher)
+                            .thenCompose(level3 -> {
+                                if (level3.size() == 1) {
+                                    return hasher.sha256(new CborObject.CborList(level3).serialize())
+                                            .thenApply(RootHash::new)
+                                            .thenApply(r -> new HashTree(r, level1, level2, level3));
+                                }
+                                return buildLevel(level3, hasher)
+                                        .thenCompose(level4 -> {
+                                            if (level4.size() == 1) {
+                                                return hasher.sha256(new CborObject.CborList(level3).serialize())
+                                                        .thenApply(RootHash::new)
+                                                        .thenApply(r -> new HashTree(r, level1, level2, level3));
+                                            }
+                                            throw new IllegalStateException("Files bigger than 5 PiB are not supported in HashTree!");
+                                        });
+                            });
+                });
+    }
+
+    private static List<ChunkHashList> buildLevel(List<byte[]> chunkHashes) {
+        List<ChunkHashList> level = new ArrayList<>();
+
+        for (int i=0; i < chunkHashes.size(); i += 1024) {
+            byte[] chunkHashesBytes = new byte[Math.min(1024, chunkHashes.size() - i) * 32];
+            for (int c=0; c < 1024; c++)
+                System.arraycopy(chunkHashes.get(i), 0, chunkHashesBytes, i * 32, 32);
+            ChunkHashList level1Section = new ChunkHashList(chunkHashesBytes);
+            level.add(level1Section);
+        }
+        return level;
+    }
+
+    private static CompletableFuture<List<ChunkHashList>> buildLevel(List<ChunkHashList> level, Hasher h) {
+        return Futures.combineAllInOrder(level.stream()
+                        .map(l1 -> h.sha256(l1.serialize()))
+                        .collect(Collectors.toList()))
+                .thenApply(HashTree::buildLevel);
+    }
+}

--- a/src/peergos/shared/user/fs/HashTree.java
+++ b/src/peergos/shared/user/fs/HashTree.java
@@ -126,9 +126,10 @@ public class HashTree implements Cborable {
         List<ChunkHashList> level = new ArrayList<>();
 
         for (int i=0; i < chunkHashes.size(); i += 1024) {
-            byte[] chunkHashesBytes = new byte[Math.min(1024, chunkHashes.size() - i) * 32];
-            for (int c=0; c < 1024; c++)
-                System.arraycopy(chunkHashes.get(i), 0, chunkHashesBytes, i * 32, 32);
+            int nChunks = Math.min(1024, chunkHashes.size() - i);
+            byte[] chunkHashesBytes = new byte[nChunks * 32];
+            for (int c=0; c < nChunks; c++)
+                System.arraycopy(chunkHashes.get(i + c), 0, chunkHashesBytes, c * 32, 32);
             ChunkHashList level1Section = new ChunkHashList(chunkHashesBytes);
             level.add(level1Section);
         }

--- a/src/peergos/shared/user/fs/RootHash.java
+++ b/src/peergos/shared/user/fs/RootHash.java
@@ -1,0 +1,46 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class RootHash implements Cborable {
+    public final byte[] hash;
+
+    public RootHash(byte[] hash) {
+        if (hash.length != 32)
+            throw new IllegalArgumentException("Incorrect hash length: " + hash.length);
+        this.hash = hash;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("h", new CborObject.CborByteArray(hash));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static RootHash fromCbor(Cborable cbor) {
+        if (!(cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for HashBranch! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new RootHash(m.getByteArray("h"));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RootHash rootHash = (RootHash) o;
+        return Objects.deepEquals(hash, rootHash.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(hash);
+    }
+}


### PR DESCRIPTION
This adds a new custom tree hash to file metadata. (And drops blake3 due to poor JS libs and webcrypto absence)

Each plaintext chunk is hashed with sha256, this is then made into a 1024-ary tree by hashing until the root, wrapping each layer in cbor. This means a 5 PiB file will have an overhead of 96 KiB in the first chunk's metadata. So less than the max thumbnail size. Every 1024'th chunk has the hash tree branch from the root.

This will make is easy to do bulk uploads in browser with hashes present, and thus not conflict with a concurrent sync client that is setting the hashes.