### PR TITLE
Fix champ.get missing roots (CAS exceptions) properly

### DIFF
--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -150,7 +150,7 @@ public class PeergosSyncFS implements SyncFilesystem {
             long chunkIndex = b * 1024;
             context.network.synchronizer.applyComplexUpdate(f.owner(), f.signingPair(),
                     (s, c) -> {
-                        CryptreeNode meta = context.network.getMetadata(s.get(f.writer()).props.get(), chunkCap).join().get();
+                        CryptreeNode meta = context.network.getMetadata(s.get(f.writer()), chunkCap).join().get();
                         return meta.updateProperties(s, c, chunkCap, Optional.of(f.signingPair()), meta.getProperties(chunkCap.rBaseKey)
                                 .withHash(Optional.of(hashTree.branch(chunkIndex))), context.network);
                     }, () -> true).join();

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -1122,7 +1122,7 @@ public class MultiUserTests {
         Optional<FileWrapper> priorUnsharedView = userToUnshareWith.getByPath(friendsPathToFile).get();
         AbsoluteCapability priorPointer = priorUnsharedView.get().getPointer().capability;
         CommittedWriterData cwd = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
-        CryptreeNode priorFileAccess = network.getMetadata(cwd.props.get(), priorPointer).get().get();
+        CryptreeNode priorFileAccess = network.getMetadata(cwd, priorPointer).get().get();
         SymmetricKey priorMetaKey = priorFileAccess.getParentKey(priorPointer.rBaseKey);
 
         // unshare with a single user
@@ -1139,7 +1139,7 @@ public class MultiUserTests {
         String friendsNewPathToFile = u1.username + "/" + newname;
         Optional<FileWrapper> unsharedView2 = userToUnshareWith.getByPath(friendsNewPathToFile).get();
         CommittedWriterData cwd2 = network.synchronizer.getValue(priorPointer.owner, priorPointer.writer).join().get(priorPointer.writer);
-        CryptreeNode fileAccess = network.getMetadata(cwd2.props.get(), priorPointer.withMapKey(newCap.getMapKey(), newCap.bat)).get().get();
+        CryptreeNode fileAccess = network.getMetadata(cwd2, priorPointer.withMapKey(newCap.getMapKey(), newCap.bat)).get().get();
         // check we are trying to decrypt the correct thing
         PaddedCipherText priorPropsCipherText = ((CborObject.CborMap) priorFileAccess.toCbor()).getObject("p", PaddedCipherText::fromCbor);
         CborObject.CborMap priorFromParent = priorPropsCipherText.decrypt(priorMetaKey, x -> (CborObject.CborMap)x);

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -2474,7 +2474,7 @@ public class PeergosNetworkUtils {
         Snapshot version = new Snapshot(cap.writer,
                 WriterData.getWriterData(cap.owner, (Cid) pointer.updated.get(), pointer.sequence, network.dhtClient).join());
 
-        Optional<CryptreeNode> next = network.getMetadata(version.get(nextChunkCap.writer).props.get(), nextChunkCap).join();
+        Optional<CryptreeNode> next = network.getMetadata(version.get(nextChunkCap.writer), nextChunkCap).join();
         Set<AbsoluteCapability> directUnnamed = direct.stream().map(n -> n.cap).collect(Collectors.toSet());
         if (! next.isPresent())
             return Arrays.asList(directUnnamed);

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -1250,7 +1250,7 @@ public abstract class UserTests {
                 updatedFile.getFileProperties().streamSecret, newcap.getMapKey(), Optional.empty(), crypto.hasher).join();
         Assert.assertTrue(nextChunkRel.right.isEmpty());
         NetworkAccess cleared = network.clear();
-        WriterData uwd = WriterData.getWriterData(owner, updatedFile.writer(), network.mutable, network.dhtClient).join().props.get();
+        CommittedWriterData uwd = WriterData.getWriterData(owner, updatedFile.writer(), network.mutable, network.dhtClient).join();
         Optional<CryptreeNode> secondChunk = cleared.getMetadata(uwd, newcap.withMapKey(nextChunkRel.left, Optional.empty())).join();
         Assert.assertTrue(secondChunk.isPresent());
         // now the third chunk
@@ -1347,7 +1347,7 @@ public abstract class UserTests {
         // check we can't get the third chunk any more
         WritableAbsoluteCapability pointer = original.writableFilePointer();
         CommittedWriterData cwd = network.synchronizer.getValue(pointer.owner, pointer.writer).join().get(pointer.writer);
-        Optional<CryptreeNode> thirdChunk = network.getMetadata(cwd.props.get(), pointer.withMapKey(thirdChunkLabel.left, thirdChunkLabel.right)).join();
+        Optional<CryptreeNode> thirdChunk = network.getMetadata(cwd, pointer.withMapKey(thirdChunkLabel.left, thirdChunkLabel.right)).join();
         Assert.assertTrue("File is truncated", ! thirdChunk.isPresent());
         Assert.assertTrue("File has correct size", truncated.getFileProperties().size == truncateLength);
 
@@ -1601,7 +1601,7 @@ public abstract class UserTests {
 
         AbsoluteCapability pointer = subfolder.getPointer().capability;
         CommittedWriterData cwd = network.synchronizer.getValue(pointer.owner, pointer.writer).join().get(pointer.writer);
-        Optional<CryptreeNode> subdir = network.getMetadata(cwd.props.get(), pointer).join();
+        Optional<CryptreeNode> subdir = network.getMetadata(cwd, pointer).join();
         Assert.assertTrue("Child deleted", ! subdir.isPresent());
     }
 

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -132,20 +132,18 @@ public class BufferedNetworkAccess extends NetworkAccess {
     }
 
     @Override
-    public CompletableFuture<Optional<Cid>> getLastCommittedRoot(PublicKeyHash writer, WriterData base) {
-        return pointerBuffer.isEmpty() ?
-                hasher.sha256(base.serialize())
-                        .thenApply(h ->  Optional.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, h))) :
-                Futures.of(pointerBuffer.getCommittedPointerTarget(writer));
-//        Optional<Cid> lastCommitTarget = pointerBuffer.getCommittedPointerTarget(writer);
-//        return lastCommitTarget.isPresent() ?
-//                Futures.of(lastCommitTarget) :
-//                hasher.sha256(base.serialize())
-//                        .thenApply(h ->  Optional.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, h)));
+    public CompletableFuture<Optional<Cid>> getLastCommittedRoot(PublicKeyHash writer, CommittedWriterData base) {
+        Optional<Pair<Optional<Cid>, Optional<Long>>> lastCommitTarget = pointerBuffer.getCommittedPointerTarget(writer);
+        if (lastCommitTarget.isEmpty())
+            return Futures.of(base.hash.toOptional().map(c -> (Cid) c));
+        // Take whichever commit was later (higher sequence)
+        return base.sequence.orElse(-1L) > lastCommitTarget.get().right.orElse(-1L) ?
+                Futures.of(base.hash.toOptional().map(c -> (Cid) c)) :
+                Futures.of(lastCommitTarget.get().left);
     }
 
     @Override
-    public CompletableFuture<Optional<CryptreeNode>> getMetadata(WriterData base, AbsoluteCapability cap) {
+    public CompletableFuture<Optional<CryptreeNode>> getMetadata(CommittedWriterData base, AbsoluteCapability cap) {
         return getLastCommittedRoot(cap.writer, base)
                 .thenCompose(committed -> super.getMetadata(base, cap, committed));
     }

--- a/src/peergos/shared/messaging/ChatController.java
+++ b/src/peergos/shared/messaging/ChatController.java
@@ -218,7 +218,7 @@ public class ChatController {
                         .thenApply(Optional::get),
                 t -> context.getByPath(PathUtil.get(mirrorUsername).resolve(sourcePath.subpath(1, sourcePath.getNameCount())).toString(), v)
                         .thenApply(Optional::get))
-                .thenCompose(f -> f.getInputStream(f.version.get(f.writer()).props.get(), context.network, context.crypto, x -> {})
+                .thenCompose(f -> f.getInputStream(f.version.get(f.writer()), context.network, context.crypto, x -> {})
                         .thenCompose(r -> dir.uploadFileSection(v, c, f.getName(), r, false, 0, f.getSize(),
                                 Optional.empty(), false, false, false, context.network, context.crypto, x -> {},
                                 context.crypto.random.randomBytes(RelativeCapability.MAP_KEY_LENGTH), Optional.empty(),

--- a/src/peergos/shared/messaging/FileBackedMessageStore.java
+++ b/src/peergos/shared/messaging/FileBackedMessageStore.java
@@ -38,7 +38,7 @@ public class FileBackedMessageStore implements MessageStore {
     private CompletableFuture<Pair<Long, Integer>> getChunkByteOffset(long index) {
         if (messages.getSize() < 5*1024*1024)
             return Futures.of(new Pair<>(0L, (int) index));
-        return indexFile.getInputStream(indexFile.version.get(indexFile.writer()).props.get(), network, crypto, x -> {})
+        return indexFile.getInputStream(indexFile.version.get(indexFile.writer()), network, crypto, x -> {})
                         .thenCompose(reader -> findOffset(reader, new byte[1024],
                                 0L, 0L, index, indexFile.getSize()));
     }
@@ -74,7 +74,7 @@ public class FileBackedMessageStore implements MessageStore {
     @Override
     public CompletableFuture<List<SignedMessage>> getMessagesFrom(long index) {
         List<SignedMessage> res = new ArrayList<>();
-        return messages.getInputStream(messages.version.get(messages.writer()).props.get(), network, crypto, x -> {})
+        return messages.getInputStream(messages.version.get(messages.writer()), network, crypto, x -> {})
                         .thenCompose(reader -> getChunkByteOffset(index)
                                 .thenCompose(p -> reader.seek(p.left)
                                         .thenCompose(seeked -> seeked.parseLimitedStream(SignedMessage::fromCbor,
@@ -85,7 +85,7 @@ public class FileBackedMessageStore implements MessageStore {
     @Override
     public CompletableFuture<List<SignedMessage>> getMessages(long fromIndex, long toIndex) {
         List<SignedMessage> res = new ArrayList<>();
-        return messages.getInputStream(messages.version.get(messages.writer()).props.get(), network, crypto, x -> {})
+        return messages.getInputStream(messages.version.get(messages.writer()), network, crypto, x -> {})
                         .thenCompose(reader -> getChunkByteOffset(fromIndex)
                                 .thenCompose(p -> reader.seek(p.left)
                                         .thenCompose(seeked -> seeked.parseLimitedStream(SignedMessage::fromCbor,

--- a/src/peergos/shared/mutable/BufferedPointers.java
+++ b/src/peergos/shared/mutable/BufferedPointers.java
@@ -44,15 +44,16 @@ public class BufferedPointers implements MutablePointers {
         this.target = target;
     }
 
-    public Optional<Cid> getCommittedPointerTarget(PublicKeyHash writer) {
+    public Optional<Pair<Optional<Cid>, Optional<Long>>> getCommittedPointerTarget(PublicKeyHash writer) {
         if (writerUpdates.isEmpty())
             return Optional.ofNullable(lastCommits.get(writer))
-                    .flatMap(u -> u.currentHash.toOptional()
-                            .map(c -> (Cid) c));
+                    .map(w -> new Pair<>(w.currentHash.toOptional().map(h ->  (Cid) h),
+                            w.currentSequence));
         return writerUpdates.stream()
-                .filter(u ->  u.writer.equals(writer)).map(u -> u.prevHash)
+                .filter(u ->  u.writer.equals(writer))
                 .findFirst()
-                .flatMap(m -> m.toOptional().map(h ->  (Cid) h));
+                .map(m -> new Pair<>(m.prevHash.toOptional().map(h ->  (Cid) h),
+                        m.currentSequence.map(x -> x-1)));
     }
 
     public List<WriterUpdate> getUpdates() {

--- a/src/peergos/shared/user/IncomingCapCache.java
+++ b/src/peergos/shared/user/IncomingCapCache.java
@@ -229,7 +229,7 @@ public class IncomingCapCache {
                     if (capsOpt.isEmpty())
                         return recurse.get();
                     FileWrapper capsFile = capsOpt.get();
-                    return capsFile.getInputStream(capsFile.version.get(capsFile.writer()).props.get(), network, crypto, x-> {})
+                    return capsFile.getInputStream(capsFile.version.get(capsFile.writer()), network, crypto, x-> {})
                             .thenCompose(r -> Serialize.readFully(r, capsFile.getSize()))
                             .thenApply(CborObject::fromByteArray)
                             .thenApply(CapsInDirectory::fromCbor)

--- a/src/peergos/shared/user/SharedWithCache.java
+++ b/src/peergos/shared/user/SharedWithCache.java
@@ -230,7 +230,7 @@ public class SharedWithCache {
     }
 
     private static CompletableFuture<SharedWithState> parseCacheFile(FileWrapper cache, NetworkAccess network, Crypto crypto) {
-        return cache.getInputStream(cache.version.get(cache.writer()).props.get(), network, crypto, x -> {})
+        return cache.getInputStream(cache.version.get(cache.writer()), network, crypto, x -> {})
                 .thenCompose(in -> Serialize.readFully(in, cache.getSize()))
                 .thenApply(CborObject::fromByteArray)
                 .thenApply(SharedWithState::fromCbor);

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -2562,7 +2562,7 @@ public class UserContext {
                                                                                               Snapshot s,
                                                                                               NetworkAccess network) {
         return homeDir.getChild(ENTRY_POINTS_FROM_FRIENDS_GROUPS_FILENAME, crypto.hasher, network)
-                .thenCompose(fopt -> fopt.map(f -> f.getInputStream(s.get(f.writer()).props.get(), network, crypto, x -> {})
+                .thenCompose(fopt -> fopt.map(f -> f.getInputStream(s.get(f.writer()), network, crypto, x -> {})
                         .thenCompose(reader -> Serialize.parse(reader, f.getSize(), FriendsGroups::fromCbor))
                         .thenApply(g -> new Pair<>(g, fopt)))
                         .orElse(CompletableFuture.completedFuture(new Pair<>(FriendsGroups.empty(), Optional.empty()))));

--- a/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
+++ b/src/peergos/shared/user/fs/EncryptedChunkRetriever.java
@@ -35,7 +35,7 @@ public class EncryptedChunkRetriever implements FileRetriever {
     }
 
     @Override
-    public CompletableFuture<AsyncReader> getFile(WriterData version,
+    public CompletableFuture<AsyncReader> getFile(CommittedWriterData version,
                                                   NetworkAccess network,
                                                   Crypto crypto,
                                                   AbsoluteCapability ourCap,
@@ -55,7 +55,7 @@ public class EncryptedChunkRetriever implements FileRetriever {
                 });
     }
 
-    public CompletableFuture<Optional<Pair<byte[], Optional<Bat>>>> getMapLabelAt(WriterData version,
+    public CompletableFuture<Optional<Pair<byte[], Optional<Bat>>>> getMapLabelAt(CommittedWriterData version,
                                                                                   AbsoluteCapability startCap,
                                                                                   Optional<byte[]> streamSecret,
                                                                                   long offset,
@@ -79,7 +79,7 @@ public class EncryptedChunkRetriever implements FileRetriever {
                 );
     }
 
-    public CompletableFuture<Optional<LocatedChunk>> getChunk(WriterData version,
+    public CompletableFuture<Optional<LocatedChunk>> getChunk(CommittedWriterData version,
                                                               NetworkAccess network,
                                                               Crypto crypto,
                                                               long startIndex,

--- a/src/peergos/shared/user/fs/FileRetriever.java
+++ b/src/peergos/shared/user/fs/FileRetriever.java
@@ -14,7 +14,7 @@ import java.util.concurrent.*;
 
 public interface FileRetriever {
 
-    CompletableFuture<AsyncReader> getFile(WriterData version,
+    CompletableFuture<AsyncReader> getFile(CommittedWriterData version,
                                            NetworkAccess network,
                                            Crypto crypto,
                                            AbsoluteCapability ourCap,
@@ -24,14 +24,14 @@ public interface FileRetriever {
                                            int nBufferedChunks,
                                            ProgressConsumer<Long> monitor);
 
-    CompletableFuture<Optional<Pair<byte[], Optional<Bat>>>> getMapLabelAt(WriterData version,
+    CompletableFuture<Optional<Pair<byte[], Optional<Bat>>>> getMapLabelAt(CommittedWriterData version,
                                                                            AbsoluteCapability startCap,
                                                                            Optional<byte[]> streamSecret,
                                                                            long offset,
                                                                            Hasher hasher,
                                                                            NetworkAccess network);
 
-    CompletableFuture<Optional<LocatedChunk>> getChunk(WriterData version,
+    CompletableFuture<Optional<LocatedChunk>> getChunk(CommittedWriterData version,
                                                        NetworkAccess network,
                                                        Crypto crypto,
                                                        long startIndex,

--- a/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
+++ b/src/peergos/shared/user/fs/LazyInputStreamCombiner.java
@@ -19,7 +19,7 @@ public class LazyInputStreamCombiner implements AsyncReader {
     public static void disableLog() {
         LOG.setLevel(Level.OFF);
     }
-    private final WriterData version;
+    private final CommittedWriterData version;
     private final NetworkAccess network;
     private final Crypto crypto;
     private final SymmetricKey baseKey;
@@ -41,7 +41,7 @@ public class LazyInputStreamCombiner implements AsyncReader {
     private AbsoluteCapability currentNextChunkPointer;
     private int index; // index within current chunk
 
-    public LazyInputStreamCombiner(WriterData version,
+    public LazyInputStreamCombiner(CommittedWriterData version,
                                    long globalIndex,
                                    byte[] chunk,
                                    Location nextChunkLoc,

--- a/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
+++ b/src/peergos/shared/user/fs/cryptree/CryptreeNode.java
@@ -612,7 +612,7 @@ public class CryptreeNode implements Cborable {
     public CompletableFuture<Optional<RetrievedCapability>> getNextChunk(Snapshot version,
                                                                          AbsoluteCapability nextChunkCap,
                                                                          NetworkAccess network) {
-        return network.getMetadata(version.get(nextChunkCap.writer).props.get(), nextChunkCap)
+        return network.getMetadata(version.get(nextChunkCap.writer), nextChunkCap)
                 .thenApply(faOpt -> faOpt.map(fa -> new RetrievedCapability(nextChunkCap, fa)));
     }
 
@@ -882,7 +882,7 @@ public class CryptreeNode implements Cborable {
 
                         return retriever(cap.rBaseKey, streamSecret, cap.getMapKey(), cap.bat, crypto.hasher)
                                 .thenCompose(retriever ->
-                                        retriever.getFile(current.get(writer).props.get(), network, crypto, cap, streamSecret, props.size, committedHash(), 1, x -> {})
+                                        retriever.getFile(current.get(writer), network, crypto, cap, streamSecret, props.size, committedHash(), 1, x -> {})
                                                 .thenCompose(data -> {
                                                     int chunkSize = (int) Math.min(props.size, Chunk.MAX_SIZE);
                                                     byte[] chunkData = new byte[chunkSize];
@@ -900,7 +900,7 @@ public class CryptreeNode implements Cborable {
                                                                         getWriterLink(cap.rBaseKey), mirrorBatId(),
                                                                         crypto.random, crypto.hasher, network, x -> {});
                                                             });
-                                                }).thenCompose(updated -> network.getMetadata(updated.get(nextCap.writer).props.get(), nextCap)
+                                                }).thenCompose(updated -> network.getMetadata(updated.get(nextCap.writer), nextCap)
                                                 .thenCompose(mOpt -> {
                                                     if (!mOpt.isPresent())
                                                         return CompletableFuture.completedFuture(updated);
@@ -967,7 +967,7 @@ public class CryptreeNode implements Cborable {
                                                         return IpfsTransaction.call(us.owner,
                                                                 tid -> next.commit(newBase, committer, nextPointer, signer, network, tid)
                                                                         .thenCompose(updatedBase ->
-                                                                                network.getMetadata(updatedBase.get(nextPointer.writer).props.get(), nextPointer)
+                                                                                network.getMetadata(updatedBase.get(nextPointer.writer), nextPointer)
                                                                                         .thenCompose(nextOpt -> nextOpt.get().
                                                                                                 addChildrenAndCommit(updatedBase, committer, remaining,
                                                                                                         nextPointer, signer, mirrorBat, network, crypto)))

--- a/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
+++ b/src/peergos/shared/user/fs/transaction/TransactionServiceImpl.java
@@ -95,7 +95,7 @@ public class TransactionServiceImpl implements TransactionService {
         byte[] data = new byte[size];
 
         CommittedWriterData cwd = version.get(txnFile.writer());
-        return txnFile.getInputStream(cwd.props.get(), networkAccess, crypto, VOID_PROGRESS)
+        return txnFile.getInputStream(cwd, networkAccess, crypto, VOID_PROGRESS)
                 .thenApply(reader -> Serialize.readFullArray(reader, data))
                 .thenApply(done -> Optional.of(Transaction.deserialize(data, txnFile.getName())))
                 .exceptionally(t -> Optional.empty());

--- a/src/peergos/shared/util/Serialize.java
+++ b/src/peergos/shared/util/Serialize.java
@@ -103,7 +103,7 @@ public class Serialize
 
     public static CompletableFuture<byte[]> readFully(FileWrapper f, Crypto crypto, NetworkAccess network) {
         long size = f.getSize();
-        return f.getInputStream(f.version.get(f.writer()).props.get(), network, crypto, x -> {})
+        return f.getInputStream(f.version.get(f.writer()), network, crypto, x -> {})
                 .thenCompose(stream -> readFully(stream, size));
     }
 
@@ -122,7 +122,7 @@ public class Serialize
                                                  NetworkAccess network,
                                                  Crypto crypto) {
         byte[] res = new byte[(int)f.getSize()];
-        return f.getInputStream(f.version.get(f.writer()).props.get(),network, crypto, x -> {})
+        return f.getInputStream(f.version.get(f.writer()),network, crypto, x -> {})
                 .thenCompose(reader -> reader.readIntoArray(res, 0, (int) f.getSize()))
                 .thenApply(i -> Cborable.parser(parser).apply(res));
     }


### PR DESCRIPTION
This means using CommittedWriterData in
net.getMetadata rather than just WriterData

The committed version has the sequence which we
can use to choose the later root.

This is much cleaner and removes a tonne of
.props.get() all over the place.