### PR TITLE
Implement a bulk champ get call.

### DIFF
--- a/src/peergos/server/storage/AuthedStorage.java
+++ b/src/peergos/server/storage/AuthedStorage.java
@@ -159,10 +159,10 @@ public class AuthedStorage extends DelegatingDeletableStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(owner, root, champKey, bat, committedRoot, h);
+        return getChampLookup(owner, root, caps, committedRoot, h);
     }
 
     @Override

--- a/src/peergos/server/storage/DelayingStorage.java
+++ b/src/peergos/server/storage/DelayingStorage.java
@@ -103,9 +103,9 @@ public class DelayingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
         sleep(4*readDelay);
-        return source.getChampLookup(owner, root, champKey, bat, committedRoot);
+        return source.getChampLookup(owner, root, caps, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/DelegatingDeletableStorage.java
+++ b/src/peergos/server/storage/DelegatingDeletableStorage.java
@@ -113,7 +113,7 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public CompletableFuture<List<PresignedUrl>> authReads(List<MirrorCap> blocks) {
+    public CompletableFuture<List<PresignedUrl>> authReads(List<BlockMirrorCap> blocks) {
         return target.authReads(blocks);
     }
 
@@ -183,8 +183,8 @@ public class DelegatingDeletableStorage implements DeletableContentAddressedStor
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return target.getChampLookup(owner, root, champKey, bat, committedRoot);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, caps, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/FileContentAddressedStorage.java
+++ b/src/peergos/server/storage/FileContentAddressedStorage.java
@@ -83,10 +83,10 @@ public class FileContentAddressedStorage implements DeletableContentAddressedSto
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(owner, root, champKey, bat, committedRoot, hasher);
+        return getChampLookup(owner, root, caps, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/storage/MetadataCachingStorage.java
+++ b/src/peergos/server/storage/MetadataCachingStorage.java
@@ -94,8 +94,8 @@ public class MetadataCachingStorage extends DelegatingDeletableStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return target.getChampLookup(owner, root, champKey, bat,committedRoot);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, caps, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/NonWriteThroughStorage.java
+++ b/src/peergos/server/storage/NonWriteThroughStorage.java
@@ -53,8 +53,8 @@ public class NonWriteThroughStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat,Optional<Cid> committedRoot) {
-        return modifications.getChampLookup(owner, root, champKey, bat, committedRoot);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return modifications.getChampLookup(owner, root, caps, committedRoot);
     }
 
     @Override

--- a/src/peergos/server/storage/RAMStorage.java
+++ b/src/peergos/server/storage/RAMStorage.java
@@ -67,8 +67,8 @@ public class RAMStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return getChampLookup(owner, root, champKey, bat, committedRoot, hasher);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return getChampLookup(owner, root, caps, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/storage/RequestCountingStorage.java
+++ b/src/peergos/server/storage/RequestCountingStorage.java
@@ -63,8 +63,8 @@ public class RequestCountingStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return target.getChampLookup(owner, root, champKey, bat, committedRoot)
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, caps, committedRoot)
                 .thenApply(blocks -> {
                     champGet.incrementAndGet();
                     return blocks;

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -272,7 +272,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<PresignedUrl>> authReads(List<MirrorCap> blocks) {
+    public CompletableFuture<List<PresignedUrl>> authReads(List<BlockMirrorCap> blocks) {
         if (blocks.size() > MAX_BLOCK_AUTHS)
             throw new IllegalStateException("Too many reads to auth!");
         List<PresignedUrl> res = new ArrayList<>();
@@ -293,7 +293,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
                         }))
                 .collect(Collectors.toList());
 
-        for (MirrorCap block : blocks) {
+        for (BlockMirrorCap block : blocks) {
             String s3Key = hashToKey(block.hash);
             res.add(S3Request.preSignGet(folder + s3Key, Optional.of(600), Optional.empty(), S3AdminRequests.asAwsDate(ZonedDateTime.now()), host, region, accessKeyId, secretKey, useHttps, hasher).join());
         }
@@ -593,10 +593,10 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat,Optional<Cid> committedRoot) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(owner, root, champKey, bat, committedRoot, hasher);
+        return getChampLookup(owner, root, caps, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/storage/TransactionalIpfs.java
+++ b/src/peergos/server/storage/TransactionalIpfs.java
@@ -146,12 +146,11 @@ public class TransactionalIpfs extends DelegatingDeletableStorage {
     @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
                                                           Cid root,
-                                                          byte[] champKey,
-                                                          Optional<BatWithId> bat,
+                                                          List<ChunkMirrorCap> caps,
                                                           Optional<Cid> committedRoot) {
         if (! hasBlock(root))
             return Futures.errored(new IllegalStateException("Champ root not present locally: " + root));
-        return getChampLookup(owner, root, champKey, bat, committedRoot, hasher);
+        return getChampLookup(owner, root, caps, committedRoot, hasher);
     }
 
     @Override

--- a/src/peergos/server/tests/RetryStorageTests.java
+++ b/src/peergos/server/tests/RetryStorageTests.java
@@ -127,7 +127,7 @@ public class RetryStorageTests {
         }
 
         @Override
-        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
             if(counter++ % retryLimit != 0) {
                 return CompletableFuture.failedFuture(new Error("failure!"));
             }else {

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -40,7 +40,7 @@ public class SyncTests {
         Files.move(base1.resolve(filename), subdir.resolve(filename));
         DirectorySync.syncDirs(localFs, base1, localFs, base2, null, null, syncedState, 32, 5);
         Assert.assertTrue(syncedState.byPath(filename) == null);
-        String fileRelPath = subdir.getFileName().resolve(filename).toString();
+        String fileRelPath = subdir.getFileName().resolve(filename).toString().replaceAll("\\\\", "/");
         Assert.assertTrue(syncedState.byPath(fileRelPath) != null);
 
         // sync should be stable

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -134,11 +134,17 @@ public class BufferedNetworkAccess extends NetworkAccess {
                 mutable, batCave, batCache, tree, synchronizer, instanceAdmin, spaceUsage, serverMessager, hasher, usernames, isJavascript());
     }
 
-    public CompletableFuture<Optional<CryptreeNode>> getMetadata(WriterData base, AbsoluteCapability cap) {
-        return (pointerBuffer.isEmpty() ?
+    @Override
+    public CompletableFuture<Optional<Cid>> getLastCommittedRoot(PublicKeyHash writer, WriterData base) {
+        return pointerBuffer.isEmpty() ?
                 hasher.sha256(base.serialize())
                         .thenApply(h ->  Optional.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, h))) :
-                Futures.of(pointerBuffer.getCommittedPointerTarget(cap.writer)))
+                Futures.of(pointerBuffer.getCommittedPointerTarget(writer));
+    }
+
+    @Override
+    public CompletableFuture<Optional<CryptreeNode>> getMetadata(WriterData base, AbsoluteCapability cap) {
+        return getLastCommittedRoot(cap.writer, base)
                 .thenCompose(committed -> super.getMetadata(base, cap, committed));
     }
 

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -200,7 +200,7 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
         return Futures.of(new ArrayList<>(storage.values()));
     }
 

--- a/src/peergos/shared/storage/BlockMirrorCap.java
+++ b/src/peergos/shared/storage/BlockMirrorCap.java
@@ -6,12 +6,12 @@ import peergos.shared.storage.auth.*;
 
 import java.util.*;
 
-public class MirrorCap implements Cborable {
+public class BlockMirrorCap implements Cborable {
 
     public final Cid hash;
     public final Optional<BatWithId> bat;
 
-    public MirrorCap(Cid hash, Optional<BatWithId> bat) {
+    public BlockMirrorCap(Cid hash, Optional<BatWithId> bat) {
         this.hash = hash;
         this.bat = bat;
     }
@@ -24,12 +24,12 @@ public class MirrorCap implements Cborable {
         return CborObject.CborMap.build(state);
     }
 
-    public static MirrorCap fromCbor(Cborable cbor) {
+    public static BlockMirrorCap fromCbor(Cborable cbor) {
         if (! (cbor instanceof CborObject.CborMap))
-            throw new IllegalStateException("Incorrect cbor for MirrorCap: " + cbor);
+            throw new IllegalStateException("Incorrect cbor for BlockMirrorCap: " + cbor);
 
         CborObject.CborMap m = (CborObject.CborMap) cbor;
-        return new MirrorCap(m.get("h", c -> Cid.cast(((CborObject.CborByteArray)c).value)),
+        return new BlockMirrorCap(m.get("h", c -> Cid.cast(((CborObject.CborByteArray)c).value)),
                 m.getOptional("b", BatWithId::fromCbor));
     }
 }

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -65,7 +65,7 @@ public class BufferedStorage extends DelegatingStorage {
         // If we are in a write transaction try to perform a local champ lookup from the buffer,
         // falling back to a direct champ get
         //TODO collect all missing lookups into a single remote bulk get
-        return Futures.combineAll(caps.stream().map(cap -> Futures.asyncExceptionally(
+        return Futures.combineAllInOrder(caps.stream().map(cap -> Futures.asyncExceptionally(
                 () -> getChampLookup(owner, root, cap.mapKey, cap.bat, committedRoot, hasher),
                 t -> target.getChampLookup(owner, root, Arrays.asList(cap), committedRoot)
         )).collect(Collectors.toList()))

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -58,17 +58,20 @@ public class BufferedStorage extends DelegatingStorage {
     @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
                                                           Cid root,
-                                                          byte[] champKey,
-                                                          Optional<BatWithId> bat,
+                                                          List<ChunkMirrorCap> caps,
                                                           Optional<Cid> committedRoot) {
         if (isEmpty())
-            return target.getChampLookup(owner, root, champKey, bat, committedRoot);
+            return target.getChampLookup(owner, root, caps, committedRoot);
         // If we are in a write transaction try to perform a local champ lookup from the buffer,
         // falling back to a direct champ get
-        return Futures.asyncExceptionally(
-                () -> getChampLookup(owner, root, champKey, bat, committedRoot, hasher),
-                t -> target.getChampLookup(owner, root, champKey, bat, committedRoot)
-        );
+        //TODO collect all missing lookups into a single remote bulk get
+        return Futures.combineAll(caps.stream().map(cap -> Futures.asyncExceptionally(
+                () -> getChampLookup(owner, root, cap.mapKey, cap.bat, committedRoot, hasher),
+                t -> target.getChampLookup(owner, root, Arrays.asList(cap), committedRoot)
+        )).collect(Collectors.toList()))
+                .thenApply(res ->res.stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
     }
 
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
@@ -109,8 +112,8 @@ public class BufferedStorage extends DelegatingStorage {
                 () -> committedRoot.isPresent() ?
                         get(owner, committedRoot.get(), Optional.empty())
                                 .thenApply(ropt -> ropt.map(WriterData::fromCbor).flatMap(wd ->  wd.tree))
-                                .thenCompose(champRoot -> target.getChampLookup(owner, (Cid) champRoot.get(), champKey, bat, Optional.empty())) :
-                        target.getChampLookup(owner, root, champKey, bat, Optional.empty()), hasher),
+                                .thenCompose(champRoot -> target.getChampLookup(owner, (Cid) champRoot.get(), Arrays.asList(new ChunkMirrorCap(champKey, bat)), Optional.empty())) :
+                        target.getChampLookup(owner, root, Arrays.asList(new ChunkMirrorCap(champKey, bat)), Optional.empty()), hasher),
                 100, 1024 * 1024);
         return ChampWrapper.create(owner, root, Optional.empty(), x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
                 .thenCompose(tree -> tree.get(champKey))

--- a/src/peergos/shared/storage/CachingVerifyingStorage.java
+++ b/src/peergos/shared/storage/CachingVerifyingStorage.java
@@ -89,8 +89,8 @@ public class CachingVerifyingStorage extends DelegatingStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return target.getChampLookup(owner, root, champKey, bat,committedRoot)
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, caps, committedRoot)
                 .thenCompose(blocks -> Futures.combineAllInOrder(blocks.stream()
                         .map(b -> hasher.hash(b, false)
                                 .thenApply(h -> cache(h, b)))

--- a/src/peergos/shared/storage/ChunkMirrorCap.java
+++ b/src/peergos/shared/storage/ChunkMirrorCap.java
@@ -1,0 +1,45 @@
+package peergos.shared.storage;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+import peergos.shared.io.ipfs.bases.Multibase;
+import peergos.shared.storage.auth.BatWithId;
+
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class ChunkMirrorCap implements Cborable {
+
+    public final byte[] mapKey;
+    public final Optional<BatWithId> bat;
+
+    public ChunkMirrorCap(byte[] mapKey, Optional<BatWithId> bat) {
+        this.mapKey = mapKey;
+        this.bat = bat;
+    }
+
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("m", new CborObject.CborByteArray(mapKey));
+        bat.ifPresent(b -> state.put("b", b));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static ChunkMirrorCap fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Incorrect cbor for ChunkMirrorCap: " + cbor);
+
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new ChunkMirrorCap(m.get("m", c -> ((CborObject.CborByteArray)c).value),
+                m.getOptional("b", BatWithId::fromCbor));
+    }
+
+    public String encodeToString() {
+        return Multibase.encode(Multibase.Base.Base58BTC, toCbor().toByteArray());
+    }
+
+    public static ChunkMirrorCap fromString(String encoded) {
+        return fromCbor(CborObject.fromByteArray(Multibase.decode(encoded)));
+    }
+}

--- a/src/peergos/shared/storage/ContentAddressedStorageProxy.java
+++ b/src/peergos/shared/storage/ContentAddressedStorageProxy.java
@@ -111,7 +111,7 @@ public interface ContentAddressedStorageProxy {
                     .map(ChunkMirrorCap::toCbor)
                     .collect(Collectors.toList()));
             return poster.get(getProxyUrlPrefix(targetServerId) + apiPrefix
-                            + "champ/get?arg=" + root.toString()
+                            + ContentAddressedStorage.HTTP.CHAMP_GET_BULK + "?arg=" + root.toString()
                             + "&owner=" + encode(owner.toString())
                             + "&caps=" + Multibase.encode(Multibase.Base.Base58BTC, capsCbor.serialize()))
                     .thenApply(CborObject::fromByteArray)

--- a/src/peergos/shared/storage/DelegatingStorage.java
+++ b/src/peergos/shared/storage/DelegatingStorage.java
@@ -81,8 +81,8 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return target.getChampLookup(owner, root, champKey, bat, committedRoot);
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return target.getChampLookup(owner, root, caps, committedRoot);
     }
 
     @Override
@@ -116,7 +116,7 @@ public abstract class DelegatingStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<PresignedUrl>> authReads(List<MirrorCap> blocks) {
+    public CompletableFuture<List<PresignedUrl>> authReads(List<BlockMirrorCap> blocks) {
         return target.authReads(blocks);
     }
 

--- a/src/peergos/shared/storage/LocalOnlyStorage.java
+++ b/src/peergos/shared/storage/LocalOnlyStorage.java
@@ -40,6 +40,11 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
     }
 
     @Override
+    public CompletableFuture<Optional<CborObject>> get(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
+        return getRaw(owner, hash, bat).thenApply(opt -> opt.map(CborObject::fromByteArray));
+    }
+
+    @Override
     public CompletableFuture<BlockStoreProperties> blockStoreProperties() {
         return Futures.of(BlockStoreProperties.empty());
     }
@@ -82,11 +87,6 @@ public class LocalOnlyStorage implements ContentAddressedStorage {
     @Override
     public CompletableFuture<List<Cid>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid) {
         throw new IllegalStateException("Unimplemented!");
-    }
-
-    @Override
-    public CompletableFuture<Optional<CborObject>> get(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
-        return getRaw(owner, hash, bat).thenApply(opt -> opt.map(CborObject::fromByteArray));
     }
 
     @Override

--- a/src/peergos/shared/storage/RetryStorage.java
+++ b/src/peergos/shared/storage/RetryStorage.java
@@ -136,8 +136,8 @@ public class RetryStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, byte[] champKey, Optional<BatWithId> bat, Optional<Cid> committedRoot) {
-        return runWithRetry(() -> target.getChampLookup(owner, root, champKey, bat,committedRoot));
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        return runWithRetry(() -> target.getChampLookup(owner, root, caps, committedRoot));
     }
 
     @Override
@@ -171,7 +171,7 @@ public class RetryStorage implements ContentAddressedStorage {
     }
 
     @Override
-    public CompletableFuture<List<PresignedUrl>> authReads(List<MirrorCap> blocks) {
+    public CompletableFuture<List<PresignedUrl>> authReads(List<BlockMirrorCap> blocks) {
         return runWithRetry(() -> target.authReads(blocks));
     }
 

--- a/src/peergos/shared/storage/UnauthedCachingStorage.java
+++ b/src/peergos/shared/storage/UnauthedCachingStorage.java
@@ -78,49 +78,57 @@ public class UnauthedCachingStorage extends DelegatingStorage {
     @Override
     public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
                                                           Cid root,
-                                                          byte[] champKey,
-                                                          Optional<BatWithId> bat,
+                                                          List<ChunkMirrorCap> caps,
                                                           Optional<Cid> committedRoot) {
         return Futures.asyncExceptionally(
-                () -> localChampLookup(owner, root, champKey, bat, committedRoot, hasher),
-                t -> target.getChampLookup(owner, root, champKey, bat,  committedRoot)
+                () -> localChampLookup(owner, root, caps, committedRoot, hasher),
+                t -> target.getChampLookup(owner, root, caps,  committedRoot)
                         .thenApply(blocks -> cacheBlocks(blocks, hasher)));
     }
 
     public CompletableFuture<List<byte[]>> localChampLookup(PublicKeyHash owner,
                                                             Cid root,
-                                                            byte[] champKey,
-                                                            Optional<BatWithId> bat,
+                                                            List<ChunkMirrorCap> caps,
                                                             Optional<Cid> committedRoot,
                                                             Hasher hasher) {
         CachingStorage cache = new CachingStorage(new LocalOnlyStorage(this.cache,
-                () -> (committedRoot.isPresent() ?
-                        get(owner, committedRoot.get(), Optional.empty())
-                                .thenApply(ropt -> ropt.map(WriterData::fromCbor).flatMap(wd ->  wd.tree))
-                                .thenCompose(champRoot -> target.getChampLookup(owner, (Cid) champRoot.get(), champKey, bat, Optional.empty())) :
-                        target.getChampLookup(owner, root, champKey, bat, Optional.empty()))
-                        .thenApply(blocks -> cacheBlocks(blocks, hasher)), hasher),
+                () -> Futures.of(Collections.emptyList()), hasher),
                 100, 1024*1024);
+
         return ChampWrapper.create(owner, root, Optional.empty(), x -> Futures.of(x.data), cache, hasher, c -> (CborObject.CborMerkleLink) c)
-                .thenCompose(tree -> tree.get(champKey))
-                .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
-                .thenApply(btreeValue -> {
-                    if (btreeValue.isPresent())
-                        return cache.get(owner, (Cid) btreeValue.get(), bat);
-                    return Optional.empty();
-                }).thenApply(x -> new ArrayList<>(cache.getCached()));
+                .thenCompose(tree -> Futures.combineAll(caps.stream()
+                        .map(cap -> tree.get(cap.mapKey)
+                                .thenApply(c -> c.map(x -> x.target)
+                                        .map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
+                                .thenCompose(btreeValue -> {
+                                    if (btreeValue.isPresent())
+                                        return cache.get(owner, (Cid) btreeValue.get(), cap.bat)
+                                                .thenApply(x -> Optional.<ChunkMirrorCap>empty());
+                                    return Futures.of(Optional.of(cap));
+                                })).collect(Collectors.toList())))
+                .thenCompose(missing -> target.getChampLookup(owner, root,
+                        missing.stream()
+                                .flatMap(Optional::stream)
+                                .collect(Collectors.toList()), Optional.empty()))
+                .thenApply(remote -> {
+                    Collection<byte[]> cached = cache.getCached();
+                    ArrayList<byte[]> res = new ArrayList<>(cached.size() + remote.size());
+                    res.addAll(cached);
+                    res.addAll(remote);
+                    return res;
+                });
     }
 
     @Override
-    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root,
-                                                          byte[] champKey,
-                                                          Optional<BatWithId> bat,
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner,
+                                                          Cid root,
+                                                          List<ChunkMirrorCap> caps,
                                                           Optional<Cid> committedRoot,
                                                           Hasher hasher) {
         System.out.println("UnauthedCachingStorage::getChampLookup " + root);
         return Futures.asyncExceptionally(
-                () -> target.getChampLookup(owner, root, champKey, bat, committedRoot, hasher),
-                        t -> super.getChampLookup(owner, root, champKey, bat, committedRoot, hasher)
+                () -> target.getChampLookup(owner, root, caps, committedRoot, hasher),
+                        t -> super.getChampLookup(owner, root, caps, committedRoot, hasher)
         ).thenApply(blocks -> cacheBlocks(blocks, hasher));
     }
 

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -455,6 +455,8 @@ public class FileWrapper {
                                                                                                 String ownername,
                                                                                                 NetworkAccess network,
                                                                                                 Snapshot version) {
+        if (caps.isEmpty())
+            return Futures.of(new Pair<>(Collections.emptySet(), Collections.emptyList()));
         Set<PublicKeyHash> childWriters = caps.stream()
                 .map(c -> c.cap.writer)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
This makes loading folders, especially large folders, much faster (5x faster for a folder with 1000 files). And Chrome is less likely to crash from too many requests because there are 20x fewer requests. 

* Leave the existing server handler for champ.get, but change the client to always use the bulk call, so we are backwards compatible until all clients are updated.
* Limit the call to 20 gets in a request

Now the bottleneck for large folders is listing the child caps, which is because the dir chunks are a linked list. That can be solved with a stream secret on dirs to allow retrieving all dir chunks in parallel. We probably want to do something cleverer there and sort the child links or turn it into a btree, so we can at least do binary search by name. 

Edit: this hasn't fixed the chrome crash, which it turns out was caused by many OPFS requests.