### PR TITLE
Use ipns extra data for publishing resolution records

### DIFF
--- a/src/peergos/server/ServerIdentity.java
+++ b/src/peergos/server/ServerIdentity.java
@@ -11,6 +11,7 @@ import peergos.shared.*;
 import peergos.shared.cbor.*;
 import peergos.shared.io.ipfs.*;
 import peergos.shared.resolution.*;
+import peergos.shared.storage.IpnsEntry;
 import peergos.shared.user.*;
 import peergos.shared.util.*;
 
@@ -84,7 +85,7 @@ public class ServerIdentity extends Builder {
         ResolutionRecord ipnsValue = new ResolutionRecord(host,
                 moved, Optional.empty(), sequence);
         byte[] value = ipnsValue.serialize();
-        return IPNS.createSignedRecord(value, expiry, sequence, ttlNanos, peerPrivate);
+        return IPNS.createSignedRecord(value, expiry, sequence, ttlNanos, Optional.of(IpnsEntry.RESOLUTION_RECORD_IPNS_SUFFIX), Optional.of(org.peergos.cbor.CborObject.fromByteArray(value)), peerPrivate);
     }
 
     public static PrivKey generateNextIdentity(String password, PeerId current, Crypto crypto) {

--- a/src/peergos/server/ServerIdentity.java
+++ b/src/peergos/server/ServerIdentity.java
@@ -46,7 +46,8 @@ public class ServerIdentity extends Builder {
                         currentRecord);
                 if (ipnsMapping.isEmpty())
                     throw new IllegalStateException("Invalid record!");
-                ResolutionRecord res = ResolutionRecord.fromCbor(CborObject.fromByteArray(ipnsMapping.get().value.value));
+                IpnsEntry entry = new IpnsEntry(ipnsMapping.get().getSignature(), ipnsMapping.get().getData());
+                ResolutionRecord res = entry.getValue();
                 boolean hasNextId = res.host.isPresent();
                 if (hasNextId) {
                     System.out.println("This server has already generated a next identity");
@@ -129,13 +130,7 @@ public class ServerIdentity extends Builder {
                         currentRecord);
                 if (ipnsMapping.isEmpty())
                     throw new IllegalStateException("Invalid record!");
-                Ipns.IpnsEntry entry;
-                try {
-                    entry = Ipns.IpnsEntry.parseFrom(ByteBuffer.wrap(ipnsMapping.get().value.raw));
-                } catch (InvalidProtocolBufferException e) {
-                    throw new RuntimeException(e);
-                }
-                IpnsEntry ipnsEntry = new IpnsEntry(entry.getSignatureV2().toByteArray(), entry.getData().toByteArray());
+                IpnsEntry ipnsEntry = new IpnsEntry(ipnsMapping.get().getSignature(), ipnsMapping.get().getData());
                 Crypto crypto = Main.initCrypto();
                 ResolutionRecord res = ipnsEntry.getValue(Multihash.decode(ipnsMapping.get().publisher.toBytes()), crypto).join();
                 PrivKey nextPriv;

--- a/src/peergos/server/storage/JdbcServerIdentityStore.java
+++ b/src/peergos/server/storage/JdbcServerIdentityStore.java
@@ -133,15 +133,6 @@ public class JdbcServerIdentityStore implements ServerIdentityStore {
         }
     }
 
-    public ResolutionRecord getValue(IpnsEntry entry) {
-        CborObject cbor = CborObject.fromByteArray(entry.data);
-        if (! (cbor instanceof CborObject.CborMap))
-            throw new IllegalStateException("Invalid cbor for IpnsEntry!");
-        CborObject.CborMap map = (CborObject.CborMap) cbor;
-        String RRKey = "_" + RESOLUTION_RECORD_IPNS_SUFFIX;
-        return ResolutionRecord.fromCbor(map.containsKey(RRKey) ? map.get(RRKey) : CborObject.fromByteArray(map.getByteArray("Value")));
-    }
-
     @Override
     public void setRecord(PeerId peerId, byte[] newRecord) {
         byte[] currentRaw = getRecord(peerId);
@@ -150,8 +141,8 @@ public class JdbcServerIdentityStore implements ServerIdentityStore {
             Ipns.IpnsEntry newEntry = Ipns.IpnsEntry.parseFrom(newRecord);
             IpnsEntry existing = new IpnsEntry(currentEntry.getSignatureV2().toByteArray(), currentEntry.getData().toByteArray());
             IpnsEntry updated = new IpnsEntry(newEntry.getSignatureV2().toByteArray(), newEntry.getData().toByteArray());
-            ResolutionRecord existingValue = getValue(existing);
-            ResolutionRecord updatedValue = getValue(updated);
+            ResolutionRecord existingValue = existing.getValue();
+            ResolutionRecord updatedValue = updated.getValue();
 
             if (updatedValue.sequence != newEntry.getSequence())
                 throw new IllegalStateException("Non matching sequence!");

--- a/src/peergos/server/storage/JdbcServerIdentityStore.java
+++ b/src/peergos/server/storage/JdbcServerIdentityStore.java
@@ -7,7 +7,6 @@ import peergos.server.sql.*;
 import peergos.server.util.Logging;
 import peergos.shared.*;
 import peergos.shared.cbor.*;
-import peergos.shared.io.ipfs.*;
 import peergos.shared.resolution.*;
 import peergos.shared.storage.*;
 
@@ -16,6 +15,8 @@ import java.sql.Connection;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.*;
+
+import static peergos.shared.storage.IpnsEntry.RESOLUTION_RECORD_IPNS_SUFFIX;
 
 public class JdbcServerIdentityStore implements ServerIdentityStore {
 	private static final Logger LOG = Logging.LOG();
@@ -137,7 +138,8 @@ public class JdbcServerIdentityStore implements ServerIdentityStore {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Invalid cbor for IpnsEntry!");
         CborObject.CborMap map = (CborObject.CborMap) cbor;
-        return ResolutionRecord.fromCbor(CborObject.fromByteArray(map.getByteArray("Value")));
+        String RRKey = "_" + RESOLUTION_RECORD_IPNS_SUFFIX;
+        return ResolutionRecord.fromCbor(map.containsKey(RRKey) ? map.get(RRKey) : CborObject.fromByteArray(map.getByteArray("Value")));
     }
 
     @Override

--- a/src/peergos/server/tests/ServerIdentityTests.java
+++ b/src/peergos/server/tests/ServerIdentityTests.java
@@ -10,9 +10,9 @@ import peergos.server.sql.*;
 import peergos.server.storage.*;
 import peergos.server.util.*;
 import peergos.shared.*;
-import peergos.shared.cbor.*;
 import peergos.shared.io.ipfs.*;
 import peergos.shared.resolution.*;
+import peergos.shared.storage.IpnsEntry;
 import peergos.shared.util.*;
 
 import java.nio.charset.*;
@@ -48,7 +48,8 @@ public class ServerIdentityTests {
         Optional<IpnsMapping> prevIpnsMapping = IPNS.parseAndValidateIpnsEntry(
                 ArrayOps.concat("/ipns/".getBytes(StandardCharsets.UTF_8), current.getBytes()),
                 prevRecord);
-        ResolutionRecord prevRes = ResolutionRecord.fromCbor(CborObject.fromByteArray(prevIpnsMapping.get().value.value));
+        IpnsEntry ipnsData = new IpnsEntry(prevIpnsMapping.get().getSignature(), prevIpnsMapping.get().getData());
+        ResolutionRecord prevRes = ipnsData.getValue();
         Assert.assertEquals(prevRes.moved, true);
         Assert.assertEquals(prevRes.host, Optional.of(Multihash.fromBase58(nextPeerId.toBase58())));
     }

--- a/src/peergos/server/tests/slow/PostgresUserTests.java
+++ b/src/peergos/server/tests/slow/PostgresUserTests.java
@@ -13,12 +13,10 @@ import peergos.server.storage.*;
 import peergos.server.tests.*;
 import peergos.server.util.*;
 import peergos.shared.*;
-import peergos.shared.cbor.*;
 import peergos.shared.io.ipfs.*;
 import peergos.shared.resolution.*;
-import peergos.shared.social.*;
+import peergos.shared.storage.IpnsEntry;
 import peergos.shared.user.*;
-import peergos.shared.user.fs.*;
 import peergos.shared.util.*;
 
 import java.nio.charset.*;
@@ -106,7 +104,8 @@ public class PostgresUserTests extends UserTests {
         Optional<IpnsMapping> prevIpnsMapping = IPNS.parseAndValidateIpnsEntry(
                 ArrayOps.concat("/ipns/".getBytes(StandardCharsets.UTF_8), current.getBytes()),
                 prevRecord);
-        ResolutionRecord prevRes = ResolutionRecord.fromCbor(CborObject.fromByteArray(prevIpnsMapping.get().value.value));
+        IpnsEntry ipnsData = new IpnsEntry(prevIpnsMapping.get().getSignature(), prevIpnsMapping.get().getData());
+        ResolutionRecord prevRes = ipnsData.getValue();
         Assert.assertEquals(prevRes.moved, true);
         Assert.assertEquals(prevRes.host, Optional.of(Multihash.fromBase58(nextPeerId.toBase58())));
     }

--- a/src/peergos/shared/storage/IpnsEntry.java
+++ b/src/peergos/shared/storage/IpnsEntry.java
@@ -10,6 +10,7 @@ import java.util.*;
 import java.util.concurrent.*;
 
 public class IpnsEntry {
+    public static final String RESOLUTION_RECORD_IPNS_SUFFIX = "peergos_rr";
     public final byte[] signature, data;
 
     public IpnsEntry(byte[] signature, byte[] data) {
@@ -30,7 +31,9 @@ public class IpnsEntry {
         if (! (cbor instanceof CborObject.CborMap))
             throw new IllegalStateException("Invalid cbor for IpnsEntry!");
         CborObject.CborMap map = (CborObject.CborMap) cbor;
-        ResolutionRecord result = ResolutionRecord.fromCbor(CborObject.fromByteArray(map.getByteArray("Value")));
+        String RRKey = "_" + RESOLUTION_RECORD_IPNS_SUFFIX;
+        // support legacy records that put the RR in the value, this can be removed in the future
+        ResolutionRecord result = ResolutionRecord.fromCbor(map.containsKey(RRKey) ? map.get(RRKey) : CborObject.fromByteArray(map.getByteArray("Value")));
         // hard code legacy RSA rotations to avoid an RSA implementation in client
         if (signer.equals(Multihash.fromBase58("QmPqn9a1tJLpMtaCz1DSQNMAfsv6qXEx6XU2eLMTc2DVV4")) &&
                 result.moved && result.host.isPresent() &&

--- a/src/peergos/shared/storage/IpnsEntry.java
+++ b/src/peergos/shared/storage/IpnsEntry.java
@@ -27,13 +27,7 @@ public class IpnsEntry {
     }
 
     public CompletableFuture<ResolutionRecord> getValue(Multihash signer, peergos.shared.Crypto crypto) {
-        CborObject cbor = CborObject.fromByteArray(data);
-        if (! (cbor instanceof CborObject.CborMap))
-            throw new IllegalStateException("Invalid cbor for IpnsEntry!");
-        CborObject.CborMap map = (CborObject.CborMap) cbor;
-        String RRKey = "_" + RESOLUTION_RECORD_IPNS_SUFFIX;
-        // support legacy records that put the RR in the value, this can be removed in the future
-        ResolutionRecord result = ResolutionRecord.fromCbor(map.containsKey(RRKey) ? map.get(RRKey) : CborObject.fromByteArray(map.getByteArray("Value")));
+        ResolutionRecord result = getValue();
         // hard code legacy RSA rotations to avoid an RSA implementation in client
         if (signer.equals(Multihash.fromBase58("QmPqn9a1tJLpMtaCz1DSQNMAfsv6qXEx6XU2eLMTc2DVV4")) &&
                 result.moved && result.host.isPresent() &&
@@ -44,6 +38,16 @@ public class IpnsEntry {
                 result.host.get().equals(Multihash.fromBase58("12D3KooWFv6ZcoUKyaDBB7nR5SQg6HpmEbDXad48WyFSyEk7xrSR")))
             return Futures.of(result);
         return verifySignature(signer, crypto).thenApply(x -> result);
+    }
+
+    public ResolutionRecord getValue() {
+        CborObject cbor = CborObject.fromByteArray(data);
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for IpnsEntry!");
+        CborObject.CborMap map = (CborObject.CborMap) cbor;
+        String RRKey = "_" + RESOLUTION_RECORD_IPNS_SUFFIX;
+        // support legacy records that put the RR in the value, this can be removed in the future
+        return ResolutionRecord.fromCbor(map.containsKey(RRKey) ? map.get(RRKey) : CborObject.fromByteArray(map.getByteArray("Value")));
     }
 
     public long getIpnsSequence() {


### PR DESCRIPTION
This is because a resolution record is not a valid value for ipns record (despite kubo accepting it). Now we use a dummy value bafkqaaa.

Remain backwards compatible with existing records for now.