### PR TITLE
Add a new "proxy" command

### DIFF
--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -589,7 +589,7 @@ public class Main extends Builder {
                             net.social, pointerCache, net.instanceAdmin, net.spaceUsage, net.serverMessager, null);
 
                     InetSocketAddress localAPIAddress = new InetSocketAddress("localhost", a.getInt("port", 8000));
-                    List<String> appSubdomains = Arrays.asList("markup-viewer,email,calendar,todo-board,code-editor,pdf".split(","));
+                    List<String> appSubdomains = Arrays.asList("markup-viewer,calendar,code-editor,pdf".split(","));
                     Cid nodeId = net.dhtClient.id().join();
                     int connectionBacklog = 50;
                     int handlerPoolSize = 4;

--- a/src/peergos/shared/OnlineState.java
+++ b/src/peergos/shared/OnlineState.java
@@ -33,7 +33,8 @@ public class OnlineState {
     }
 
     public boolean isOfflineException(Throwable t) {
-        if (t.toString().contains("ConnectException")) {
+        String err = t.toString();
+        if (err.contains("ConnectException") || err.contains("UnknownHostException")) {
             testedState.set(false);
             return true;
         }


### PR DESCRIPTION
This runs a localhost proxy that serves up the web-ui and proxies api requests to a peergos server.

The default, if no commands or -help are specified, is to run the proxy, and then open the web-ui in the browser.

This is almost copy pasted form the mobile app, which can now use this code.