### PR TITLE
Fix bulk S3 deletion on some S3 implementations (including B2)

### DIFF
--- a/src/peergos/server/storage/S3AdminRequests.java
+++ b/src/peergos/server/storage/S3AdminRequests.java
@@ -361,6 +361,7 @@ public class S3AdminRequests {
                                              String accessKeyId,
                                              String s3SecretKey,
                                              Function<byte[], String> sha256,
+                                             Function<byte[], String> sha256toBase64,
                                              BiFunction<PresignedUrl, byte[], byte[]> poster,
                                              Supplier<DocumentBuilder> builder,
                                              boolean useHttps,
@@ -384,6 +385,7 @@ public class S3AdminRequests {
         String contentSha256 = sha256.apply(body);
         Map<String, String> extraHeaders = new TreeMap<>();
         extraHeaders.put("Content-Length", "" + body.length);
+        extraHeaders.put("x-amz-checksum-sha256", sha256toBase64.apply(body));
         extraHeaders.put("Content-Type", "text/xml");
         Map<String, String> extraQueryParameters = new TreeMap<>();
         extraQueryParameters.put("delete", "true");

--- a/src/peergos/server/storage/S3BlockStorage.java
+++ b/src/peergos/server/storage/S3BlockStorage.java
@@ -15,6 +15,7 @@ import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.io.ipfs.bases.Base64;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.user.fs.*;
@@ -1026,6 +1027,7 @@ public class S3BlockStorage implements DeletableContentAddressedStorage {
         try {
             S3AdminRequests.bulkDelete(keyVersions, ZonedDateTime.now(), host, region, accessKeyId, secretKey,
                     b -> ArrayOps.bytesToHex(Hash.sha256(b)),
+                    b -> Base64.encodeBase64String(Hash.sha256(b)),
                     (url, body) -> {
                         try {
                             return HttpUtil.post(url, body);

--- a/src/peergos/server/storage/S3DeleteOld.java
+++ b/src/peergos/server/storage/S3DeleteOld.java
@@ -4,8 +4,8 @@ import peergos.server.*;
 import peergos.server.util.*;
 import peergos.shared.*;
 import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.bases.Base64;
 import peergos.shared.storage.*;
-import peergos.shared.storage.auth.*;
 import peergos.shared.util.*;
 
 import java.io.*;
@@ -119,6 +119,7 @@ public class S3DeleteOld {
         try {
             S3AdminRequests.bulkDelete(keyVersions, ZonedDateTime.now(), config.getHost(), config.region, config.accessKey, config.secretKey,
                     b -> ArrayOps.bytesToHex(Hash.sha256(b)),
+                    b -> Base64.encodeBase64String(Hash.sha256(b)),
                     (url, body) -> {
                         try {
                             return HttpUtil.post(url, body);

--- a/src/peergos/server/storage/S3Exploration.java
+++ b/src/peergos/server/storage/S3Exploration.java
@@ -6,6 +6,7 @@ import peergos.server.util.*;
 import peergos.shared.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.io.ipfs.bases.Base64;
 import peergos.shared.storage.*;
 import peergos.shared.storage.auth.*;
 import peergos.shared.util.*;
@@ -81,7 +82,9 @@ class S3Exploration {
                 .collect(Collectors.toList()));
         // delete all versions of the key and delete markers using a bulk delete call
         S3AdminRequests.BulkDeleteReply bulkDelete = S3AdminRequests.bulkDelete(
-                versionsToDelete, ZonedDateTime.now(), host, region, accessKey, secretKey, b -> ArrayOps.bytesToHex(Hash.sha256(b)),
+                versionsToDelete, ZonedDateTime.now(), host, region, accessKey, secretKey,
+                b -> ArrayOps.bytesToHex(Hash.sha256(b)),
+                b -> Base64.encodeBase64String(Hash.sha256(b)),
                 (url, body) -> {
                     try {
                         System.out.println("URL: " + url.base);
@@ -192,7 +195,9 @@ class S3Exploration {
             String nonExistentKey = tempKey2 + "ZZ";
             S3AdminRequests.BulkDeleteReply bulkDelete = S3AdminRequests.bulkDelete(
                     Arrays.asList(new Pair<>(tempKey, null), new Pair<>(tempKey2, null), new Pair<>(nonExistentKey, null)),
-                    ZonedDateTime.now(), host, region, accessKey, secretKey, b -> ArrayOps.bytesToHex(Hash.sha256(b)),
+                    ZonedDateTime.now(), host, region, accessKey, secretKey,
+                    b -> ArrayOps.bytesToHex(Hash.sha256(b)),
+                    b -> Base64.encodeBase64String(Hash.sha256(b)),
                     (url, body) -> {
                         try {
                             System.out.println("URL: " + url.base);


### PR DESCRIPTION
Backblaze finally implemented this, and it appears there is a new required header (by Amazon S3) which wasn't documented originally. 

This makes gc deletion about 100x faster