### PR TITLE
Make sync O(1) I/O if remote state has not changed.

### DIFF
--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -193,7 +193,7 @@ public class DirectorySync {
                         (v, w) -> v.withWriter(owner, w, network),
                         (a, b) -> a.mergeAndOverwriteWith(b)).join();
         SyncState remoteState = remoteVersion.equals(syncedVersion) && ! remoteVersion.versions.isEmpty() ? syncedVersions : new RamTreeState();
-        if (! remoteVersion.equals(syncedVersion) && ! syncedVersion.versions.isEmpty())
+        if (! remoteVersion.equals(syncedVersion) || remoteVersion.versions.isEmpty())
             buildDirState(remoteFS, remoteDir, remoteState, syncedVersions);
         log("Found " + remoteState.filesCount() + " remote files");
 

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -9,6 +9,7 @@ import peergos.server.util.Logging;
 import peergos.shared.Crypto;
 import peergos.shared.NetworkAccess;
 import peergos.shared.corenode.HTTPCoreNode;
+import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.login.mfa.MultiFactorAuthMethod;
 import peergos.shared.login.mfa.MultiFactorAuthRequest;
 import peergos.shared.login.mfa.MultiFactorAuthResponse;
@@ -17,6 +18,7 @@ import peergos.shared.social.HttpSocialNetwork;
 import peergos.shared.storage.HttpSpaceUsage;
 import peergos.shared.storage.UnauthedCachingStorage;
 import peergos.shared.user.LinkProperties;
+import peergos.shared.user.Snapshot;
 import peergos.shared.user.TrieNodeImpl;
 import peergos.shared.user.UserContext;
 import peergos.shared.user.fs.*;
@@ -95,7 +97,9 @@ public class DirectorySync {
                         Path remoteDir = PathUtil.get(linkPath);
                         log("Syncing " + localDir + " to+from " + remoteDir);
                         long t0 = System.currentTimeMillis();
-                        syncDirs(local, localDir, remote, remoteDir, syncedState, maxDownloadParallelism, minFreeSpacePercent);
+                        String username = remoteDir.getName(0).toString();
+                        PublicKeyHash owner = network.coreNode.getPublicKeyHash(username).join().get();
+                        syncDirs(local, localDir, remote, remoteDir, owner, network, syncedState, maxDownloadParallelism, minFreeSpacePercent);
                         long t1 = System.currentTimeMillis();
                         log("Dir sync took " + (t1 - t0) / 1000 + "s");
                     }
@@ -164,7 +168,7 @@ public class DirectorySync {
     }
 
     public static void syncDirs(SyncFilesystem localFS, Path localDir,
-                                SyncFilesystem remoteFS, Path remoteDir,
+                                SyncFilesystem remoteFS, Path remoteDir, PublicKeyHash owner, NetworkAccess network,
                                 SyncState syncedVersions,
                                 int maxParallelism,
                                 int minPercentFreeSpace) throws IOException {
@@ -181,12 +185,20 @@ public class DirectorySync {
         buildDirState(localFS, localDir, localState, syncedVersions);
         log("Found " + localState.filesByPath.size() + " local files");
 
-        RamTreeState remoteState = new RamTreeState();
-        buildDirState(remoteFS, remoteDir, remoteState, syncedVersions);
-        log("Found " + remoteState.filesByPath.size() + " remote files");
+        Snapshot syncedVersion = syncedVersions.getSnapshot(remoteDir.toString());
+        Snapshot remoteVersion = network == null ?
+                new Snapshot(new HashMap<>()) :
+                Futures.reduceAll(syncedVersion.versions.keySet(),
+                        new Snapshot(new HashMap<>()),
+                        (v, w) -> v.withWriter(owner, w, network),
+                        (a, b) -> a.mergeAndOverwriteWith(b)).join();
+        SyncState remoteState = remoteVersion.equals(syncedVersion) && ! remoteVersion.versions.isEmpty() ? syncedVersions : new RamTreeState();
+        if (! remoteVersion.equals(syncedVersion) && ! syncedVersion.versions.isEmpty())
+            buildDirState(remoteFS, remoteDir, remoteState, syncedVersions);
+        log("Found " + remoteState.filesCount() + " remote files");
 
         TreeSet<String> allPaths = new TreeSet<>(localState.filesByPath.keySet());
-        allPaths.addAll(remoteState.filesByPath.keySet());
+        allPaths.addAll(remoteState.allFilePaths());
         Set<String> doneFiles = Collections.synchronizedSet(new HashSet<>());
 
         // upload new small files in a single bulk operation
@@ -339,6 +351,8 @@ public class DirectorySync {
                 }
             }
         }
+
+        syncedVersions.setSnapshot(remoteDir.toString(), remoteVersion);
     }
 
     private static void log(String msg) {
@@ -349,7 +363,7 @@ public class DirectorySync {
     public static void syncFile(FileState synced, FileState local, FileState remote,
                                 SyncFilesystem localFs, Path localDir,
                                 SyncFilesystem remoteFs, Path remoteDir,
-                                SyncState syncedVersions, RamTreeState localTree, RamTreeState remoteTree,
+                                SyncState syncedVersions, RamTreeState localTree, SyncState remoteTree,
                                 Set<String> doneFiles, int minPercentFree) throws IOException {
         long totalSpace = Files.getFileStore(localDir).getTotalSpace();
         long freeSpace = Files.getFileStore(localDir).getUsableSpace();
@@ -595,9 +609,26 @@ public class DirectorySync {
         targetFs.setHash(op.target, op.sourceState.hashTree, size);
     }
 
-    public static void buildDirState(SyncFilesystem fs, Path dir, RamTreeState res, SyncState synced) throws IOException {
+    private static class SnapshotTracker {
+        private Snapshot s;
+
+        public SnapshotTracker(Snapshot s) {
+            this.s = s;
+        }
+
+        public synchronized void update(Snapshot s2) {
+            s = s.mergeAndOverwriteWith(s2);
+        }
+
+        public synchronized Snapshot get() {
+            return s;
+        }
+    }
+
+    public static Snapshot buildDirState(SyncFilesystem fs, Path dir, SyncState res, SyncState synced) throws IOException {
         if (! fs.exists(dir))
             throw new IllegalStateException("Dir does not exist: " + dir);
+        SnapshotTracker version = new SnapshotTracker(new Snapshot(new HashMap<>()));
         List<Pair<FileWrapper, HashTree>> toUpdate = new ArrayList<>();
         fs.applyToSubtree(dir, props -> {
             String relPath = props.path.toString().substring(dir.toString().length() + 1);
@@ -607,6 +638,7 @@ public class DirectorySync {
             } else {
                 HashTree hashTree = fs.hashFile(props.path, props.meta, relPath, synced);
                 if (props.meta.isPresent()) {
+                    version.update(props.meta.get().version);
                     Optional<HashBranch> remoteHash = props.meta.get().getFileProperties().treeHash;
                     if (! remoteHash.isPresent()) {
                         // collect new hashes to set in bulk later
@@ -616,13 +648,15 @@ public class DirectorySync {
                 FileState fstat = new FileState(relPath, props.modifiedTime, props.size, hashTree);
                 res.add(fstat);
             }
-        }, d -> {
-            String relPath = d.toString().substring(dir.toString().length() + 1);
+        }, p -> {
+            String relPath = p.path.toString().substring(dir.toString().length() + 1);
+            p.meta.ifPresent(d -> version.update(d.version));
             res.addDir(relPath);
         });
         if (! toUpdate.isEmpty()) {
             log("REMOTE: Updating " + toUpdate.size() + " hashes");
             fs.setHashes(toUpdate);
         }
+        return version.get();
     }
 }

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -121,12 +121,13 @@ public class LocalFileSystem implements SyncFilesystem {
     }
 
     @Override
-    public void applyToSubtree(Path start, Consumer<FileProps> file, Consumer<Path> dir) throws IOException {
+    public void applyToSubtree(Path start, Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException {
         Files.list(start).forEach(c -> {
+            FileProps props = new FileProps(start.resolve(c.getFileName()), c.toFile().lastModified() / 1000 * 1000, c.toFile().length(), Optional.empty());
             if (Files.isRegularFile(c)) {
-                file.accept(new FileProps(c, c.toFile().lastModified()/ 1000 * 1000, c.toFile().length(), Optional.empty()));
+                file.accept(props);
             } else if (Files.isDirectory(c)) {
-                dir.accept(start.resolve(c.getFileName()));
+                dir.accept(props);
                 try {
                     applyToSubtree(start.resolve(c.getFileName()), file, dir);
                 } catch (IOException e) {

--- a/src/peergos/server/sync/RamTreeState.java
+++ b/src/peergos/server/sync/RamTreeState.java
@@ -1,5 +1,6 @@
 package peergos.server.sync;
 
+import peergos.shared.user.Snapshot;
 import peergos.shared.user.fs.RootHash;
 
 import java.util.*;
@@ -9,6 +10,27 @@ class RamTreeState implements SyncState {
     public final Map<RootHash, List<FileState>> fileByHash = new HashMap<>();
     private final Set<String> dirs = new HashSet<>();
     private final List<CopyOp> inProgress = new ArrayList<>();
+    private final Map<String, Snapshot> versions = new HashMap<>();
+
+    @Override
+    public long filesCount() {
+        return filesByPath.size();
+    }
+
+    @Override
+    public Set<String> allFilePaths() {
+        return filesByPath.keySet();
+    }
+
+    @Override
+    public synchronized void setSnapshot(String basePath, Snapshot s) {
+        versions.put(basePath, s);
+    }
+
+    @Override
+    public synchronized Snapshot getSnapshot(String basePath) {
+        return versions.getOrDefault(basePath, new Snapshot(new HashMap<>()));
+    }
 
     @Override
     public synchronized void add(FileState fs) {

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -43,7 +43,7 @@ interface SyncFilesystem {
 
     HashTree hashFile(Path p, Optional<FileWrapper> meta, String relativePath, SyncState syncedState);
 
-    void applyToSubtree(Path start, Consumer<FileProps> file, Consumer<Path> dir) throws IOException;
+    void applyToSubtree(Path start, Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException;
 
     class FileProps {
         public final Path path;

--- a/src/peergos/server/sync/SyncState.java
+++ b/src/peergos/server/sync/SyncState.java
@@ -1,11 +1,16 @@
 package peergos.server.sync;
 
+import peergos.shared.user.Snapshot;
 import peergos.shared.user.fs.RootHash;
 
 import java.util.List;
 import java.util.Set;
 
 public interface SyncState {
+
+    long filesCount();
+
+    Set<String> allFilePaths();
 
     void add(FileState fs);
 
@@ -28,4 +33,8 @@ public interface SyncState {
     void finishCopies(List<CopyOp> ops);
 
     List<CopyOp> getInProgressCopies();
+
+    void setSnapshot(String basePath, Snapshot s);
+
+    Snapshot getSnapshot(String basePath);
 }

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -23,38 +23,38 @@ public class SyncTests {
         LocalFileSystem localFs = new LocalFileSystem(Main.initCrypto().hasher);
         SyncState syncedState = new JdbcTreeState(":memory:");
 
-        DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);
+        DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
 
         byte[] data = new byte[6 * 1024 * 1024];
         new Random(42).nextBytes(data);
         String filename = "file.bin";
         Files.write(base1.resolve(filename), data, StandardOpenOption.CREATE);
 
-        DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);
+        DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
         Assert.assertTrue(syncedState.byPath(filename) != null);
 
         // move file to a subdir
         Path subdir = base1.resolve("subdir");
         subdir.toFile().mkdirs();
         Files.move(base1.resolve(filename), subdir.resolve(filename));
-        DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);
+        DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
         Assert.assertTrue(syncedState.byPath(filename) == null);
         String fileRelPath = subdir.getFileName().resolve(filename).toString();
         Assert.assertTrue(syncedState.byPath(fileRelPath) != null);
 
         // sync should be stable
-        DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);
+        DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
         Assert.assertTrue(syncedState.byPath(filename) == null);
         Assert.assertTrue(syncedState.byPath(fileRelPath) != null);
 
         // move the file back
         Files.move(subdir.resolve(filename), base1.resolve(filename));
-        DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);
+        DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
         Assert.assertTrue(syncedState.byPath(filename) != null);
         Assert.assertTrue(syncedState.byPath(fileRelPath) == null);
 
         // check stability
-        DirectorySync.syncDirs(localFs, base1, localFs, base2, syncedState, 32, 5);
+        DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
         Assert.assertTrue(syncedState.byPath(filename) != null);
         Assert.assertTrue(syncedState.byPath(fileRelPath) == null);
 

--- a/src/peergos/shared/user/WriterData.java
+++ b/src/peergos/shared/user/WriterData.java
@@ -399,7 +399,7 @@ public class WriterData implements Cborable {
         return CborObject.CborMap.build(result);
     }
 
-    public static WriterData fromCbor(CborObject cbor) {
+    public static WriterData fromCbor(Cborable cbor) {
         if (! ( cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Cbor for WriterData should be a map! " + cbor);
 


### PR DESCRIPTION
We store the snapshot from the listing in the db (writer public keys and targets). This makes listing an unchanged remote FS O(1) rather than O(# files + # dirs).