### PR TITLE
Persistent reachability

### DIFF
--- a/src/peergos/server/storage/BlockVersion.java
+++ b/src/peergos/server/storage/BlockVersion.java
@@ -27,4 +27,11 @@ public class BlockVersion {
     public int hashCode() {
         return Objects.hash(cid, version);
     }
+
+    @Override
+    public String toString() {
+        if (version == null)
+            return cid.toString();
+        return cid.toString() + ":" + version;
+    }
 }

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -278,6 +278,7 @@ public class GarbageCollector {
         long deletedRawBlocks = deleted.right;
         long t7 = System.nanoTime();
         metadata.compact();
+        reachability.compact();
         long t8 = System.nanoTime();
         System.out.println("Deleting blocks took " + (t7-t6)/1_000_000_000 + "s");
         System.out.println("GC complete. Freed " + deletedCborBlocks + " cbor blocks and " + deletedRawBlocks +

--- a/src/peergos/server/storage/GarbageCollector.java
+++ b/src/peergos/server/storage/GarbageCollector.java
@@ -13,9 +13,7 @@ import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
 import peergos.shared.util.*;
 
-import java.io.*;
 import java.nio.file.*;
-import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -212,9 +210,9 @@ public class GarbageCollector {
         // TODO: do GC in O(1) RAM with a bloom filter?: mark into bloom. Then list and check bloom to delete.
         storage.clearOldTransactions(System.currentTimeMillis() - 24*3600*1000L);
         long t0 = System.nanoTime();
-        Path reachabilityDbFile = reachabilityDbDir.resolve("reachability-" + LocalDate.now() + "-"
-                + new Random().nextInt(100_000)+".sql");
+        Path reachabilityDbFile = reachabilityDbDir.resolve("reachability.sqlite");
         SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb(reachabilityDbFile);
+        reachability.clearReachable();
         // Versions are only relevant for versioned S3 buckets, otherwise version is null
         // For S3, clients write raw blocks directly, we need to get their version directly from S3
         listBlocks(reachability, listFromBlockstore, storage, metadata);
@@ -271,7 +269,7 @@ public class GarbageCollector {
         AtomicLong progressCounter = new AtomicLong(0);
         List<ForkJoinTask<Pair<Long, Long>>> futures = new ArrayList<>();
         reachability.getUnreachable(toDel -> futures.add(pool.submit(() ->
-                deleteUnreachableBlocks(toDel, progressCounter, delCount.get(), storage, metadata))));
+                deleteUnreachableBlocks(toDel, progressCounter, delCount.get(), storage, metadata, reachability))));
         Pair<Long, Long> deleted = futures.stream()
                 .map(ForkJoinTask::join)
                 .reduce((a, b) -> new Pair<>(a.left + b.left, a.right + b.right))
@@ -281,9 +279,6 @@ public class GarbageCollector {
         long t7 = System.nanoTime();
         metadata.compact();
         long t8 = System.nanoTime();
-        try {
-            Files.delete(reachabilityDbFile);
-        } catch (IOException e) {}
         System.out.println("Deleting blocks took " + (t7-t6)/1_000_000_000 + "s");
         System.out.println("GC complete. Freed " + deletedCborBlocks + " cbor blocks and " + deletedRawBlocks +
                 " raw blocks, total duration: " + (t7-t0)/1_000_000_000 + "s, metadata.compact took " + (t8-t7)/1_000_000_000 + "s");
@@ -325,13 +320,15 @@ public class GarbageCollector {
                                                             AtomicLong progress,
                                                             long totalBlocksToDelete,
                                                             DeletableContentAddressedStorage storage,
-                                                            BlockMetadataStore metadata) {
+                                                            BlockMetadataStore metadata,
+                                                            SqliteBlockReachability reachability) {
         if (toDelete.isEmpty())
             return new Pair<>(0L, 0L);
         long deletedCborBlocks = toDelete.stream().filter(v -> ! v.cid.isRaw()).count();
         long deletedRawBlocks = toDelete.size() - deletedCborBlocks;
         for (BlockVersion block : toDelete) {
             metadata.remove(block.cid);
+            reachability.removeBlock(block.cid);
         }
         getWithBackoff(() -> {storage.bulkDelete(toDelete); return true;});
 
@@ -364,14 +361,21 @@ public class GarbageCollector {
             queue.add(block);
 
         try {
-            List<Cid> links = metadata.get(block).map(m -> m.links)
-                    .orElseGet(() -> getWithBackoff(() -> storage.getLinks(block).join()));
-            queue.addAll(links);
+            Optional<List<Cid>> fromRdb = block.isRaw() ?
+                    Optional.of(Collections.emptyList()) :
+                    reachability.getLinks(block);
+            List<Cid> newLinks = fromRdb
+                    .orElseGet(() -> metadata.get(block).map(m -> m.links)
+                            .orElseGet(() -> getWithBackoff(() -> storage.getLinks(block).join())));
+
+            if (fromRdb.isEmpty() && ! block.isRaw())
+                reachability.setLinks(block, newLinks);
+            queue.addAll(newLinks);
             if (queue.size() > 1000) {
                 reachability.setReachable(queue, totalReachable);
                 queue.clear();
             }
-            for (Cid link : links) {
+            for (Cid link : newLinks) {
                 markReachable(storage, false, queue, link, reachability, metadata, username, totalReachable);
             }
         } catch (Exception e) {

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -35,7 +35,7 @@ public class SqliteBlockReachability {
     private static final String CLEAR_REACHABLE = "UPDATE reachability SET reachable=false";
     private static final String SET_REACHABLE = "UPDATE reachability SET reachable=true WHERE hash = ? AND latest = true";
     private static final String INSERT_SUFFIX = "INTO reachability (hash, version, latest, reachable) VALUES(?, ?, ?, false)";
-    private static final String NOT_LATEST = "update reachability set latest=false WHERE hash=?";
+    private static final String NOT_LATEST = "update reachability set latest=false WHERE hash=? AND version!=?";
     private static final String INSERT_LINK_SUFFIX = "INTO links (parent, child) VALUES(?, ?)";
     private static final String INSERT_EMPTY_LINKS_SUFFIX = "INTO emptylinks (parent) VALUES(?)";
     private static final String UNREACHABLE = "SELECT hash, version FROM reachability WHERE reachable = false";
@@ -96,6 +96,7 @@ public class SqliteBlockReachability {
                     .toList();
             for (BlockVersion latest : latestVersions) {
                 oldlatest.setBytes(1, latest.cid.toBytes());
+                oldlatest.setString(2, latest.version);
                 oldlatest.addBatch();
             }
             if (! latestVersions.isEmpty()) {

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -299,7 +299,7 @@ public class SqliteBlockReachability {
 
     public static void main(String[] a) throws IOException {
         // This is a benchmark to test baseline speed of a blockstore GC
-        String filename = "temp.sql";
+        String filename = System.nanoTime() + "temp.sql";
         Path file = Path.of(filename);
         SqliteBlockReachability reachabilityDb = createReachabilityDb(file);
         List<BlockVersion> versions = new ArrayList<>();
@@ -321,6 +321,9 @@ public class SqliteBlockReachability {
         int batchSize = 10_000;
         for (int i = 0; i < count / batchSize; i++) {
             reachabilityDb.addBlocks(versions.subList(i * batchSize, (i+1)* batchSize));
+            long size = reachabilityDb.size();
+            if (size != (i +1) * batchSize)
+                throw new IllegalStateException("Incorrect size: " + size + ", expected " + (i+1)*batchSize);
         }
         long t1 = System.nanoTime();
         System.out.println("Load duration " + (t1-t0)/1_000_000_000 + "s, batch size = " + batchSize);
@@ -347,7 +350,7 @@ public class SqliteBlockReachability {
 
         long size = reachabilityDb.size();
         if (size != count)
-            throw new IllegalStateException("Missing rows!");
+            throw new IllegalStateException("Missing rows! " + size + ", expected " + count);
 
         // Now double the size with unreachable blocks
         for (int i = 0; i < count; i++) {

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -236,7 +236,7 @@ public class SqliteBlockReachability {
         }
     }
 
-    public Optional<List<Cid>> getLinks(Cid block) {
+    public synchronized Optional<List<Cid>> getLinks(Cid block) {
         long index;
         try {
             index = getBlockIndex(block);

--- a/src/peergos/server/storage/SqliteBlockReachability.java
+++ b/src/peergos/server/storage/SqliteBlockReachability.java
@@ -17,16 +17,32 @@ import java.util.stream.*;
 public class SqliteBlockReachability {
     private static final Logger LOG = peergos.server.util.Logging.LOG();
     private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS reachability (" +
+            "idx integer primary key,"+
             "hash bytes not null, " +
             "version text, " +
             "latest boolean not null," +
             "reachable boolean not null); " +
-                "CREATE UNIQUE INDEX IF NOT EXISTS hash_reachable_index ON reachability (hash, version);";
+                "CREATE UNIQUE INDEX IF NOT EXISTS hash_reachable_index ON reachability (hash, version);" +
+            "CREATE TABLE IF NOT EXISTS links (" +
+            "parent integer references reachability(idx) not null," +
+            "child integer references reachability(idx) not null" +
+            ");" +
+            "CREATE UNIQUE INDEX IF NOT EXISTS links_index ON links (parent, child);" +
+            "CREATE TABLE IF NOT EXISTS emptylinks (" +
+            "parent integer references reachability(idx) not null primary key" +
+            ");";
 
+    private static final String CLEAR_REACHABLE = "UPDATE reachability SET reachable=false";
     private static final String SET_REACHABLE = "UPDATE reachability SET reachable=true WHERE hash = ? AND latest = true";
     private static final String INSERT_SUFFIX = "INTO reachability (hash, version, latest, reachable) VALUES(?, ?, ?, false)";
+    private static final String INSERT_LINK_SUFFIX = "INTO links (parent, child) VALUES(?, ?)";
+    private static final String INSERT_EMPTY_LINKS_SUFFIX = "INTO emptylinks (parent) VALUES(?)";
     private static final String UNREACHABLE = "SELECT hash, version FROM reachability WHERE reachable = false";
     private static final String COUNT = "SELECT COUNT(*) FROM reachability";
+    private static final String BLOCK_INDEX = "SELECT idx FROM reachability WHERE hash=?";
+    private static final String BLOCK_BY_INDEX = "SELECT hash FROM reachability WHERE idx=?";
+    private static final String LINKS = "SELECT child FROM links WHERE parent=?";
+    private static final String EMPTY_LINKS = "SELECT parent FROM emptylinks WHERE parent=?";
 
     private final Supplier<Connection> conn;
     private final SqlSupplier cmds;
@@ -78,10 +94,18 @@ public class SqliteBlockReachability {
             }
             int[] changed = insert.executeBatch();
             conn.commit();
-            if (IntStream.of(changed).sum() < distinct.size())
-                throw new IllegalStateException("Couldn't insert blocks!");
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+        }
+    }
+
+    public synchronized void clearReachable() {
+        try (Connection conn = getConnection();
+             PreparedStatement update = conn.prepareStatement(CLEAR_REACHABLE)) {
+            update.executeUpdate();
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
         }
     }
 
@@ -137,15 +161,115 @@ public class SqliteBlockReachability {
         }
     }
 
+    private long getBlockIndex(Cid block) {
+        try (Connection conn = getConnection();
+             PreparedStatement query = conn.prepareStatement(BLOCK_INDEX)) {
+            query.setBytes(1, block.toBytes());
+            ResultSet res = query.executeQuery();
+            res.next();
+            return res.getLong(1);
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    private Cid getBlock(long index) {
+        try (Connection conn = getConnection();
+             PreparedStatement query = conn.prepareStatement(BLOCK_BY_INDEX)) {
+            query.setLong(1, index);
+            ResultSet res = query.executeQuery();
+            res.next();
+            return Cid.cast(res.getBytes(1));
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    public synchronized void setLinks(Cid block, List<Cid> links) {
+        long parentIndex = getBlockIndex(block);
+        if (links.isEmpty()) {
+            try (Connection conn = getConnection();
+                 PreparedStatement insert = conn.prepareStatement(cmds.insertOrIgnoreCommand("INSERT ", INSERT_EMPTY_LINKS_SUFFIX))) {
+                insert.setLong(1, parentIndex);
+                int updated = insert.executeUpdate();
+                if (updated != 1)
+                    throw new IllegalStateException("Couldn't insert links!");
+            } catch (SQLException sqe) {
+                LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            }
+            return;
+        }
+        List<Long> linkIndices = links.stream()
+                .map(this::getBlockIndex)
+                .toList();
+        try (Connection conn = getNonCommittingConnection();
+             PreparedStatement insert = conn.prepareStatement(cmds.insertOrIgnoreCommand("INSERT ", INSERT_LINK_SUFFIX))) {
+            for (Long linkIndex : linkIndices) {
+                insert.setLong(1, parentIndex);
+                insert.setLong(2, linkIndex);
+                insert.addBatch();
+            }
+            int[] changed = insert.executeBatch();
+            conn.commit();
+            if (IntStream.of(changed).sum() < links.size())
+                throw new IllegalStateException("Couldn't insert links!");
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    public Optional<List<Cid>> getLinks(Cid block) {
+        long index;
+        try {
+            index = getBlockIndex(block);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return Optional.empty();
+        }
+        try (Connection conn = getConnection();
+             PreparedStatement query = conn.prepareStatement(EMPTY_LINKS)) {
+            query.setLong(1, index);
+            ResultSet res = query.executeQuery();
+            if (res.next())
+                return Optional.of(Collections.emptyList());
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+
+        try (Connection conn = getConnection();
+             PreparedStatement query = conn.prepareStatement(LINKS)) {
+            query.setLong(1, index);
+            ResultSet res = query.executeQuery();
+            List<Cid> links = new ArrayList<>();
+            while (res.next()) {
+                links.add(getBlock(res.getLong(1)));
+            }
+            if (links.isEmpty())
+                return Optional.empty();
+            return Optional.of(links);
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    public void removeBlock(Cid block) {
+        // remove links
+        // remove cid
+        System.out.println("Removed " + block);
+    }
+
     public static SqliteBlockReachability createReachabilityDb(Path dbFile) {
         try {
-            if (Files.exists(dbFile))
-                Files.delete(dbFile);
-            Connection memory = Sqlite.build(dbFile.toString());
+            Connection file = Sqlite.build(dbFile.toString());
             // We need a connection that ignores close
-            Connection instance = new Sqlite.UncloseableConnection(memory);
+            Connection instance = new Sqlite.UncloseableConnection(file);
             return new SqliteBlockReachability(() -> instance, new SqliteCommands());
-        } catch (SQLException | IOException e) {
+        } catch (SQLException e) {
             throw new RuntimeException(e);
         }
     }

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -513,20 +513,24 @@ public class DirectorySync {
                     if (syncRemoteDeletes) {
                         LOG.accept("Sync local: delete dir " + dirPath);
                         localFS.delete(localFS.resolve(dirPath));
+                        syncedVersions.removeDir(dirPath);
                     }
                 } else {
                     LOG.accept("Sync Remote: mkdir " + dirPath);
                     remoteFS.mkdirs(remoteFS.resolve(dirPath));
+                    syncedVersions.addDir(dirPath);
                 }
             } else {
                 if (hasSynced) { // delete
                     if (syncLocalDeletes) {
                         LOG.accept("Sync Remote: delete dir " + dirPath);
                         remoteFS.delete(remoteFS.resolve(dirPath));
+                        syncedVersions.removeDir(dirPath);
                     }
                 } else {
                     LOG.accept("Sync Local: mkdir " + dirPath);
                     localFS.mkdirs(localFS.resolve(dirPath));
+                    syncedVersions.addDir(dirPath);
                 }
             }
         }

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -7,31 +7,21 @@ import peergos.server.corenode.JdbcIpnsAndSocial;
 import peergos.server.space.JdbcUsageStore;
 import peergos.server.sql.*;
 import peergos.server.storage.*;
-import peergos.server.storage.auth.Want;
 import peergos.server.util.*;
 import peergos.shared.Crypto;
 import peergos.shared.MaybeMultihash;
 import peergos.shared.cbor.*;
-import peergos.shared.corenode.CoreNode;
 import peergos.shared.crypto.SigningKeyPair;
 import peergos.shared.crypto.asymmetric.PublicSigningKey;
 import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.io.ipfs.*;
 import peergos.shared.mutable.PointerUpdate;
 import peergos.shared.storage.*;
-import peergos.shared.storage.auth.BatWithId;
-import peergos.shared.user.fs.EncryptedCapability;
-import peergos.shared.user.fs.SecretLink;
-import peergos.shared.util.EfficientHashMap;
 import peergos.shared.util.Futures;
-import peergos.shared.util.ProgressConsumer;
 
 import java.io.*;
 import java.nio.file.*;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.sql.*;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
@@ -63,6 +53,55 @@ public class GCTests {
 
         Optional<List<Cid>> fromDb = rdb.getLinks(block);
         Assert.assertEquals(fromDb.get(), links);
+    }
+
+    @Test
+    public void versionedGC() throws Exception {
+        Path dir = Files.createTempDirectory("peergos-gc-test");
+        SqliteCommands cmds = new SqliteCommands();
+        RequestCountingBlockMetadataStore metadb = new RequestCountingBlockMetadataStore(new JdbcBlockMetadataStore(getDb(dir.resolve("metadata.sqlite")), cmds));
+
+        VersionedWriteOnlyStorage storage = new VersionedWriteOnlyStorage(metadb);
+        JdbcIpnsAndSocial pointers = new JdbcIpnsAndSocial(getDb(dir.resolve("mutable.sqlite")), cmds);
+        JdbcUsageStore usage = new JdbcUsageStore(getDb(dir.resolve("usage.sqlite")), cmds);
+
+        GarbageCollector gc = new GarbageCollector(storage, pointers, usage, dir, (x, y) -> Futures.of(true), true);
+        gc.collect(s -> Futures.of(true));
+        Path dbFile = dir.resolve("reachability.sqlite");
+        Assert.assertTrue(Files.exists(dbFile));
+        SqliteBlockReachability rdb = SqliteBlockReachability.createReachabilityDb(dbFile);
+
+        verifyAllReachableBlocksArePresent(pointers, metadb, storage);
+
+        // write a 2 block tree, gc and verify again
+        SigningKeyPair signer = SigningKeyPair.random(crypto.random, crypto.signer);
+        PublicKeyHash writer = ContentAddressedStorage.hashKey(signer.publicSigningKey);
+        Random r = new Random(42);
+        Cid leaf = randomRaw(r);
+        byte[] raw = new CborObject.CborList(Stream.of(leaf)
+                .map(CborObject.CborMerkleLink::new).toList()
+        ).serialize();
+        Cid root = new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, Hash.sha256(raw));
+        storage.add(leaf);
+        BlockVersion rootV1 = storage.add(root);
+        metadb.put(root, rootV1.version, raw);
+        byte[] signedCas = signer.signMessage(new PointerUpdate(MaybeMultihash.empty(), MaybeMultihash.of(root), Optional.of(1L)).serialize()).join();
+        pointers.setPointer(writer, Optional.empty(), signedCas).join();
+
+        verifyAllReachableBlocksArePresent(pointers, metadb, storage);
+        Assert.assertEquals(2, storage.storage.size());
+        List<BlockVersion> versions1 = new ArrayList<>();
+        storage.getAllBlockHashVersions(versions1::addAll);
+        Assert.assertEquals(2, versions1.size());
+
+        // add a new version of the leaf block, and check it is kept and the original is deleted
+        BlockVersion leafV2 = storage.add(leaf);
+        gc.collect(s -> Futures.of(true));
+        Assert.assertEquals(2, storage.storage.size());
+        List<BlockVersion> versions2 = new ArrayList<>();
+        storage.getAllBlockHashVersions(versions2::addAll);
+        Assert.assertEquals(2, versions2.size());
+        Assert.assertTrue(versions2.contains(leafV2));
     }
 
     @Test
@@ -165,6 +204,8 @@ public class GCTests {
                                      DeletableContentAddressedStorage storage) {
         if (! storage.hasBlock(block))
             throw new IllegalStateException("Absent block " + block);
+        if (block.isRaw())
+            return;
         BlockMetadata m = meta.get(block).get();
         for (Cid link : m.links) {
             verifySubtreePresent(link, meta, storage);
@@ -279,231 +320,5 @@ public class GCTests {
         byte[] hash = new byte[32];
         r.nextBytes(hash);
         return new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
-    }
-
-    public static class WriteOnlyStorage implements DeletableContentAddressedStorage {
-        private Map<Cid, Boolean> storage = new EfficientHashMap<>();
-        private final BlockMetadataStore metadb;
-
-        public WriteOnlyStorage(BlockMetadataStore metadb) {
-            this.metadb = metadb;
-        }
-
-        public Optional<BlockMetadataStore> getBlockMetadataStore() {
-            return Optional.of(metadb);
-        }
-
-        @Override
-        public Stream<Cid> getAllBlockHashes(boolean useBlockstore) {
-            return storage.keySet().stream();
-        }
-
-        @Override
-        public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
-            List<BlockVersion> batch = new ArrayList<>();
-            for (Cid cid : storage.keySet()) {
-                batch.add(new BlockVersion(cid, "hey", true));
-                if (batch.size() == 1000) {
-                    res.accept(batch);
-                    batch.clear();
-                }
-            }
-            res.accept(batch);
-        }
-
-        @Override
-        public List<Cid> getOpenTransactionBlocks() {
-            return List.of();
-        }
-
-        @Override
-        public void clearOldTransactions(long cutoffMillis) {
-
-        }
-
-        @Override
-        public boolean hasBlock(Cid hash) {
-            return storage.containsKey(hash);
-        }
-
-        @Override
-        public void delete(Cid block) {
-            storage.remove(block);
-        }
-
-        @Override
-        public void setPki(CoreNode pki) {
-
-        }
-
-        @Override
-        public CompletableFuture<Optional<CborObject>> get(List<Multihash> peerIds, Cid hash, String auth, boolean persistBlock) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<Optional<byte[]>> getRaw(List<Multihash> peerIds, Cid hash, String auth, boolean persistBlock) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public List<List<Cid>> bulkGetLinks(List<Multihash> peerIds, List<Want> wants) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<String> linkHost(PublicKeyHash owner) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public ContentAddressedStorage directToOrigin() {
-            return this;
-        }
-
-        @Override
-        public Optional<BlockCache> getBlockCache() {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<Cid> id() {
-            return Futures.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, new byte[32]));
-        }
-
-        @Override
-        public CompletableFuture<List<Cid>> ids() {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<List<Cid>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid) {
-            return Futures.of(blocks.stream().map(b -> hashToCid(b, false)).toList());
-        }
-
-        @Override
-        public CompletableFuture<Optional<CborObject>> get(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<List<Cid>> putRaw(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid, ProgressConsumer<Long> progressCounter) {
-            return Futures.of(blocks.stream().map(b -> hashToCid(b, true)).toList());
-        }
-
-        @Override
-        public CompletableFuture<Optional<byte[]>> getRaw(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<IpnsEntry> getIpnsEntry(Multihash signer) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        @Override
-        public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
-            throw new IllegalStateException("Not implemented!");
-        }
-
-        public static Cid hashToCid(byte[] input, boolean isRaw) {
-            byte[] hash = hash(input);
-            return new Cid(1, isRaw ? Cid.Codec.Raw : Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
-        }
-
-        public static byte[] hash(byte[] input)
-        {
-            try {
-                MessageDigest md = MessageDigest.getInstance("SHA-256");
-                md.update(input);
-                return md.digest();
-            } catch (NoSuchAlgorithmException e)
-            {
-                throw new IllegalStateException("couldn't find hash algorithm");
-            }
-        }
-    }
-
-    static class RequestCountingBlockMetadataStore implements BlockMetadataStore {
-        private final BlockMetadataStore target;
-        private final AtomicLong count = new AtomicLong(0);
-
-        public RequestCountingBlockMetadataStore(BlockMetadataStore target) {
-            this.target = target;
-        }
-
-        public long getRequestCount() {
-            return count.get();
-        }
-
-        public void resetRequestCount() {
-            count.set(0);
-        }
-
-        @Override
-        public Optional<BlockMetadata> get(Cid block) {
-            count.incrementAndGet();
-            return target.get(block);
-        }
-
-        @Override
-        public void put(Cid block, String version, BlockMetadata meta) {
-            target.put(block, version, meta);
-        }
-
-        @Override
-        public void remove(Cid block) {
-            target.remove(block);
-        }
-
-        @Override
-        public long size() {
-            return target.size();
-        }
-
-        @Override
-        public void applyToAll(Consumer<Cid> consumer) {
-            target.applyToAll(consumer);
-        }
-
-        @Override
-        public Stream<BlockVersion> list() {
-            return target.list();
-        }
-
-        @Override
-        public void listCbor(Consumer<List<BlockVersion>> res) {
-            target.listCbor(res);
-        }
-
-        @Override
-        public void compact() {
-            target.compact();
-        }
     }
 }

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -109,7 +109,7 @@ public class GCTests {
         Path dbFile = dir.resolve("reachability.sqlite");
         Assert.assertTrue(Files.exists(dbFile));
         SqliteBlockReachability rdb = SqliteBlockReachability.createReachabilityDb(dbFile);
-        Optional<List<Cid>> links = rdb.getLinks(toRemove);
+        Optional<List<Cid>> links = rdb.getLinks(root);
         Assert.assertEquals(1999, rdb.size());
         Assert.assertTrue(links.isPresent());
 

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -102,6 +102,15 @@ public class GCTests {
         storage.getAllBlockHashVersions(versions2::addAll);
         Assert.assertEquals(2, versions2.size());
         Assert.assertTrue(versions2.contains(leafV2));
+
+        // now add a new version of the root
+        BlockVersion rootV2 = storage.add(root);
+        gc.collect(s -> Futures.of(true));
+        Assert.assertEquals(2, storage.storage.size());
+        List<BlockVersion> versions3 = new ArrayList<>();
+        storage.getAllBlockHashVersions(versions3::addAll);
+        Assert.assertEquals(2, versions3.size());
+        Assert.assertTrue(versions3.contains(rootV2));
     }
 
     @Test

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -160,6 +160,7 @@ public class MultiNodeNetworkTests {
             int peergosPort = TestPorts.getPort();
             int proxyTargetPort = TestPorts.getPort();
             Args normalNode = UserTests.buildArgs()
+                    .with(Main.PEERGOS_PATH, Files.createTempDirectory("peergos-mnnt-" + System.nanoTime()).toString())
                     .with("useIPFS", "true")
                     .with("enable-gc", "true")
                     .with("port", "" + peergosPort)

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -583,7 +583,7 @@ public class RamUserTests extends UserTests {
     @Test
     public void testReuseOfAsyncReader() throws Exception {
 
-        String username = "test";
+        String username = generateUsername();
         String password = "test01";
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         FileWrapper userRoot = context.getUserRoot().join();
@@ -623,7 +623,7 @@ public class RamUserTests extends UserTests {
     @Test
     public void testReuseOfAsyncReaderSerialRead() throws Exception {
 
-        String username = "test";
+        String username = generateUsername();
         String password = "test01";
         UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
         FileWrapper userRoot = context.getUserRoot().join();

--- a/src/peergos/server/tests/RequestCountingBlockMetadataStore.java
+++ b/src/peergos/server/tests/RequestCountingBlockMetadataStore.java
@@ -1,0 +1,70 @@
+package peergos.server.tests;
+
+import peergos.server.storage.BlockMetadata;
+import peergos.server.storage.BlockMetadataStore;
+import peergos.server.storage.BlockVersion;
+import peergos.shared.io.ipfs.Cid;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+class RequestCountingBlockMetadataStore implements BlockMetadataStore {
+    private final BlockMetadataStore target;
+    private final AtomicLong count = new AtomicLong(0);
+
+    public RequestCountingBlockMetadataStore(BlockMetadataStore target) {
+        this.target = target;
+    }
+
+    public long getRequestCount() {
+        return count.get();
+    }
+
+    public void resetRequestCount() {
+        count.set(0);
+    }
+
+    @Override
+    public Optional<BlockMetadata> get(Cid block) {
+        count.incrementAndGet();
+        return target.get(block);
+    }
+
+    @Override
+    public void put(Cid block, String version, BlockMetadata meta) {
+        target.put(block, version, meta);
+    }
+
+    @Override
+    public void remove(Cid block) {
+        target.remove(block);
+    }
+
+    @Override
+    public long size() {
+        return target.size();
+    }
+
+    @Override
+    public void applyToAll(Consumer<Cid> consumer) {
+        target.applyToAll(consumer);
+    }
+
+    @Override
+    public Stream<BlockVersion> list() {
+        return target.list();
+    }
+
+    @Override
+    public void listCbor(Consumer<List<BlockVersion>> res) {
+        target.listCbor(res);
+    }
+
+    @Override
+    public void compact() {
+        target.compact();
+    }
+}

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -87,7 +87,7 @@ public abstract class UserTests {
                     "-admin-usernames", "peergos",
                     "-logToConsole", "true",
                     "-enable-gc", "true",
-                    "-gc.period.millis", "60000",
+                    "-gc.period.millis", "1000",
                     "max-users", "10000",
                     "max-daily-signups", "20000",
                     Main.PEERGOS_PATH, peergosDir.toString(),

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -87,7 +87,7 @@ public abstract class UserTests {
                     "-admin-usernames", "peergos",
                     "-logToConsole", "true",
                     "-enable-gc", "true",
-                    "-gc.period.millis", "1000",
+                    "-gc.period.millis", "10000",
                     "max-users", "10000",
                     "max-daily-signups", "20000",
                     Main.PEERGOS_PATH, peergosDir.toString(),

--- a/src/peergos/server/tests/VersionedWriteOnlyStorage.java
+++ b/src/peergos/server/tests/VersionedWriteOnlyStorage.java
@@ -1,0 +1,219 @@
+package peergos.server.tests;
+
+import peergos.server.storage.BlockMetadataStore;
+import peergos.server.storage.BlockVersion;
+import peergos.server.storage.DeletableContentAddressedStorage;
+import peergos.server.storage.auth.Want;
+import peergos.shared.cbor.CborObject;
+import peergos.shared.corenode.CoreNode;
+import peergos.shared.crypto.hash.PublicKeyHash;
+import peergos.shared.io.ipfs.Cid;
+import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.storage.*;
+import peergos.shared.storage.auth.BatWithId;
+import peergos.shared.user.fs.EncryptedCapability;
+import peergos.shared.user.fs.SecretLink;
+import peergos.shared.util.EfficientHashMap;
+import peergos.shared.util.Futures;
+import peergos.shared.util.ProgressConsumer;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class VersionedWriteOnlyStorage implements DeletableContentAddressedStorage {
+    public final Map<Cid, Boolean> storage = new EfficientHashMap<>();
+    private final BlockMetadataStore metadb;
+    private final AtomicLong nextVersion = new AtomicLong(0);
+    private final Map<Cid, Set<String>> versions = new HashMap<>();
+
+    public VersionedWriteOnlyStorage(BlockMetadataStore metadb) {
+        this.metadb = metadb;
+    }
+
+    public BlockVersion add(Cid c) {
+        Set<String> versions = this.versions.computeIfAbsent(c, x -> new HashSet<>());
+        String version = Long.toString(nextVersion.incrementAndGet());
+        versions.add(version);
+        storage.put(c, true);
+        return new BlockVersion(c, version, true);
+    }
+
+    public Optional<BlockMetadataStore> getBlockMetadataStore() {
+        return Optional.of(metadb);
+    }
+
+    @Override
+    public Stream<Cid> getAllBlockHashes(boolean useBlockstore) {
+        return storage.keySet().stream();
+    }
+
+    @Override
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        List<BlockVersion> batch = new ArrayList<>();
+        for (Cid cid : storage.keySet()) {
+            Set<String> versions = this.versions.getOrDefault(cid, Collections.emptySet());
+            if (!versions.isEmpty()) {
+                String latest = versions.stream().sorted(Comparator.reverseOrder()).findFirst().get();
+                for (String version : versions) {
+                    batch.add(new BlockVersion(cid, version, version.equals(latest)));
+                }
+                if (batch.size() >= 1000) {
+                    res.accept(batch);
+                    batch.clear();
+                }
+            }
+        }
+        res.accept(batch);
+    }
+
+    @Override
+    public List<Cid> getOpenTransactionBlocks() {
+        return List.of();
+    }
+
+    @Override
+    public void clearOldTransactions(long cutoffMillis) {
+
+    }
+
+    @Override
+    public boolean hasBlock(Cid hash) {
+        return storage.containsKey(hash);
+    }
+
+    @Override
+    public void delete(Cid block) {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void delete(BlockVersion v) {
+        Set<String> versions = this.versions.get(v.cid);
+        if (versions == null || versions.isEmpty())
+            return;
+        versions.remove(v.version);
+        if (versions.isEmpty())
+            storage.remove(v.cid);
+    }
+
+    @Override
+    public void setPki(CoreNode pki) {
+
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(List<Multihash> peerIds, Cid hash, String auth, boolean persistBlock) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(List<Multihash> peerIds, Cid hash, String auth, boolean persistBlock) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public List<List<Cid>> bulkGetLinks(List<Multihash> peerIds, List<Want> wants) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<String> linkHost(PublicKeyHash owner) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
+    public Optional<BlockCache> getBlockCache() {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Cid> id() {
+        return Futures.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, new byte[32]));
+    }
+
+    @Override
+    public CompletableFuture<List<Cid>> ids() {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<List<Cid>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid) {
+        return Futures.of(blocks.stream().map(b -> hashToCid(b, false)).toList());
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<List<Cid>> putRaw(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid, ProgressConsumer<Long> progressCounter) {
+        return Futures.of(blocks.stream().map(b -> hashToCid(b, true)).toList());
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<IpnsEntry> getIpnsEntry(Multihash signer) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    public static Cid hashToCid(byte[] input, boolean isRaw) {
+        byte[] hash = hash(input);
+        return new Cid(1, isRaw ? Cid.Codec.Raw : Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
+    }
+
+    public static byte[] hash(byte[] input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(input);
+            return md.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("couldn't find hash algorithm");
+        }
+    }
+}

--- a/src/peergos/server/tests/WriteOnlyStorage.java
+++ b/src/peergos/server/tests/WriteOnlyStorage.java
@@ -1,0 +1,195 @@
+package peergos.server.tests;
+
+import peergos.server.storage.BlockMetadataStore;
+import peergos.server.storage.BlockVersion;
+import peergos.server.storage.DeletableContentAddressedStorage;
+import peergos.server.storage.auth.Want;
+import peergos.shared.cbor.CborObject;
+import peergos.shared.corenode.CoreNode;
+import peergos.shared.crypto.hash.PublicKeyHash;
+import peergos.shared.io.ipfs.Cid;
+import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.storage.*;
+import peergos.shared.storage.auth.BatWithId;
+import peergos.shared.user.fs.EncryptedCapability;
+import peergos.shared.user.fs.SecretLink;
+import peergos.shared.util.EfficientHashMap;
+import peergos.shared.util.Futures;
+import peergos.shared.util.ProgressConsumer;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class WriteOnlyStorage implements DeletableContentAddressedStorage {
+    public final Map<Cid, Boolean> storage = new EfficientHashMap<>();
+    private final BlockMetadataStore metadb;
+
+    public WriteOnlyStorage(BlockMetadataStore metadb) {
+        this.metadb = metadb;
+    }
+
+    public Optional<BlockMetadataStore> getBlockMetadataStore() {
+        return Optional.of(metadb);
+    }
+
+    @Override
+    public Stream<Cid> getAllBlockHashes(boolean useBlockstore) {
+        return storage.keySet().stream();
+    }
+
+    @Override
+    public void getAllBlockHashVersions(Consumer<List<BlockVersion>> res) {
+        List<BlockVersion> batch = new ArrayList<>();
+        for (Cid cid : storage.keySet()) {
+            batch.add(new BlockVersion(cid, "hey", true));
+            if (batch.size() == 1000) {
+                res.accept(batch);
+                batch.clear();
+            }
+        }
+        res.accept(batch);
+    }
+
+    @Override
+    public List<Cid> getOpenTransactionBlocks() {
+        return List.of();
+    }
+
+    @Override
+    public void clearOldTransactions(long cutoffMillis) {
+
+    }
+
+    @Override
+    public boolean hasBlock(Cid hash) {
+        return storage.containsKey(hash);
+    }
+
+    @Override
+    public void delete(Cid block) {
+        storage.remove(block);
+    }
+
+    @Override
+    public void setPki(CoreNode pki) {
+
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(List<Multihash> peerIds, Cid hash, String auth, boolean persistBlock) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(List<Multihash> peerIds, Cid hash, String auth, boolean persistBlock) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public List<List<Cid>> bulkGetLinks(List<Multihash> peerIds, List<Want> wants) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<String> linkHost(PublicKeyHash owner) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public ContentAddressedStorage directToOrigin() {
+        return this;
+    }
+
+    @Override
+    public Optional<BlockCache> getBlockCache() {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Cid> id() {
+        return Futures.of(new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, new byte[32]));
+    }
+
+    @Override
+    public CompletableFuture<List<Cid>> ids() {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<TransactionId> startTransaction(PublicKeyHash owner) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Boolean> closeTransaction(PublicKeyHash owner, TransactionId tid) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<List<Cid>> put(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid) {
+        return Futures.of(blocks.stream().map(b -> hashToCid(b, false)).toList());
+    }
+
+    @Override
+    public CompletableFuture<Optional<CborObject>> get(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<List<Cid>> putRaw(PublicKeyHash owner, PublicKeyHash writer, List<byte[]> signedHashes, List<byte[]> blocks, TransactionId tid, ProgressConsumer<Long> progressCounter) {
+        return Futures.of(blocks.stream().map(b -> hashToCid(b, true)).toList());
+    }
+
+    @Override
+    public CompletableFuture<Optional<byte[]>> getRaw(PublicKeyHash owner, Cid hash, Optional<BatWithId> bat) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<List<byte[]>> getChampLookup(PublicKeyHash owner, Cid root, List<ChunkMirrorCap> caps, Optional<Cid> committedRoot) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<Optional<Integer>> getSize(Multihash block) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<IpnsEntry> getIpnsEntry(Multihash signer) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<EncryptedCapability> getSecretLink(SecretLink link) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    @Override
+    public CompletableFuture<LinkCounts> getLinkCounts(String owner, LocalDateTime after, BatWithId mirrorBat) {
+        throw new IllegalStateException("Not implemented!");
+    }
+
+    public static Cid hashToCid(byte[] input, boolean isRaw) {
+        byte[] hash = hash(input);
+        return new Cid(1, isRaw ? Cid.Codec.Raw : Cid.Codec.DagCbor, Multihash.Type.sha2_256, hash);
+    }
+
+    public static byte[] hash(byte[] input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(input);
+            return md.digest();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("couldn't find hash algorithm");
+        }
+    }
+}

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -889,7 +889,7 @@ public class NetworkAccess {
                     if (optList.stream().anyMatch(Optional::isEmpty)) {
                         if (retriesLeft > 0)
                             return downloadFragments(owner, hashes, bats, dhtClient, hasher, monitor, spaceIncreaseFactor, retriesLeft - 1);
-                        throw new IllegalStateException("Couldn't retrieve blocks!");
+                        throw new IllegalStateException("Couldn't retrieve blocks! " + hashes);
                     }
                     return Futures.of(optList.stream()
                             .filter(Optional::isPresent)


### PR DESCRIPTION
This persists the block graph in the reachability sqlite db to make GC O(new blocks) in calls to the metadata db. 

In the future we can do even better and make it O(new blocks + garbage) by keeping reachability and roots, and only traversing the diffs, and marking removed blocks unreachable. However need to be careful about blocks being referenced from multiple places, including maliciously. So need to keep track of all parents of a block. 