### PR TITLE
Fix: XXE in WebDav servlet's document builder configuration.

### DIFF
--- a/src/peergos/server/webdav/modeshape/webdav/methods/AbstractMethod.java
+++ b/src/peergos/server/webdav/modeshape/webdav/methods/AbstractMethod.java
@@ -191,6 +191,7 @@ public abstract class AbstractMethod implements IMethodExecutor {
         try {
             documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);
+            documentBuilderFactory.setExpandEntityReferences(false);
             documentBuilder = documentBuilderFactory.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
             throw new ServletException("jaxp failed");


### PR DESCRIPTION
### Description
This PR addresses a potential XML External Entity (XXE) injection vulnerability in the getDocumentBuilder() method by disabling entity reference expansion. 

### References
Identical fix in this commit
https://github.com/apache/tomcat/commit/1e7b31e24801777f4de45d565f6a20a5377dd22c
