### PR TITLE
Make resuming a large folder upload 1000x faster

### DIFF
--- a/src/peergos/server/simulation/PeergosFileSystemImpl.java
+++ b/src/peergos/server/simulation/PeergosFileSystemImpl.java
@@ -67,7 +67,7 @@ public class PeergosFileSystemImpl implements FileSystem {
     @Override
     public void writeSubtree(Path path, Stream<FileWrapper.FolderUploadProperties> folders, Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile) {
         FileWrapper parentDir = getPath(path);
-        parentDir.uploadSubtree(folders, userContext.mirrorBatId(), userContext.network, userContext.crypto, userContext.getTransactionService(), resumeFile, () -> true).join();
+        parentDir.uploadSubtree(folders, userContext.mirrorBatId(), userContext.network, userContext.crypto, userContext.getTransactionService(), resumeFile, f -> Futures.of(true), () -> true).join();
     }
 
     @Override

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -250,7 +250,7 @@ public class PeergosSyncFS implements SyncFilesystem {
     public void uploadSubtree(Stream<FileWrapper.FolderUploadProperties> directories) {
         FileWrapper base = context.getByPath(root).join().get();
         Optional<BatId> mirrorBat = base.mirrorBatId();
-        base.uploadSubtree(directories, mirrorBat, context.network, context.crypto, context.getTransactionService(), x -> Futures.of(false), () -> true).join();
+        base.uploadSubtree(directories, mirrorBat, context.network, context.crypto, context.getTransactionService(), x -> Futures.of(false), f -> Futures.of(true), () -> true).join();
     }
 
     @Override

--- a/src/peergos/server/tests/PeergosNetworkUtils.java
+++ b/src/peergos/server/tests/PeergosNetworkUtils.java
@@ -171,7 +171,7 @@ public class PeergosNetworkUtils {
                 new FileWrapper.FolderUploadProperties(List.of(subdirName, "nested"), files)
         );
         destFolder.get().uploadSubtree(upload,
-                Optional.empty(), network, crypto, shareeUser.getTransactionService(), x -> Futures.of(false), () -> true).join();
+                Optional.empty(), network, crypto, shareeUser.getTransactionService(), x -> Futures.of(false), f -> Futures.of(true), () -> true).join();
 
         // check sharer can see folder
         Optional<FileWrapper> foundFolder = sharerUser.getByPath(sharedPath.resolve(subdirName)).join();

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -223,7 +223,7 @@ public class RamUserTests extends UserTests {
         FileWrapper.FolderUploadProperties folderProps = new FileWrapper.FolderUploadProperties(convert(remoteRelativeDir), files);
         List<FileWrapper.FolderUploadProperties> folders = new ArrayList<>();
         folders.add(folderProps);
-        context.getUserRoot().join().uploadSubtree(folders.stream(), context.mirrorBatId(), context.network, crypto, context.getTransactionService(), x -> Futures.of(true), () -> true).join();
+        context.getUserRoot().join().uploadSubtree(folders.stream(), context.mirrorBatId(), context.network, crypto, context.getTransactionService(), x -> Futures.of(true), f -> Futures.of(true), () -> true).join();
 
         String appName = "pandoc";
         String installAppFromFolder = context.username + "/" + appName;
@@ -368,7 +368,7 @@ public class RamUserTests extends UserTests {
         try {
             FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties("somefile", () -> thrower, 0, size, Optional.empty(), Optional.empty(), false, false, x -> {});
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(username), Arrays.asList(fileUpload));
-            userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
+            userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         } catch (Exception e) {}
         try {
             context.getUserRoot().join().uploadFileJS("anotherfile", thrower, 0, size, false,
@@ -415,7 +415,7 @@ public class RamUserTests extends UserTests {
         try {
             FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties("somefile", () -> thrower, 0, size, Optional.empty(), Optional.empty(), false, false, x -> {});
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(subdir), Arrays.asList(fileUpload));
-            userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
+            userRoot.uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         } catch (Exception e) {}
         long usageAfterFail = context.getSpaceUsage(false).join();
         if (usageAfterFail <= throwAtIndex) { // give server a chance to recalculate usage

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -731,7 +731,7 @@ public abstract class UserTests {
 
         int priorChildren = userRoot.getChildren(crypto.hasher, network).join().size();
 
-        userRoot.uploadSubtree(byFolder, Optional.empty(), network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
+        userRoot.uploadSubtree(byFolder, Optional.empty(), network, crypto, context.getTransactionService(), f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
 
         userRoot = context.getUserRoot().join();
         int postChildren = userRoot.getChildren(crypto.hasher, network).join().size();
@@ -763,7 +763,7 @@ public abstract class UserTests {
             FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties(filename, () -> thrower, 0, size, Optional.empty(), Optional.empty(), false, false, x -> {
             });
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(subdir), Arrays.asList(fileUpload));
-            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
+            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         } catch (Exception e) {
         }
         FileWrapper home = context.getUserRoot().join();
@@ -797,7 +797,7 @@ public abstract class UserTests {
         try {
             FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties(filename, () -> reader, 0, size, Optional.empty(), Optional.empty(), false, false, monitor);
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(subdir), Arrays.asList(fileUpload));
-            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), () -> true).join();
+            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns, f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         } catch (Exception e) {
         }
         long[] monitorUploadJSVal = new long[1];
@@ -819,7 +819,7 @@ public abstract class UserTests {
         try {
             FileWrapper.FileUploadProperties fileUpload = new FileWrapper.FileUploadProperties(filename, () -> reader2, 0, size, Optional.empty(), Optional.empty(), false, true, monitor2);
             FileWrapper.FolderUploadProperties dirUploads = new FileWrapper.FolderUploadProperties(Arrays.asList(subdir), Arrays.asList(fileUpload));
-            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns2, f -> Futures.of(false), () -> true).join();
+            context.getUserRoot().join().uploadSubtree(Stream.of(dirUploads), context.mirrorBatId(), network, crypto, txns2, f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         } catch (Exception e) {
         }
         Assert.assertTrue("bulkMonitor", monitor2Val[0] == monitorVal[0]);

--- a/src/peergos/server/tests/slow/DeleteBenchmark.java
+++ b/src/peergos/server/tests/slow/DeleteBenchmark.java
@@ -71,7 +71,7 @@ public class DeleteBenchmark {
                 .collect(Collectors.toList());
         String dirName = "folder";
         userRoot.uploadSubtree(Stream.of(new FileWrapper.FolderUploadProperties(Arrays.asList(dirName), files)),
-                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
+                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         Path dirPath = PathUtil.get(username, dirName);
         FileWrapper folder = context.getByPath(dirPath).join().get();
 
@@ -97,7 +97,7 @@ public class DeleteBenchmark {
                 .collect(Collectors.toList());
         String dirName = "folder";
         userRoot.uploadSubtree(Stream.of(new FileWrapper.FolderUploadProperties(Arrays.asList(dirName), files)),
-                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
+                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         Path dirPath = PathUtil.get(username, dirName);
         FileWrapper folder = context.getByPath(dirPath).join().get();
 

--- a/src/peergos/server/tests/slow/SmallFileBenchmark.java
+++ b/src/peergos/server/tests/slow/SmallFileBenchmark.java
@@ -75,7 +75,7 @@ public class SmallFileBenchmark {
                 .map(n -> new FileWrapper.FileUploadProperties(n, () -> AsyncReader.build(data), 0, data.length, Optional.empty(), Optional.empty(), false, false, progressCounter))
                 .collect(Collectors.toList());
         userRoot.uploadSubtree(Stream.of(new FileWrapper.FolderUploadProperties(Collections.emptyList(), files)),
-                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), () -> true).join();
+                userRoot.mirrorBatId(), context.network, crypto, context.getTransactionService(), f -> Futures.of(false), f -> Futures.of(true), () -> true).join();
         long duration = System.currentTimeMillis() - start;
         System.err.printf("UPLOAD("+names.size()+") duration: %d mS, av: %d mS\n", duration, (duration) / names.size());
         Assert.assertTrue("Correct progress", progressReceived.stream().mapToLong(i -> i).sum() == data.length * names.size());

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -708,7 +708,7 @@ public class FileWrapper {
                                                        Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile) {
         FileUploadProperties fileProps = new FileUploadProperties(filename, () -> fileData, lengthHi, lengthLow, Optional.empty(), Optional.empty(), false, overwriteExisting, monitor);
         FolderUploadProperties currentFolder = new FolderUploadProperties(Collections.emptyList(), Collections.singletonList(fileProps));
-        return uploadSubtree(Stream.of(currentFolder), mirrorBat, network, crypto, transactions, resumeFile, () -> true);
+        return uploadSubtree(Stream.of(currentFolder), mirrorBat, network, crypto, transactions, resumeFile, f -> Futures.of(true), () -> true);
     }
 
     public CompletableFuture<Pair<Snapshot, Optional<NamedRelativeCapability>>> resumeUpload(FileUploadTransaction txn,
@@ -962,6 +962,12 @@ public class FileWrapper {
             this.monitor = monitor;
         }
 
+        public FileUploadProperties withOverwriteExisting() {
+            return new FileUploadProperties(filename, fileData,
+                    (int)(length >> 32), (int) length,
+                    modifiedTime, hash, skipExisting, true, monitor);
+        }
+
         @Override
         public String toString() {
             return filename + " [" + length + "]";
@@ -990,6 +996,7 @@ public class FileWrapper {
                                                         Crypto crypto,
                                                         TransactionService txns,
                                                         Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile,
+                                                        Function<String, CompletableFuture<Boolean>> replaceFile,
                                                         Supplier<Boolean> commitWatcher) {
         Supplier<Boolean> isCancelled = () -> false; // TODO support this in UI
         // only use the supplied mirror BAT if the parent doesn't have a mirror BAT
@@ -1000,7 +1007,7 @@ public class FileWrapper {
                             return getUpdated(s, network).thenCompose(us -> Futures.reduceAll(directories, us,
                                             (dir, children) -> dir.getOrMkdirs(children.relativePath, false, mirror, network, crypto, dir.version, c)
                                                     .thenCompose(p -> uploadFolder(PathUtil.get(path).resolve(children.path()), p.right,
-                                                            children, mirrorBat, txns, resumeFile, commitWatcher, isCancelled, network, crypto, c)
+                                                            children, mirrorBat, txns, resumeFile, replaceFile, commitWatcher, isCancelled, network, crypto, c)
                                                             .thenCompose(v -> dir.getUpdated(v, network))),
                                             (a, b) -> b))
                                     .thenApply(d -> d.version);
@@ -1015,6 +1022,7 @@ public class FileWrapper {
                                                            Optional<BatId> mirrorBat,
                                                            TransactionService transactions,
                                                            Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile,
+                                                           Function<String, CompletableFuture<Boolean>> replaceFile,
                                                            Supplier<Boolean> commitWatcher,
                                                            Supplier<Boolean> isCancelled,
                                                            NetworkAccess network,
@@ -1040,93 +1048,133 @@ public class FileWrapper {
             groupedChildren.get(groupedChildren.size() - 1).add(next);
             currentTotal += next.length;
         }
-        return Futures.reduceAll(groupedChildren, identity, (id, group) -> Futures.reduceAll(group, id,
-                        (p, f) -> {
-                            // don't bother with file upload transactions as single chunk uploads are atomic anyway
-                            // (nothing to resume or cleanup later in case of failure)
-                            AsyncReader fileData = f.fileData.get();
-                            if (f.length <= Chunk.MAX_SIZE || transactions == null) // small files or writable public links
-                                return parent.uploadFileSection(p.left, c, f.filename, fileData, Optional.empty(), false, 0, f.length, f.hash, f.modifiedTime,
-                                                Optional.empty(), Optional.empty(), Optional.empty(), f.skipExisting,
-                                                f.overwriteExisting, true, network.disableCommits(), crypto, isCancelled, f.monitor,
-                                                crypto.random.randomBytes(32), Optional.empty(), Optional.of(Bat.random(crypto.random)), mirrorBat)
-                                        .thenApply(pair -> new Pair<>(pair.left, Stream.concat(p.right.stream(), pair.right.stream()).collect(Collectors.toList())))
-                                        .thenCompose(r -> {
-                                            fileData.close();
-                                            if (! network.isFull())
-                                                return Futures.of(r);
-                                            return atomicallyClearTransactionsAndAddToParent(Collections.emptyList(), r.right, parent, transactions, r.left, c, commitWatcher, network, crypto);
-                                        });
 
-                            // Before enabling commits, flush any directory entries accumulated from
-                            // preceeding small files into the buffer while commits are still disabled.
-                            // This ensures a subsequent auto-commit cannot permanently commit a small
-                            // file's chunk without its parent directory entry.
-                            CompletableFuture<Snapshot> preFlush = p.right.isEmpty() ?
-                                    Futures.of(p.left) :
-                                    parent.getUpdated(p.left, network)
-                                          .thenCompose(latest -> latest.addChildPointers(p.left, c, p.right, network.disableCommits(), crypto));
-                            return preFlush.thenCompose(flushedVersion -> {
-                                network.enableCommits();
-                                List<FileUploadTransaction> toClose = new ArrayList<>();
-                                LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
-                                return calculateMimeType(fileData, f.length, f.filename).thenCompose(mimeType -> {
-                                    FileProperties props = new FileProperties(f.filename,
-                                            false, false, mimeType, f.length,
-                                            now, now, false, Optional.empty(), Optional.of(crypto.random.randomBytes(32)), f.hash.map(t -> t.branch(0)));
-                                    return Transaction.buildFileUploadTransaction(toParent.resolve(f.filename).toString(), f.length,
-                                            props, props.streamSecret.get(), SymmetricKey.random(), SymmetricKey.random(),
-                                            SymmetricKey.random(), parent.signingPair(), new Location(parent.owner(), parent.writer(),
-                                                    crypto.random.randomBytes(32)), Optional.of(Bat.random(crypto.random)), crypto.hasher);
-                                }).thenCompose(txn -> transactions.open(flushedVersion, c, txn)
-                                                .thenCompose(r -> {
-                                                    if (r.isB()) // we must clear legacy transactions which can't be resumed or ones whose parent has rotated writer
-                                                        return (r.b().isLegacy() || ! parent.writer().equals(r.b().writer()) ?
-                                                                Futures.of(false) :
-                                                                (r.b().props.treeHash.isPresent() &&
-                                                                        f.hash.isPresent() &&
-                                                                        r.b().props.treeHash.get().rootHash.equals(f.hash.get().rootHash)) ?
-                                                                        Futures.of(true) : resumeFile.apply(r.b()))
-                                                                .thenCompose(resume -> {
-                                                                    if (resume) {
-                                                                        toClose.add(r.b());
-                                                                        return parent.resumeUpload(r.b(), fileData, isCancelled, f.monitor, flushedVersion, c, network, crypto)
-                                                                                .thenCompose(res -> fileData.reset().thenCompose(resetAgain ->
-                                                                                                parent.generateThumbnailAndUpdate(res.left, c, r.b().writeCap(), f.filename, resetAgain,
-                                                                                                        network, false, r.b().props.mimeType,
-                                                                                                        f.length, r.b().startTime(), r.b().startTime(), Optional.of(r.b().streamSecret()), f.monitor))
-                                                                                        .thenApply(s -> new Pair<>(s, res.right)));
-                                                                    }
-                                                                    return transactions.close(flushedVersion, c, r.b())
-                                                                            .thenCompose(s2 -> transactions.open(s2, c, txn))
-                                                                            .thenCompose(r2 -> {
-                                                                                if (r2.isB())
-                                                                                    throw new IllegalStateException("Error uploading file - concurrent upload of same file?");
-                                                                                toClose.add(txn);
-                                                                                return fileData.reset().thenCompose(reset -> parent.uploadFileSection(r2.a(), c, f.filename, reset, Optional.empty(),
-                                                                                        false, 0, f.length, f.hash, f.modifiedTime, Optional.of(txn.baseKey), Optional.of(txn.dataKey), Optional.of(txn.writeKey),
-                                                                                        f.skipExisting, f.overwriteExisting, true,
-                                                                                        network, crypto, isCancelled, f.monitor, txn.firstMapKey(),
-                                                                                        Optional.of(txn.streamSecret()), txn.firstBat, mirrorBat));
-                                                                            });
-                                                                }).thenApply(pair -> new Pair<>(pair.left, pair.right.stream().collect(Collectors.toList())));
-                                                    toClose.add(txn);
-                                                    return fileData.reset().thenCompose(reset -> parent.uploadFileSection(r.a(), c, f.filename, fileData, Optional.empty(), false,
-                                                                    0, f.length, f.hash, f.modifiedTime, Optional.of(txn.baseKey), Optional.of(txn.dataKey), Optional.of(txn.writeKey), f.skipExisting, f.overwriteExisting, true,
-                                                                    network, crypto, isCancelled, f.monitor, txn.firstMapKey(), Optional.of(txn.streamSecret()), txn.firstBat, mirrorBat))
-                                                            .thenApply(pair -> new Pair<>(pair.left, pair.right.stream().collect(Collectors.toList())));
-                                                })
-                                ).thenCompose(r -> atomicallyClearTransactionsAndAddToParent(toClose, r.right, parent, transactions, r.left, c, commitWatcher, network, crypto))
-                                        .thenApply(res -> {
-                                            fileData.close();
-                                            return res;
-                                        });
-                            });
+        // Pre-load the existing children of this directory in one parallel batch so we
+        // can compare hashes without a per-file CHAMP lookup inside the reduce loop.
+        Set<String> filenames = sortedChildren.stream().map(f -> f.filename).collect(Collectors.toSet());
+        return parent.getChildren(filenames, crypto.hasher, network, true)
+                .thenApply(existing -> existing.stream()
+                        .collect(Collectors.toMap(FileWrapper::getName, fw -> fw.getFileProperties())))
+                .thenCompose(existingByName -> Futures.reduceAll(groupedChildren, identity, (id, group) -> Futures.reduceAll(group, id,
+                        (p, f) -> {
+                            // Fast path: compare hash against the pre-loaded remote state before
+                            // doing any per-file network work.
+                            FileProperties existingProps = existingByName.get(f.filename);
+                            if (existingProps != null) {
+                                Optional<HashBranch> remoteHash = existingProps.treeHash;
+                                if (f.hash.isPresent() && remoteHash.isPresent()
+                                        && f.hash.get().rootHash.equals(remoteHash.get().rootHash)) {
+                                    // Identical content already uploaded — skip silently.
+                                    f.monitor.accept(f.length + THUMBNAIL_PROGRESS_OFFSET);
+                                    return Futures.of(new Pair<>(p.left, p.right));
+                                }
+                                // Remote file exists but content differs — ask the caller.
+                                return replaceFile.apply(toParent.resolve(f.filename).toString())
+                                        .thenCompose(replace -> replace ?
+                                                uploadFilePart(toParent, parent, p, f.withOverwriteExisting(),
+                                                        mirrorBat, transactions, resumeFile, commitWatcher, isCancelled, network, crypto, c) :
+                                                Futures.of(new Pair<>(p.left, p.right)));
+                            }
+                            return uploadFilePart(toParent, parent, p, f,
+                                    mirrorBat, transactions, resumeFile, commitWatcher, isCancelled, network, crypto, c);
                         },
                         (a, b) -> new Pair<>(b.left, Stream.concat(a.right.stream(), b.right.stream()).collect(Collectors.toList())))
                 .thenCompose(r -> atomicallyClearTransactionsAndAddToParent(Collections.emptyList(), r.right, parent, transactions, r.left, c, commitWatcher, network, crypto)),
                         (a, b) -> new Pair<>(b.left, Stream.concat(a.right.stream(), b.right.stream()).collect(Collectors.toList())))
-                .thenApply(x -> x.left);
+                .thenApply(x -> x.left));
+    }
+
+    private static CompletableFuture<Pair<Snapshot, List<NamedRelativeCapability>>> uploadFilePart(
+            Path toParent,
+            FileWrapper parent,
+            Pair<Snapshot, List<NamedRelativeCapability>> p,
+            FileUploadProperties f,
+            Optional<BatId> mirrorBat,
+            TransactionService transactions,
+            Function<FileUploadTransaction, CompletableFuture<Boolean>> resumeFile,
+            Supplier<Boolean> commitWatcher,
+            Supplier<Boolean> isCancelled,
+            NetworkAccess network,
+            Crypto crypto,
+            Committer c) {
+        AsyncReader fileData = f.fileData.get();
+        if (f.length <= Chunk.MAX_SIZE || transactions == null) // small files or writable public links
+            return parent.uploadFileSection(p.left, c, f.filename, fileData, Optional.empty(), false, 0, f.length, f.hash, f.modifiedTime,
+                            Optional.empty(), Optional.empty(), Optional.empty(), f.skipExisting,
+                            f.overwriteExisting, true, network.disableCommits(), crypto, isCancelled, f.monitor,
+                            crypto.random.randomBytes(32), Optional.empty(), Optional.of(Bat.random(crypto.random)), mirrorBat)
+                    .thenApply(pair -> new Pair<>(pair.left, Stream.concat(p.right.stream(), pair.right.stream()).collect(Collectors.toList())))
+                    .thenCompose(r -> {
+                        fileData.close();
+                        if (! network.isFull())
+                            return Futures.of(r);
+                        return atomicallyClearTransactionsAndAddToParent(Collections.emptyList(), r.right, parent, transactions, r.left, c, commitWatcher, network, crypto);
+                    });
+
+        // Before enabling commits, flush any directory entries accumulated from
+        // preceding small files into the buffer while commits are still disabled.
+        // This ensures a subsequent auto-commit cannot permanently commit a small
+        // file's chunk without its parent directory entry.
+        CompletableFuture<Snapshot> preFlush = p.right.isEmpty() ?
+                Futures.of(p.left) :
+                parent.getUpdated(p.left, network)
+                      .thenCompose(latest -> latest.addChildPointers(p.left, c, p.right, network.disableCommits(), crypto));
+        return preFlush.thenCompose(flushedVersion -> {
+            network.enableCommits();
+            List<FileUploadTransaction> toClose = new ArrayList<>();
+            LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+            return calculateMimeType(fileData, f.length, f.filename).thenCompose(mimeType -> {
+                FileProperties props = new FileProperties(f.filename,
+                        false, false, mimeType, f.length,
+                        now, now, false, Optional.empty(), Optional.of(crypto.random.randomBytes(32)), f.hash.map(t -> t.branch(0)));
+                return Transaction.buildFileUploadTransaction(toParent.resolve(f.filename).toString(), f.length,
+                        props, props.streamSecret.get(), SymmetricKey.random(), SymmetricKey.random(),
+                        SymmetricKey.random(), parent.signingPair(), new Location(parent.owner(), parent.writer(),
+                                crypto.random.randomBytes(32)), Optional.of(Bat.random(crypto.random)), crypto.hasher);
+            }).thenCompose(txn -> transactions.open(flushedVersion, c, txn)
+                            .thenCompose(r -> {
+                                if (r.isB()) // we must clear legacy transactions which can't be resumed or ones whose parent has rotated writer
+                                    return (r.b().isLegacy() || ! parent.writer().equals(r.b().writer()) ?
+                                            Futures.of(false) :
+                                            (r.b().props.treeHash.isPresent() &&
+                                                    f.hash.isPresent() &&
+                                                    r.b().props.treeHash.get().rootHash.equals(f.hash.get().rootHash)) ?
+                                                    Futures.of(true) : resumeFile.apply(r.b()))
+                                            .thenCompose(resume -> {
+                                                if (resume) {
+                                                    toClose.add(r.b());
+                                                    return parent.resumeUpload(r.b(), fileData, isCancelled, f.monitor, flushedVersion, c, network, crypto)
+                                                            .thenCompose(res -> fileData.reset().thenCompose(resetAgain ->
+                                                                            parent.generateThumbnailAndUpdate(res.left, c, r.b().writeCap(), f.filename, resetAgain,
+                                                                                    network, false, r.b().props.mimeType,
+                                                                                    f.length, r.b().startTime(), r.b().startTime(), Optional.of(r.b().streamSecret()), f.monitor))
+                                                                    .thenApply(s -> new Pair<>(s, res.right)));
+                                                }
+                                                return transactions.close(flushedVersion, c, r.b())
+                                                        .thenCompose(s2 -> transactions.open(s2, c, txn))
+                                                        .thenCompose(r2 -> {
+                                                            if (r2.isB())
+                                                                throw new IllegalStateException("Error uploading file - concurrent upload of same file?");
+                                                            toClose.add(txn);
+                                                            return fileData.reset().thenCompose(reset -> parent.uploadFileSection(r2.a(), c, f.filename, reset, Optional.empty(),
+                                                                    false, 0, f.length, f.hash, f.modifiedTime, Optional.of(txn.baseKey), Optional.of(txn.dataKey), Optional.of(txn.writeKey),
+                                                                    f.skipExisting, f.overwriteExisting, true,
+                                                                    network, crypto, isCancelled, f.monitor, txn.firstMapKey(),
+                                                                    Optional.of(txn.streamSecret()), txn.firstBat, mirrorBat));
+                                                        });
+                                            }).thenApply(pair -> new Pair<>(pair.left, pair.right.stream().collect(Collectors.toList())));
+                                toClose.add(txn);
+                                return fileData.reset().thenCompose(reset -> parent.uploadFileSection(r.a(), c, f.filename, fileData, Optional.empty(), false,
+                                                0, f.length, f.hash, f.modifiedTime, Optional.of(txn.baseKey), Optional.of(txn.dataKey), Optional.of(txn.writeKey), f.skipExisting, f.overwriteExisting, true,
+                                                network, crypto, isCancelled, f.monitor, txn.firstMapKey(), Optional.of(txn.streamSecret()), txn.firstBat, mirrorBat))
+                                        .thenApply(pair -> new Pair<>(pair.left, pair.right.stream().collect(Collectors.toList())));
+                            })
+            ).thenCompose(r -> atomicallyClearTransactionsAndAddToParent(toClose, r.right, parent, transactions, r.left, c, commitWatcher, network, crypto))
+                    .thenApply(res -> {
+                        fileData.close();
+                        return res;
+                    });
+        });
     }
 
     private static CompletableFuture<Pair<Snapshot, List<NamedRelativeCapability>>> atomicallyClearTransactionsAndAddToParent(
@@ -1459,8 +1507,6 @@ public class FileWrapper {
                                             if (childOpt.isPresent()) {
                                                 if (skipExisting)
                                                     return Futures.of(new Pair<>(current, Optional.empty()));
-                                                if (! overwriteExisting)
-                                                    throw new FileExistsException(filename);
                                                 FileWrapper child = childOpt.get();
                                                 FileProperties childProps = child.getFileProperties();
                                                 Optional<HashBranch> existingHash = childProps.treeHash;
@@ -1470,6 +1516,8 @@ public class FileWrapper {
                                                     monitor.accept(endIndex - startIndex + THUMBNAIL_PROGRESS_OFFSET);
                                                     return Futures.of(new Pair<>(current, Optional.<NamedRelativeCapability>empty()));
                                                 }
+                                                if (! overwriteExisting)
+                                                    throw new FileExistsException(filename);
 
                                                 TriFunction<FileWrapper, Snapshot, Long, CompletableFuture<Snapshot>> updatePropsIfNecessary =
                                                         (updatedChild, latestSnapshot, writeEnd) -> {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -1051,10 +1051,19 @@ public class FileWrapper {
 
         // Pre-load the existing children of this directory in one parallel batch so we
         // can compare hashes without a per-file CHAMP lookup inside the reduce loop.
+        // We must NOT use parent.getChildren(Set<String>) here because uploadFolder
+        // runs inside applyComplexUpdate which already holds the WriteSynchronizer
+        // lock; that path calls getAllChildrenCapabilities() → withWriter() →
+        // getValue() which tries to re-acquire the same lock, causing an async
+        // deadlock.  CryptreeNode.getChildren(Snapshot,...) traverses all CHAMP
+        // chunks using the provided Snapshot directly and never calls withWriter(),
+        // so it is safe to call while the lock is held.
         Set<String> filenames = sortedChildren.stream().map(f -> f.filename).collect(Collectors.toSet());
-        return parent.getChildren(filenames, crypto.hasher, network, true)
+        RetrievedCapability parentRc = parent.getPointer();
+        return parentRc.fileAccess.getChildren(parent.version, crypto.hasher, network, parentRc.capability)
                 .thenApply(existing -> existing.stream()
-                        .collect(Collectors.toMap(FileWrapper::getName, fw -> fw.getFileProperties())))
+                        .filter(rc -> filenames.contains(rc.getProperties().name))
+                        .collect(Collectors.toMap(rc -> rc.getProperties().name, RetrievedCapability::getProperties)))
                 .thenCompose(existingByName -> Futures.reduceAll(groupedChildren, identity, (id, group) -> Futures.reduceAll(group, id,
                         (p, f) -> {
                             // Fast path: compare hash against the pre-loaded remote state before


### PR DESCRIPTION
Previously 2N champ.gets were done in series to check for conflicts. N is the number of already uploaded files. Now it does a single bulk get of the children (with each req for 500 kids retrieved in parallel). 