### PR TITLE
Fix writable secret links

### DIFF
--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -108,14 +108,13 @@ public class DirectorySync {
     }
 
     public static PeergosSyncFS buildRemote(String link,
-                                            Path linkPath,
                                             NetworkAccess network,
                                             Crypto crypto) {
         Supplier<CompletableFuture<String>> linkUserPassword = () -> Futures.of("");
         List<Supplier<CompletableFuture<String>>> linkPasswords = List.of(linkUserPassword);
         UserContext context = UserContext.fromSecretLinksV2(List.of(link), linkPasswords, network, crypto).join();
-
-        return new PeergosSyncFS(context, linkPath);
+        Path path = PathUtil.get(context.getEntryPath().join());
+        return new PeergosSyncFS(context, path);
     }
 
     public static boolean syncDirs(List<String> links,
@@ -161,7 +160,7 @@ public class DirectorySync {
                     long t0 = System.currentTimeMillis();
                     String username = remoteDir.getName(0).toString();
                     PublicKeyHash owner = network.coreNode.getPublicKeyHash(username).join().get();
-                    PeergosSyncFS remote = buildRemote(links.get(i), remoteDir, network, crypto);
+                    PeergosSyncFS remote = buildRemote(links.get(i), network, crypto);
                     SyncFilesystem local = localBuilder.apply(localDirs.get(i));
                     syncDir(local, remote, syncLocalDeletes.get(i), syncRemoteDeletes.get(i),
                             owner, network, syncedState, maxDownloadParallelism, minFreeSpacePercent, crypto, isCancelled, LOG);

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import peergos.server.crypto.hash.ScryptJava;
 import peergos.server.simulation.FileAsyncReader;
 import peergos.shared.crypto.hash.Hasher;
+import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.PathUtil;
 import peergos.shared.util.Triple;
@@ -200,8 +201,9 @@ public class LocalFileSystem implements SyncFilesystem {
     }
 
     @Override
-    public void applyToSubtree(Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException {
+    public Optional<PublicKeyHash> applyToSubtree(Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException {
         applyToSubtree(root, file, dir);
+        return Optional.empty();
     }
 
     private void applyToSubtree(Path start, Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException {

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -1,6 +1,7 @@
 package peergos.server.sync;
 
 import peergos.server.util.Logging;
+import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.storage.auth.Bat;
 import peergos.shared.storage.auth.BatId;
 import peergos.shared.user.UserContext;
@@ -298,15 +299,16 @@ public class PeergosSyncFS implements SyncFilesystem {
     }
 
     @Override
-    public void applyToSubtree(Consumer<FileProps> onFile, Consumer<FileProps> onDir) {
-        applyToSubtree(root, onFile, onDir);
+    public Optional<PublicKeyHash> applyToSubtree(Consumer<FileProps> onFile, Consumer<FileProps> onDir) {
+        return applyToSubtree(root, onFile, onDir);
     }
 
-    private void applyToSubtree(Path start, Consumer<FileProps> onFile, Consumer<FileProps> onDir) {
+    private Optional<PublicKeyHash> applyToSubtree(Path start, Consumer<FileProps> onFile, Consumer<FileProps> onDir) {
         Optional<FileWrapper> baseDir = context.getByPath(start).join();
         if (baseDir.isEmpty())
             throw new IllegalStateException("Couldn't retrieve Peergos base directory!");
         applyToSubtree(start, baseDir.get(), onFile, onDir);
+        return Optional.of(baseDir.get().getLinkPointer().capability.writer);
     }
 
     private void applyToSubtree(Path basePath, FileWrapper base, Consumer<FileProps> onFile, Consumer<FileProps> onDir) {

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -1,5 +1,6 @@
 package peergos.server.sync;
 
+import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.user.fs.*;
 import peergos.shared.util.Triple;
 
@@ -64,7 +65,14 @@ public interface SyncFilesystem {
 
     HashTree hashFile(Path p, Optional<FileWrapper> meta, String relativePath, SyncState syncedState);
 
-    void applyToSubtree(Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException;
+    /**
+     *
+     * @param file
+     * @param dir
+     * @return the writer to ignore from snapshots (we only have read access to it as the entry point)
+     * @throws IOException
+     */
+    Optional<PublicKeyHash> applyToSubtree(Consumer<FileProps> file, Consumer<FileProps> dir) throws IOException;
 
     class FileProps {
         public final String relPath;

--- a/src/peergos/server/sync/SyncRunner.java
+++ b/src/peergos/server/sync/SyncRunner.java
@@ -120,7 +120,7 @@ public interface SyncRunner {
                                 DirectorySync.syncDirs(links, localDirs, syncLocalDeletes, syncRemoteDeletes,
                                         maxDownloadParallelism, minFreeSpacePercent, true,
                                         root -> new LocalFileSystem(Paths.get(root), crypto.hasher),
-                                        peergosDir, status::isCancelled, statusUpdater, errorUpdater, network, crypto);
+                                        peergosDir, status::isCancelled, statusUpdater, errorUpdater, network.clear(), crypto);
                             } catch (Exception e) {
                                 LOG.log(Level.WARNING, e.getMessage(), e);
                             }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -924,7 +924,6 @@ public abstract class UserTests {
         AbsoluteCapability linkCap = network.getSecretLink(thelink)
                 .thenCompose(retrieved -> retrieved.decryptFromPassword(thelink.labelString(), link.linkPassword, crypto)).join();
         Assert.assertEquals(linkCap.writer, rootWriter);
-        assertTrue(! linkCap.isWritable());
 
         UserContext fromLink = UserContext.fromSecretLinkV2(link.toLinkString(file.owner()), () -> Futures.of(""), network.clear(), crypto).join();
         String entryPath = fromLink.getEntryPath().join();
@@ -933,6 +932,7 @@ public abstract class UserTests {
         Optional<FileWrapper> dirFromLink = fromLink.getByPath(username + "/" + newname).join();
         Assert.assertTrue(oldPathFromLink.isEmpty());
         Assert.assertTrue(dirFromLink.isPresent());
+        assertTrue(dirFromLink.get().isWritable());
 
         FileProperties dirFromLinkProps = dirFromLink.get().getLinkPointer().getProperties();
         assertEquals(dirFromLinkProps.name, newname);

--- a/src/peergos/shared/user/Snapshot.java
+++ b/src/peergos/shared/user/Snapshot.java
@@ -63,6 +63,12 @@ public class Snapshot implements Cborable {
         return versions.get(writer.publicKeyHash);
     }
 
+    public Snapshot remove(PublicKeyHash w) {
+        HashMap<PublicKeyHash, CommittedWriterData> removed = new HashMap<>(versions);
+        removed.remove(w);
+        return new Snapshot(removed);
+    }
+
     public Snapshot withVersion(PublicKeyHash writer, CommittedWriterData version) {
         HashMap<PublicKeyHash, CommittedWriterData> result = new HashMap<>(versions);
         result.put(writer, version);
@@ -96,8 +102,8 @@ public class Snapshot implements Cborable {
         if (list.value.size() % 2 != 0)
             throw new IllegalStateException("Invalid cbor list length for Snapshot!");
         HashMap<PublicKeyHash, CommittedWriterData> res = new HashMap<>();
-        for (int i=0; i < list.value.size()/2; i ++)
-            res.put(list.get(i, PublicKeyHash::fromCbor), list.get(i + 1, CommittedWriterData::fromCbor));
+        for (int i=0; i < list.value.size()/2; i++)
+            res.put(list.get(2*i, PublicKeyHash::fromCbor), list.get(2*i + 1, CommittedWriterData::fromCbor));
         return new Snapshot(res);
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -813,7 +813,7 @@ public class UserContext {
                     boolean differentWriter = file.getPointer().getParentCap().writer.map(parentWriter -> ! parentWriter.equals(file.writer())).orElse(false);
                     if (props.isLinkWritable && ! differentWriter)
                         throw new IllegalStateException("To generate a writable secret link, the target must already be in a different writing space!");
-                    AbsoluteCapability cap = props.isLinkWritable ? file.getLinkPointer().capability.readOnly() : file.getPointer().capability.readOnly();
+                    AbsoluteCapability cap = props.isLinkWritable ? file.getLinkPointer().capability : file.getPointer().capability.readOnly();
                     SecretLink res = new SecretLink(id, props.label, props.linkPassword);
                     String fullPassword = props.linkPassword + props.userPassword;
                     return EncryptedCapability.createFromPassword(cap, res.labelString(), fullPassword, !props.userPassword.isEmpty(), crypto)

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -813,7 +813,7 @@ public class UserContext {
                     boolean differentWriter = file.getPointer().getParentCap().writer.map(parentWriter -> ! parentWriter.equals(file.writer())).orElse(false);
                     if (props.isLinkWritable && ! differentWriter)
                         throw new IllegalStateException("To generate a writable secret link, the target must already be in a different writing space!");
-                    AbsoluteCapability cap = props.isLinkWritable ? file.getPointer().capability : file.getPointer().capability.readOnly();
+                    AbsoluteCapability cap = props.isLinkWritable ? file.getLinkPointer().capability.readOnly() : file.getPointer().capability.readOnly();
                     SecretLink res = new SecretLink(id, props.label, props.linkPassword);
                     String fullPassword = props.linkPassword + props.userPassword;
                     return EncryptedCapability.createFromPassword(cap, res.labelString(), fullPassword, !props.userPassword.isEmpty(), crypto)


### PR DESCRIPTION
Make sure link cap is to cryptree node with the name in the parent writing space.

Make sure we update both cryptree nodes in case of rename.

This fixes renaming the peergos root of a sync