### PR TITLE
Handle concurrent modifications automatically

### DIFF
--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -66,17 +66,12 @@ public class RamUserTests extends UserTests {
     public static class NoopCache implements BlockCache {
         @Override
         public CompletableFuture<Boolean> put(Cid hash, byte[] data) {
-            CompletableFuture<Boolean> res = new CompletableFuture<>();
-            ForkJoinPool.commonPool().submit(() -> res.complete(true));
-            return res;
-//            return Futures.of(true);
+            return CompletableFuture.supplyAsync(() -> true);
         }
 
         @Override
         public CompletableFuture<Optional<byte[]>> get(Cid hash) {
-            CompletableFuture<Optional<byte[]>> res = new CompletableFuture<>();
-            ForkJoinPool.commonPool().submit(() -> res.complete(Optional.empty()));
-            return res;
+            return CompletableFuture.supplyAsync(Optional::empty);
         }
 
         @Override

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -130,6 +130,14 @@ public abstract class UserTests {
                 parent.mirrorBatId());
     }
 
+    @After
+    public void clearBuffer() {
+        if (network instanceof BufferedNetworkAccess) {
+            ((BufferedNetworkAccess) network).forceClear();
+        } else
+            network.clear();
+    }
+
     @Test
     public void serializationSizesSmall() {
         SigningKeyPair signer = SigningKeyPair.random(crypto.random, crypto.signer);

--- a/src/peergos/server/util/JavaPoster.java
+++ b/src/peergos/server/util/JavaPoster.java
@@ -1,6 +1,7 @@
 package peergos.server.util;
 
 import peergos.shared.io.ipfs.api.*;
+import peergos.shared.storage.PointerCasException;
 import peergos.shared.user.*;
 import peergos.shared.util.*;
 
@@ -107,7 +108,12 @@ public class JavaPoster implements HttpPoster {
                 System.err.println("Trailer:" + trailer);
             else
                 System.err.println(e.getMessage() + " retrieving " + url);
-            res.completeExceptionally(trailer.isEmpty() ? e : new RuntimeException(trailer.get()));
+            Throwable rese = trailer.isEmpty() ?
+                    e :
+                    trailer.get().startsWith("PointerCAS:") ?
+                            PointerCasException.fromString(trailer.get()) :
+                            new RuntimeException(trailer.get());
+            res.completeExceptionally(rese);
         } else
             res.completeExceptionally(e);
     }

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -98,6 +98,12 @@ public class BufferedNetworkAccess extends NetworkAccess {
                 base.mutable, base.batCave, base.batCache, tree, synchronizer, base.instanceAdmin, base.spaceUsage, base.serverMessager, hasher, usernames, isJavascript());
     }
 
+    public void forceClear() {
+        blockBuffer.clear();
+        pointerBuffer.clear();
+        synchronizer.clear();
+    }
+
     @Override
     public NetworkAccess withStorage(Function<ContentAddressedStorage, ContentAddressedStorage> modifiedStorage) {
         BufferedStorage blockBuffer = this.blockBuffer.withStorage(modifiedStorage);

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -205,7 +205,8 @@ public class BufferedNetworkAccess extends NetworkAccess {
                                                                     // 3. commit the new pointer
                                                                     Optional<Long> seq = cas.sequence;
                                                                     return blockBuffer.put(owner, writers.get(u.left.writer), newWD.serialize(), hasher, tid)
-                                                                            .thenCompose(mergedRoot -> blockBuffer.commit(owner, u.left.writer, tid)
+                                                                            .thenCompose(mergedRoot -> blockBuffer.signBlocks(writers)
+                                                                                    .thenCompose(signed -> blockBuffer.commit(owner, u.left.writer, tid))
                                                                                     .thenCompose(x -> pointerBuffer.commit(owner, writers.get(u.left.writer),
                                                                                             new PointerUpdate(actualExisting, MaybeMultihash.of(mergedRoot), seq.map(s -> s + 1)))));
                                                                 });

--- a/src/peergos/shared/hamt/ChampUtil.java
+++ b/src/peergos/shared/hamt/ChampUtil.java
@@ -1,0 +1,165 @@
+package peergos.shared.hamt;
+
+import peergos.shared.MaybeMultihash;
+import peergos.shared.cbor.Cborable;
+import peergos.shared.crypto.SigningPrivateKeyAndPublicHash;
+import peergos.shared.crypto.hash.Hasher;
+import peergos.shared.crypto.hash.PublicKeyHash;
+import peergos.shared.io.ipfs.Cid;
+import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.storage.ContentAddressedStorage;
+import peergos.shared.storage.TransactionId;
+import peergos.shared.storage.auth.BatId;
+import peergos.shared.util.ByteArrayWrapper;
+import peergos.shared.util.Futures;
+import peergos.shared.util.Pair;
+import peergos.shared.util.Triple;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ChampUtil {
+
+    public static <V extends Cborable> CompletableFuture<Pair<Champ<V>, Multihash>> merge(
+            PublicKeyHash owner,
+            SigningPrivateKeyAndPublicHash writer,
+            MaybeMultihash original,
+            MaybeMultihash updated,
+            MaybeMultihash remote,
+            Optional<BatId> mirrorBat,
+            TransactionId tid,
+            int bitWidth,
+            int maxHashCollisionsPerLevel,
+            Function<ByteArrayWrapper, CompletableFuture<byte[]>> keyHasher,
+            Function<Cborable, V> fromCbor,
+            ContentAddressedStorage storage,
+            Hasher writeHasher) {
+        Set<ByteArrayWrapper> ourChangedKeys = new HashSet<>();
+        Set<ByteArrayWrapper> remoteChangedKeys = new HashSet<>();
+        List<Triple<ByteArrayWrapper, Optional<V>, Optional<V>>> remoteUpdates = new ArrayList<>();
+        return applyToDiff(owner, original, updated, 0, keyHasher, Collections.emptyList(), Collections.emptyList(),
+                    t -> ourChangedKeys.add(t.left), bitWidth, storage, fromCbor)
+                .thenCompose(b -> applyToDiff(owner, original, remote, 0, keyHasher, Collections.emptyList(), Collections.emptyList(),
+                    t -> {
+                        remoteChangedKeys.add(t.left);
+                        remoteUpdates.add(t);
+                    }, bitWidth, storage, fromCbor))
+                .thenCompose(x -> {
+                    ourChangedKeys.retainAll(remoteChangedKeys);
+                    if (! ourChangedKeys.isEmpty())
+                        throw new IllegalStateException("Concurrent modification of a file or directory!");
+                    return updated.map(h -> storage.get(owner, (Cid)h, Optional.empty()))
+                            .orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()))
+                            .thenApply(rawOpt -> rawOpt.map(y -> Champ.fromCbor(y, fromCbor)))
+                            .thenCompose(champ -> Futures.reduceAll(remoteUpdates,
+                                    new Pair<>(champ.get(), updated.get()),
+                                    (p, t) -> keyHasher.apply(t.left)
+                                            .thenCompose(hash -> p.left.put(owner, writer, t.left, hash, 0, t.middle, t.right,
+                                                    bitWidth, maxHashCollisionsPerLevel,
+                                                    mirrorBat, keyHasher, tid, storage, writeHasher, p.right)),
+                                    (a, b) -> b));
+                });
+    }
+
+    public static <V extends Cborable> CompletableFuture<Boolean> applyToDiff(
+            PublicKeyHash owner,
+            MaybeMultihash original,
+            MaybeMultihash updated,
+            int depth,
+            Function<ByteArrayWrapper, CompletableFuture<byte[]>> hasher,
+            List<Champ.KeyElement<V>> higherLeftMappings,
+            List<Champ.KeyElement<V>> higherRightMappings,
+            Consumer<Triple<ByteArrayWrapper, Optional<V>, Optional<V>>> consumer,
+            int bitWidth,
+            ContentAddressedStorage storage,
+            Function<Cborable, V> fromCbor) {
+
+        if (updated.equals(original))
+            return CompletableFuture.completedFuture(true);
+        return original.map(h -> storage.get(owner, (Cid)h, Optional.empty())).orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()))
+                .thenApply(rawOpt -> rawOpt.map(y -> Champ.fromCbor(y, fromCbor)))
+                .thenCompose(left -> updated.map(h -> storage.get(owner, (Cid)h, Optional.empty())).orElseGet(() -> CompletableFuture.completedFuture(Optional.empty()))
+                        .thenApply(rawOpt -> rawOpt.map(y -> Champ.fromCbor(y, fromCbor)))
+                        .thenCompose(right -> Champ.hashAndMaskKeys(higherLeftMappings, depth, bitWidth, hasher)
+                                .thenCompose(leftHigherMappingsByBit -> Champ.hashAndMaskKeys(higherRightMappings, depth, bitWidth, hasher)
+                                        .thenCompose(rightHigherMappingsByBit -> {
+
+                                            int leftMax = left.map(c -> Math.max(c.dataMap.length(), c.nodeMap.length())).orElse(0);
+                                            int rightMax = right.map(c -> Math.max(c.dataMap.length(), c.nodeMap.length())).orElse(0);
+                                            int maxBit = Math.max(leftMax, rightMax);
+                                            int leftDataIndex = 0, rightDataIndex = 0, leftNodeCount = 0, rightNodeCount = 0;
+
+                                            List<CompletableFuture<Boolean>> deeperLayers = new ArrayList<>();
+
+                                            for (int i = 0; i < maxBit; i++) {
+                                                // either the payload is present OR higher mappings are non empty OR the champ is absent
+                                                Optional<Champ.HashPrefixPayload<V>> leftPayload = Champ.getElement(i, leftDataIndex, leftNodeCount, left);
+                                                Optional<Champ.HashPrefixPayload<V>> rightPayload = Champ.getElement(i, rightDataIndex, rightNodeCount, right);
+
+                                                List<Champ.KeyElement<V>> leftHigherMappings = leftHigherMappingsByBit.getOrDefault(i, Collections.emptyList());
+                                                List<Champ.KeyElement<V>> leftMappings = leftPayload
+                                                        .filter(p -> !p.isShard())
+                                                        .map(p -> Arrays.asList(p.mappings))
+                                                        .orElse(leftHigherMappings);
+                                                List<Champ.KeyElement<V>> rightHigherMappings = rightHigherMappingsByBit.getOrDefault(i, Collections.emptyList());
+                                                List<Champ.KeyElement<V>> rightMappings = rightPayload
+                                                        .filter(p -> !p.isShard())
+                                                        .map(p -> Arrays.asList(p.mappings))
+                                                        .orElse(rightHigherMappings);
+
+                                                Optional<MaybeMultihash> leftShard = leftPayload
+                                                        .filter(p -> p.isShard())
+                                                        .map(p -> p.link);
+
+                                                Optional<MaybeMultihash> rightShard = rightPayload
+                                                        .filter(p -> p.isShard())
+                                                        .map(p -> p.link);
+
+                                                if (leftShard.isPresent() || rightShard.isPresent()) {
+                                                    deeperLayers.add(applyToDiff(owner,
+                                                            leftShard.orElse(MaybeMultihash.empty()),
+                                                            rightShard.orElse(MaybeMultihash.empty()), depth + 1, hasher,
+                                                            leftMappings, rightMappings, consumer, bitWidth, storage, fromCbor));
+                                                } else {
+                                                    Map<ByteArrayWrapper, Optional<V>> leftMap = leftMappings.stream()
+                                                            .collect(Collectors.toMap(e -> e.key, e -> e.valueHash));
+                                                    Map<ByteArrayWrapper, Optional<V>> rightMap = rightMappings.stream()
+                                                            .collect(Collectors.toMap(e -> e.key, e -> e.valueHash));
+
+                                                    HashSet<ByteArrayWrapper> both = new HashSet<>(leftMap.keySet());
+                                                    both.retainAll(rightMap.keySet());
+
+                                                    for (Map.Entry<ByteArrayWrapper, Optional<V>> entry : leftMap.entrySet()) {
+                                                        if (! both.contains(entry.getKey()))
+                                                            consumer.accept(new Triple<>(entry.getKey(), entry.getValue(), Optional.empty()));
+                                                        else if (! entry.getValue().equals(rightMap.get(entry.getKey())))
+                                                            consumer.accept(new Triple<>(entry.getKey(), entry.getValue(), rightMap.get(entry.getKey())));
+                                                    }
+                                                    for (Map.Entry<ByteArrayWrapper, Optional<V>> entry : rightMap.entrySet()) {
+                                                        if (! both.contains(entry.getKey()))
+                                                            consumer.accept(new Triple<>(entry.getKey(), Optional.empty(), entry.getValue()));
+                                                    }
+                                                }
+
+                                                if (leftPayload.isPresent()) {
+                                                    if (leftPayload.get().isShard())
+                                                        leftNodeCount++;
+                                                    else
+                                                        leftDataIndex++;
+                                                }
+                                                if (rightPayload.isPresent()) {
+                                                    if (rightPayload.get().isShard())
+                                                        rightNodeCount++;
+                                                    else
+                                                        rightDataIndex++;
+                                                }
+                                            }
+
+                                            return Futures.combineAll(deeperLayers).thenApply(x -> true);
+                                        })))
+                );
+    }
+}

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -6,8 +6,8 @@ import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.MaybeMultihash;
-import peergos.shared.storage.CasException;
 import peergos.shared.storage.ContentAddressedStorage;
+import peergos.shared.storage.PointerCasException;
 import peergos.shared.util.*;
 
 import java.util.*;
@@ -85,7 +85,7 @@ public interface MutablePointers {
                             // check CAS [current hash, new hash]
                             boolean validSequence = currentSequence.isEmpty() || (newSequence.isPresent() && newSequence.get() > currentSequence.get());
                             if (!existing.equals(claimedCurrentHash))
-                                return Futures.errored(new CasException(existing, claimedCurrentHash));
+                                return Futures.errored(new PointerCasException(existing, currentSequence, claimedCurrentHash));
                             if (!validSequence)
                                 return Futures.errored(new IllegalStateException("Invalid sequence number update in mutable pointer: " + currentSequence + " => " + newSequence));
                             return Futures.of(true);

--- a/src/peergos/shared/mutable/RetryMutablePointers.java
+++ b/src/peergos/shared/mutable/RetryMutablePointers.java
@@ -2,6 +2,7 @@ package peergos.shared.mutable;
 
 import peergos.shared.crypto.hash.*;
 import peergos.shared.storage.CasException;
+import peergos.shared.storage.PointerCasException;
 
 import java.net.*;
 import java.util.*;
@@ -40,6 +41,8 @@ public class RetryMutablePointers implements MutablePointers {
                         if (retriesLeft == 1) {
                             res.completeExceptionally(e);
                         } else if (e instanceof ConnectException) {
+                            res.completeExceptionally(e);
+                        } else if (e instanceof PointerCasException) {
                             res.completeExceptionally(e);
                         } else if (e instanceof CasException) {
                             res.completeExceptionally(e);

--- a/src/peergos/shared/storage/PointerCasException.java
+++ b/src/peergos/shared/storage/PointerCasException.java
@@ -1,0 +1,18 @@
+package peergos.shared.storage;
+
+import peergos.shared.MaybeMultihash;
+
+import java.util.Optional;
+
+public class PointerCasException extends RuntimeException {
+
+    public final MaybeMultihash existing, claimedExisting;
+    public final Optional<Long> sequence;
+
+    public PointerCasException(MaybeMultihash actualExisting, Optional<Long> actualSequence, MaybeMultihash claimedExisting) {
+        super("CAS exception updating cryptree node. existing: " + actualExisting + ", claimed: " + claimedExisting);
+        this.existing = actualExisting;
+        this.claimedExisting = claimedExisting;
+        this.sequence = actualSequence;
+    }
+}

--- a/src/peergos/shared/storage/PointerCasException.java
+++ b/src/peergos/shared/storage/PointerCasException.java
@@ -1,6 +1,8 @@
 package peergos.shared.storage;
 
+import jsinterop.annotations.JsMethod;
 import peergos.shared.MaybeMultihash;
+import peergos.shared.io.ipfs.Cid;
 
 import java.util.Optional;
 
@@ -10,9 +12,21 @@ public class PointerCasException extends RuntimeException {
     public final Optional<Long> sequence;
 
     public PointerCasException(MaybeMultihash actualExisting, Optional<Long> actualSequence, MaybeMultihash claimedExisting) {
-        super("CAS exception updating cryptree node. existing: " + actualExisting + ", claimed: " + claimedExisting);
+        super("PointerCAS:" + actualExisting + "," + actualSequence.map(Object::toString).orElse("") + "," + claimedExisting);
         this.existing = actualExisting;
         this.claimedExisting = claimedExisting;
         this.sequence = actualSequence;
+    }
+
+    @JsMethod
+    public static PointerCasException fromString(String msg) {
+        msg = msg.substring("PointerCAS:".length());
+        String[] parts = msg.split(",");
+        MaybeMultihash actualExisting = MaybeMultihash.of(Cid.decode(parts[0]));
+        MaybeMultihash claimedExisting = MaybeMultihash.of(Cid.decode(parts[2]));
+        Optional<Long> actualSequence = parts[1].length() == 0 ?
+                Optional.empty() :
+                Optional.of(Long.parseLong(parts[1]));
+        return new PointerCasException(actualExisting, actualSequence, claimedExisting);
     }
 }

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -62,7 +62,8 @@ public class MutableTreeImpl implements MutableTree {
     public CompletableFuture<MaybeMultihash> get(WriterData base, PublicKeyHash owner, PublicKeyHash writer, byte[] mapKey) {
         if (! base.tree.isPresent())
             throw new IllegalStateException("Tree root not present for " + writer);
-        return ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c).thenCompose(tree -> tree.get(mapKey))
+        return ChampWrapper.create(owner, (Cid)base.tree.get(), Optional.empty(), hasher, dht, writeHasher, c -> (CborObject.CborMerkleLink)c)
+                .thenCompose(tree -> tree.get(mapKey))
                 .thenApply(c -> c.map(x -> x.target).map(MaybeMultihash::of).orElse(MaybeMultihash.empty()))
                 .thenApply(maybe -> LOGGING ?
                         log(maybe, "TREE.get (" + ArrayOps.bytesToHex(mapKey)


### PR DESCRIPTION
Catch the CAS exception and do a champ merge. This will succeed if the modified champ mappings are disjoint. i.e. No file or dir has been concurrently modified, which is by far the most common case. 

Fixes: https://github.com/Peergos/Peergos/issues/1125