### PR TITLE
Update tree hash branches during file overwrite

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -233,7 +233,7 @@
   </target>
 
   <target name="gwtc" depends="javac" description="GWT compile to JavaScript (production mode)">
-    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="3g">
+    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="4g">
       <classpath>
         <pathelement location="src"/>
         <path refid="project.class.path"/>

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -429,7 +429,8 @@ public class Main extends Builder {
                     new Command.Arg("peergos-url", "Peergos service address", false, "https://peergos.net"),
                     new Command.Arg("local-dirs", "The directories to sync to and from Peergos (comma separated)", true),
                     new Command.Arg("max-parallelism", "The maximum parallelism to download files with", false, "32"),
-                    new Command.Arg("block-cache-size-bytes", "The size of the local block cache, e.g. 5g", false, "1g")
+                    new Command.Arg("block-cache-size-bytes", "The size of the local block cache, e.g. 5g", false, "1g"),
+                    new Command.Arg("run-once", "Only sync the directory once", false)
             ).collect(Collectors.toList())
     );
 

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -151,7 +151,7 @@ public class DirectorySync {
 
             String cap = link.toLinkString(context.signer.publicKeyHash);
 
-            System.out.println("Run the sync dir command with the following args: -links " + cap + " -local-dirs $LOCAL_DIR");
+            System.out.println("Run the sync dir command on all devices you want to sync using the following args: -links " + cap + " -local-dirs $LOCAL_DIR");
             return true;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1131,7 +1131,9 @@ public class FileWrapper {
                                                     Optional.empty();
 
                                             return fileData.readIntoArray(raw, internalStart, internalEnd - internalStart)
-                                                    .thenCompose(read -> treeHasher.setChunk((int)(inputStartIndex / Chunk.MAX_SIZE), raw, crypto.hasher).thenApply(x -> read))
+                                                    .thenCompose(read -> updateTreeHash ?
+                                                            treeHasher.setChunk((int)(inputStartIndex / Chunk.MAX_SIZE), raw, crypto.hasher).thenApply(x -> read) :
+                                                            Futures.of(read))
                                                     .thenCompose(read -> {
 
                                                 Chunk updated = new Chunk(raw, dataKey, currentOriginal.location.getMapKey(), dataKey.createNonce());

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1137,7 +1137,7 @@ public class FileWrapper {
                                                 Chunk updated = new Chunk(raw, dataKey, currentOriginal.location.getMapKey(), dataKey.createNonce());
                                                 LocatedChunk located = new LocatedChunk(currentOriginal.location, currentOriginal.bat, currentOriginal.existingHash, updated);
                                                 long currentSize = filesSize.get();
-                                                // remove hash from properties as we are changing the file (todo: update subsequent hash branches for files > 5 GiB)
+                                                // remove hash from properties as we are changing the file
                                                 FileProperties newProps = new FileProperties(props.name, false,
                                                         props.isLink, props.mimeType,
                                                         endIndex > currentSize ? endIndex : currentSize,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1184,7 +1184,8 @@ public class FileWrapper {
                                     if (! updateTreeHash)
                                         return Futures.of(preHashVersion);
                                     // update hash branches every 5 GiB
-                                    return treeHasher.complete(crypto.hasher)
+                                    return (endIndex == 0 ? treeHasher.setChunk(0, new byte[0], crypto.hasher) : Futures.of(true))
+                                            .thenCompose(x -> treeHasher.complete(crypto.hasher))
                                             .thenCompose(treeHash -> network.getFile(preHashVersion, ourCap, entryWriter, ownername)
                                                     .thenCompose(updatedUs -> updatedUs.get()
                                                             .getHashUpdates(treeHash, network, crypto.hasher))

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1067,6 +1067,8 @@ public class FileWrapper {
         Location parentLocation = getPointer().getParentCap().getLocation(owner(), writer());
         Optional<Bat> parentBat = getPointer().getParentCap().bat;
         WritableAbsoluteCapability ourCap = writableFilePointer();
+        boolean updateTreeHash = inputStartIndex == 0 && endIndex >= props.size;
+        HashTreeBuilder treeHasher = updateTreeHash ? new HashTreeBuilder(endIndex) : null;
         return current.withWriter(owner(), writer(), network)
                 .thenCompose(base -> {
                     FileWrapper us = this;
@@ -1128,12 +1130,14 @@ public class FileWrapper {
                                                     us.pointer.fileAccess.getWriterLink(us.pointer.capability.rBaseKey) :
                                                     Optional.empty();
 
-                                            return fileData.readIntoArray(raw, internalStart, internalEnd - internalStart).thenCompose(read -> {
+                                            return fileData.readIntoArray(raw, internalStart, internalEnd - internalStart)
+                                                    .thenCompose(read -> treeHasher.setChunk((int)(inputStartIndex / Chunk.MAX_SIZE), raw, crypto.hasher).thenApply(x -> read))
+                                                    .thenCompose(read -> {
 
                                                 Chunk updated = new Chunk(raw, dataKey, currentOriginal.location.getMapKey(), dataKey.createNonce());
                                                 LocatedChunk located = new LocatedChunk(currentOriginal.location, currentOriginal.bat, currentOriginal.existingHash, updated);
                                                 long currentSize = filesSize.get();
-                                                // remove hash from properties as we are changing the file (todo: update hash)
+                                                // remove hash from properties as we are changing the file (todo: update subsequent hash branches for files > 5 GiB)
                                                 FileProperties newProps = new FileProperties(props.name, false,
                                                         props.isLink, props.mimeType,
                                                         endIndex > currentSize ? endIndex : currentSize,
@@ -1153,16 +1157,27 @@ public class FileWrapper {
                                                         filesSize.set(updatedLength);
 
                                                         if (updatedLength > Chunk.MAX_SIZE) {
-                                                            // update file size in FileProperties of first chunk
-                                                            return network.getFile(updatedBase, ourCap, entryWriter, ownername)
-                                                                    .thenCompose(updatedUs -> {
-                                                                        FileProperties correctedSize = updatedUs.get()
-                                                                                .getPointer().fileAccess.getProperties(ourCap.rBaseKey)
-                                                                                .withSize(endIndex);
-                                                                        return updatedUs.get()
-                                                                                .getPointer().fileAccess.updateProperties(updatedBase,
-                                                                                        committer, ourCap, entryWriter, correctedSize, network);
-                                                                    });
+                                                            // update file size and treehash (if complete overwrite) in FileProperties of first chunk
+                                                            return (updateTreeHash ?
+                                                                    treeHasher.complete(crypto.hasher).thenApply(Optional::of) :
+                                                                    Futures.of(Optional.<HashTree>empty()))
+                                                                    .thenCompose(treeHash -> network.getFile(updatedBase, ourCap, entryWriter, ownername)
+                                                                            .thenCompose(updatedUs -> {
+                                                                                FileProperties correctedSize = updatedUs.get()
+                                                                                        .getPointer().fileAccess.getProperties(ourCap.rBaseKey)
+                                                                                        .withSize(endIndex)
+                                                                                        .withHash(treeHash.map(t -> t.branch(0)));
+                                                                                return updatedUs.get()
+                                                                                        .getPointer().fileAccess.updateProperties(updatedBase,
+                                                                                                committer, ourCap, entryWriter, correctedSize, network);
+                                                                            }).thenCompose(updatedBase2 -> {
+                                                                                if (! updateTreeHash || endIndex < 1024 * Chunk.MAX_SIZE)
+                                                                                    return Futures.of(updatedBase2);
+                                                                                return network.getFile(updatedBase, ourCap, entryWriter, ownername)
+                                                                                        .thenCompose(updatedUs -> updatedUs.get()
+                                                                                                .getHashUpdates(treeHash.get(), network, crypto.hasher))
+                                                                                        .thenCompose(hashUpdates -> FileWrapper.bulkSetSameNameProperties(updatedBase2, committer, owner(), hashUpdates, network));
+                                                                            }));
                                                         }
                                                     }
                                                     return CompletableFuture.completedFuture(updatedBase);
@@ -1860,16 +1875,24 @@ public class FileWrapper {
                 .collect(Collectors.toList()));
     }
 
+    public static CompletableFuture<Snapshot> bulkSetSameNameProperties(Snapshot s,
+                                                                        Committer c,
+                                                                        PublicKeyHash owner,
+                                                                        List<PropsUpdate> updates,
+                                                                        NetworkAccess network) {
+        return Futures.reduceAll(updates, s,
+                (v, p) -> v.withWriter(owner, p.cap.writer, network)
+                        .thenCompose(v2 -> p.meta.updateProperties(v2, c, p.cap, p.entryWriter, p.newProps, network)),
+                (a, b) -> a.mergeAndOverwriteWith(b));
+    }
+
     public static CompletableFuture<Boolean> bulkSetSameNameProperties(List<PropsUpdate> updates,
                                                                        NetworkAccess network) {
         PropsUpdate first = updates.get(0);
         PublicKeyHash owner = first.cap.owner;
         SigningPrivateKeyAndPublicHash signer = first.meta.getSigner(first.cap.rBaseKey, first.cap.wBaseKey.get(), first.entryWriter);
         return network.synchronizer.applyComplexUpdate(owner, signer,
-                        (s, c) -> Futures.reduceAll(updates, s,
-                                (v, p) -> v.withWriter(owner, p.cap.writer, network)
-                                        .thenCompose(v2 -> p.meta.updateProperties(v2, c, p.cap, p.entryWriter, p.newProps, network)),
-                                (a, b) -> a.mergeAndOverwriteWith(b)))
+                        (s, c) -> bulkSetSameNameProperties(s, c, owner, updates, network))
                 .thenApply(fa -> true);
     }
 

--- a/src/peergos/shared/user/fs/HashTreeBuilder.java
+++ b/src/peergos/shared/user/fs/HashTreeBuilder.java
@@ -2,29 +2,30 @@ package peergos.shared.user.fs;
 
 import peergos.shared.crypto.hash.Hasher;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 
 public class HashTreeBuilder {
 
-    private final List<byte[]> chunkHashes;
+    private final byte[][] chunkHashes;
 
     public HashTreeBuilder(long filesize) {
-        this.chunkHashes = new ArrayList<>( (int)(filesize/ Chunk.MAX_SIZE));
+        this.chunkHashes = new byte[filesize == 0 ? 1 : ((int)((filesize + Chunk.MAX_SIZE - 1) / Chunk.MAX_SIZE))][];
     }
 
     public CompletableFuture<Boolean> setChunk(int chunkIndex, byte[] chunk, Hasher h) {
         return h.sha256(chunk)
-                .thenApply(hash -> chunkHashes.set(chunkIndex, hash))
-                .thenApply(x -> true);
+                .thenApply(hash -> {
+                    chunkHashes[chunkIndex] = hash;
+                    return true;
+                });
     }
 
     public void setChunkHash(int chunkIndex, byte[] hash) {
-        chunkHashes.set(chunkIndex, hash);
+        chunkHashes[chunkIndex] = hash;
     }
 
     public CompletableFuture<HashTree> complete(Hasher h) {
-        return HashTree.build(chunkHashes, h);
+        return HashTree.build(Arrays.asList(chunkHashes), h);
     }
 }

--- a/src/peergos/shared/user/fs/HashTreeBuilder.java
+++ b/src/peergos/shared/user/fs/HashTreeBuilder.java
@@ -1,0 +1,30 @@
+package peergos.shared.user.fs;
+
+import peergos.shared.crypto.hash.Hasher;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class HashTreeBuilder {
+
+    private final List<byte[]> chunkHashes;
+
+    public HashTreeBuilder(long filesize) {
+        this.chunkHashes = new ArrayList<>( (int)(filesize/ Chunk.MAX_SIZE));
+    }
+
+    public CompletableFuture<Boolean> setChunk(int chunkIndex, byte[] chunk, Hasher h) {
+        return h.sha256(chunk)
+                .thenApply(hash -> chunkHashes.set(chunkIndex, hash))
+                .thenApply(x -> true);
+    }
+
+    public void setChunkHash(int chunkIndex, byte[] hash) {
+        chunkHashes.set(chunkIndex, hash);
+    }
+
+    public CompletableFuture<HashTree> complete(Hasher h) {
+        return HashTree.build(chunkHashes, h);
+    }
+}

--- a/src/peergos/shared/user/fs/HashTreeBuilder.java
+++ b/src/peergos/shared/user/fs/HashTreeBuilder.java
@@ -26,6 +26,9 @@ public class HashTreeBuilder {
     }
 
     public CompletableFuture<HashTree> complete(Hasher h) {
+        for (int i=0; i < chunkHashes.length; i++)
+            if (chunkHashes[i] == null)
+                throw new IllegalStateException("Incomplete tree hash state!");
         return HashTree.build(Arrays.asList(chunkHashes), h);
     }
 }


### PR DESCRIPTION
This means webdav bridge now sets tree hashes, as well as overwrites in the web-ui.