### PR TITLE
feat: support self-hosted servers in desktop/proxy mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,16 @@ You can then access the web interface and login via http://localhost:8000.
 
 In this mode of operation all your writes are proxied directly to your home server. The local instance caches any blocks you access for faster subsequent access. 
 
+If you are using the packaged desktop app, or the default `peergos` launcher on macOS, you can point it at a self-hosted instance with:
+```bash
+peergos -server-url https://YOUR_PEERGOS_SERVER_DOMAIN
+```
+To make that persistent for the desktop app, add the following to `~/.peergos/config`:
+```ini
+server-url = https://YOUR_PEERGOS_SERVER_DOMAIN
+```
+For security, prefer `https` for remote servers, and only use plain `http` for loopback addresses such as `http://localhost:8000`.
+
 Usage - self hosting
 -----
 Use this method to run a new home-server (which is best with a publicly routable IP, and always on machine) to create accounts on or migrate accounts to.

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -90,6 +90,7 @@ public class Main extends Builder {
     public static final Command.Arg ARG_ANNOUNCE_ADDRESSES = new Command.Arg("ipfs-announce-addresses",
             "Comma separated list of extra announce multi-addresses. e.g. a public NAT address with port forwarding: /ip4/$IP/tcp/4001", false);
     public static final Command.Arg ARG_HTTP_PROXY = new Command.Arg("http_proxy", "Use a http proxy for all requests, format host:port", false);
+    public static final Command.Arg ARG_SERVER_URL = new Command.Arg("server-url", "Address of the remote Peergos or self-hosted server to use in app/proxy mode", false);
 
     public static final Command.Arg LISTEN_HOST = new Command.Arg("listen-host", "The hostname/interface to listen on", true, "localhost");
     public static final Command.Arg QUOTA_UPLOAD_LIMIT_SECONDS = new Command.Arg("quota-upload-limit-seconds", "The minimum time period during which a user is allowed to upload their total quota, in seconds. Faster uploads will be rejected.", false, "86400");
@@ -645,12 +646,12 @@ public class Main extends Builder {
                     Crypto crypto = JavaCrypto.init();
                     PublicSigningKey.addProvider(PublicSigningKey.Type.Ed25519, crypto.signer);
                     ThumbnailGenerator.setInstance(new JavaImageThumbnailer());
-                    URL target = new URL(a.getArg("peergos-url", "https://peergos.net"));
+                    URL target = new URL(getAppServerUrl(a));
                     Optional<ProxySelector> proxy = ProxyChooser.build(a);
                     if (proxy.isPresent())
                         System.out.println("Using http proxy " + proxy.get());
                     JavaPoster poster = new JavaPoster(target,
-                            ! target.getHost().equals("localhost"),
+                            ! isLoopbackHost(target.getHost()),
                             Optional.empty(),
                             Optional.of("Peergos-" + UserService.CURRENT_VERSION + "-proxy"),
                             proxy);
@@ -701,7 +702,8 @@ public class Main extends Builder {
 
                     SyncProperties sync = new SyncProperties(syncConfig, peergosDir, syncer, syncDirChooser);
                     UserService server = new UserService(withoutS3, offlineBats, crypto, offlineCorenode, offlineAccounts,
-                            httpSocial, pointerCache, admin, httpUsage, serverMessager, null, Optional.of(sync));
+                            httpSocial, pointerCache, admin, httpUsage, serverMessager, null, Optional.of(sync),
+                            Optional.of(new UserService.LocalAppProperties(peergosDir, getAppServerUrl(a))));
 
                     InetSocketAddress localAPIAddress = new InetSocketAddress("localhost", port);
                     List<String> appSubdomains = Arrays.asList("markup-viewer,calendar,code-editor,pdf".split(","));
@@ -717,6 +719,7 @@ public class Main extends Builder {
                 }
             },
             Arrays.asList(
+                    ARG_SERVER_URL,
                     new Command.Arg("peergos-url", "Address of the Peergos server", false, "https://peergos.net"),
                     ARG_HTTP_PROXY,
                     new Command.Arg("port", "Localhost server port", true, "7777"),
@@ -737,6 +740,52 @@ public class Main extends Builder {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    private static boolean isLoopbackHost(String host) {
+        if (host == null || host.isEmpty())
+            return false;
+        if ("localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host) || "::1".equals(host) || "[::1]".equals(host))
+            return true;
+        try {
+            return InetAddress.getByName(host).isLoopbackAddress();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String getAppServerUrl(Args args) {
+        String serverUrl = args.getArg(ARG_SERVER_URL.name, args.getArg("peergos-url", null));
+        if (serverUrl == null)
+            serverUrl = readSavedServerUrl(args.getPeergosDir()).orElse("https://peergos.net");
+        try {
+            URL target = new URL(serverUrl);
+            boolean secureLoopback = "http".equalsIgnoreCase(target.getProtocol()) && isLoopbackHost(target.getHost());
+            if (! "https".equalsIgnoreCase(target.getProtocol()) && ! secureLoopback)
+                System.err.println("Warning: desktop/proxy mode should use https, or http only for a loopback self-hosted server. Proceeding with " + serverUrl);
+            return serverUrl;
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Invalid server-url: " + serverUrl, e);
+        }
+    }
+
+    private static Optional<String> readSavedServerUrl(Path peergosDir) {
+        try {
+            Path configFile = peergosDir.resolve("config");
+            if (! Files.exists(configFile))
+                return Optional.empty();
+            for (String line : Files.readAllLines(configFile)) {
+                String trimmed = line.trim();
+                if (trimmed.startsWith("server-url") || trimmed.startsWith("peergos-url")) {
+                    String[] parts = trimmed.split("=", 2);
+                    if (parts.length == 2 && ! parts[1].trim().isEmpty())
+                        return Optional.of(parts[1].trim());
+                }
+            }
+        } catch (IOException e) {
+            // Config unreadable — fall through to default
+        }
+        return Optional.empty();
     }
 
     private static PublicKeyHash getPkiKey(PublicKeyHash pkiOwnerIdentity,
@@ -1216,6 +1265,8 @@ public class Main extends Builder {
                     System.out.println("Run with -help to show options");
 
                 try {
+                    if (args.hasArg(ARG_SERVER_URL.name))
+                        args = args.with("peergos-url", getAppServerUrl(args));
                     // By default we run a proxy instance and open it in the browser
                     // Check if proxy is already running and stop it if the version is different
                     int port = args.getInt("port", 7777);
@@ -1324,7 +1375,10 @@ public class Main extends Builder {
                     throw new RuntimeException(e);
                 }
             },
-            Collections.emptyList(),
+            Arrays.asList(
+                    ARG_SERVER_URL,
+                    new Command.Arg("port", "Localhost server port for app/proxy mode", false, "7777")
+            ),
             Arrays.asList(
                     PEERGOS,
                     SHELL,

--- a/src/peergos/server/UserService.java
+++ b/src/peergos/server/UserService.java
@@ -92,6 +92,7 @@ public class UserService {
     public final GarbageCollector gc; // not exposed
     private final Optional<BlockCache> blockCache;
     private final Optional<SyncProperties> syncProps;
+    private final Optional<LocalAppProperties> localAppProps;
     private HttpServer localhostServer;
 
     public UserService(ContentAddressedStorage storage,
@@ -106,6 +107,23 @@ public class UserService {
                        ServerMessager serverMessages,
                        GarbageCollector gc,
                        Optional<SyncProperties> syncProps) {
+        this(storage, bats, crypto, coreNode, account, social, mutable, controller, usage, serverMessages, gc,
+                syncProps, Optional.empty());
+    }
+
+    public UserService(ContentAddressedStorage storage,
+                       BatCave bats,
+                       Crypto crypto,
+                       CoreNode coreNode,
+                       Account account,
+                       SocialNetwork social,
+                       MutablePointers mutable,
+                       InstanceAdmin controller,
+                       SpaceUsage usage,
+                       ServerMessager serverMessages,
+                       GarbageCollector gc,
+                       Optional<SyncProperties> syncProps,
+                       Optional<LocalAppProperties> localAppProps) {
         this.storage = storage;
         this.bats = bats;
         this.crypto = crypto;
@@ -119,6 +137,7 @@ public class UserService {
         this.gc = gc;
         this.blockCache = storage.getBlockCache();
         this.syncProps = syncProps;
+        this.localAppProps = localAppProps;
     }
 
     public static class TlsProperties {
@@ -127,6 +146,16 @@ public class UserService {
         public TlsProperties(String hostname, String keyfilePassword) {
             this.hostname = hostname;
             this.keyfilePassword = keyfilePassword;
+        }
+    }
+
+    public static class LocalAppProperties {
+        public final Path peergosDir;
+        public final String currentServerUrl;
+
+        public LocalAppProperties(Path peergosDir, String currentServerUrl) {
+            this.peergosDir = peergosDir;
+            this.currentServerUrl = currentServerUrl;
         }
     }
 
@@ -284,7 +313,7 @@ public class UserService {
             addHandler(localhostServer, null, "/" + Constants.STOP,
                     new StopHandler(), basicAuth, local, host, nodeIds, false);
             blockCache.ifPresent(cache -> addHandler(localhostServer, null, "/" + Constants.CONFIG,
-                    new ConfigHandler(cache),
+                    new ConfigHandler(cache, localAppProps),
                     basicAuth, local, host, nodeIds, false));
             syncProps.ifPresent(props -> {
                 SyncConfigHandler sync = new SyncConfigHandler(props.config, props.peergosDir, props.syncer, storage, mutable, props.hostDirs, coreNode, crypto);

--- a/src/peergos/server/net/ConfigHandler.java
+++ b/src/peergos/server/net/ConfigHandler.java
@@ -2,26 +2,133 @@ package peergos.server.net;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import peergos.server.UserService;
 import peergos.server.util.HttpUtil;
 import peergos.server.util.Logging;
 import peergos.shared.io.ipfs.api.JSONParser;
 import peergos.shared.storage.BlockCache;
 import peergos.shared.util.Constants;
 
+import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.*;
 import java.util.function.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class ConfigHandler implements HttpHandler {
 	private static final Logger LOG = Logging.LOG();
 
     private static final boolean LOGGING = true;
+    private static final String LEGACY_SERVER_URL_KEY = "peergos-url";
+    private static final String SERVER_URL_KEY = "server-url";
     private final BlockCache cache;
+    private final Optional<UserService.LocalAppProperties> localAppProps;
 
-    public ConfigHandler(BlockCache cache) {
+    public ConfigHandler(BlockCache cache, Optional<UserService.LocalAppProperties> localAppProps) {
         this.cache = cache;
+        this.localAppProps = localAppProps;
+    }
+
+    private static boolean isLoopbackHost(String host) {
+        if (host == null || host.isEmpty())
+            return false;
+        if ("localhost".equalsIgnoreCase(host) || "127.0.0.1".equals(host) || "::1".equals(host) || "[::1]".equals(host))
+            return true;
+        try {
+            return InetAddress.getByName(host).isLoopbackAddress();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String validateServerUrl(String serverUrl) {
+        String trimmed = serverUrl.trim();
+        if (trimmed.isEmpty())
+            return "";
+        try {
+            URL target = new URL(trimmed);
+            if (target.getHost() == null || target.getHost().isEmpty())
+                throw new IllegalStateException("server-url must include a host");
+            if (target.getUserInfo() != null)
+                throw new IllegalStateException("server-url must not include embedded credentials");
+            if (target.getQuery() != null || target.getRef() != null)
+                throw new IllegalStateException("server-url must not include query parameters or fragments");
+            boolean secureLoopback = "http".equalsIgnoreCase(target.getProtocol()) && isLoopbackHost(target.getHost());
+            if (! "https".equalsIgnoreCase(target.getProtocol()) && ! secureLoopback)
+                throw new IllegalStateException("desktop/proxy mode requires https, or http only for a loopback self-hosted server");
+            return target.toString();
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Invalid server-url: " + trimmed, e);
+        }
+    }
+
+    private synchronized Map<String, String> readConfig(Path configFile) throws IOException {
+        if (! Files.exists(configFile))
+            return new LinkedHashMap<>();
+        List<String> lines = Files.readAllLines(configFile, StandardCharsets.UTF_8);
+        Map<String, String> config = new LinkedHashMap<>();
+        for (String originalLine : lines) {
+            String line = originalLine.trim();
+            if (line.isEmpty() || line.matches("\\s+"))
+                continue;
+            int commentPos = line.indexOf("#");
+            if (commentPos == 0)
+                continue;
+            if (commentPos != -1 && line.charAt(commentPos - 1) == ' ')
+                line = line.substring(0, commentPos).trim();
+            String[] split = line.split("=", 2);
+            if (split.length != 2)
+                throw new IllegalStateException("Illegal line '" + line + "'");
+            config.put(split[0].trim(), split[1].trim());
+        }
+        return config;
+    }
+
+    private synchronized void writeConfig(Path configFile, Map<String, String> config) throws IOException {
+        Files.createDirectories(configFile.getParent());
+        String text = new TreeMap<>(config).entrySet().stream()
+                .map(e -> e.getKey() + " = " + e.getValue())
+                .collect(Collectors.joining("\n"));
+        Files.write(configFile, text.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private synchronized Optional<String> getConfiguredServerUrl(Path configFile) throws IOException {
+        Map<String, String> config = readConfig(configFile);
+        if (config.containsKey(SERVER_URL_KEY))
+            return Optional.of(config.get(SERVER_URL_KEY));
+        return Optional.ofNullable(config.get(LEGACY_SERVER_URL_KEY));
+    }
+
+    private synchronized void saveServerUrl(Path configFile, String serverUrl) throws IOException {
+        Map<String, String> config = readConfig(configFile);
+        if (serverUrl.isEmpty()) {
+            config.remove(SERVER_URL_KEY);
+            config.remove(LEGACY_SERVER_URL_KEY);
+        } else {
+            config.put(SERVER_URL_KEY, serverUrl);
+            config.put(LEGACY_SERVER_URL_KEY, serverUrl);
+        }
+        writeConfig(configFile, config);
+    }
+
+    private static void replyJson(HttpExchange exchange, Object payload) throws IOException {
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        byte[] res = JSONParser.toString(payload).getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, res.length);
+        try (OutputStream resp = exchange.getResponseBody()) {
+            resp.write(res);
+        }
     }
 
     @Override
@@ -53,12 +160,35 @@ public class ConfigHandler implements HttpHandler {
             } else if (action.equals("cache/get-size")) {
                 long cacheSizeBytes = cache.getMaxSize();
                 long cacheSizeMB = cacheSizeBytes / (1024 * 1024);
-                exchange.getResponseHeaders().set("Content-Type", "application/json");
-                byte[] res = JSONParser.toString("{\"size\": " + cacheSizeMB + "}").getBytes();
-                exchange.sendResponseHeaders(200, res.length);
-                OutputStream resp = exchange.getResponseBody();
-                resp.write(res);
-                exchange.close();
+                Map<String, Object> json = new LinkedHashMap<>();
+                json.put("size", cacheSizeMB);
+                replyJson(exchange, json);
+            } else if (action.equals("server-url/get")) {
+                if (localAppProps.isEmpty()) {
+                    exchange.sendResponseHeaders(404, 0);
+                    exchange.close();
+                    return;
+                }
+                UserService.LocalAppProperties props = localAppProps.get();
+                Path configFile = props.peergosDir.resolve("config");
+                Map<String, Object> json = new LinkedHashMap<>();
+                json.put("current", props.currentServerUrl);
+                json.put("configured", getConfiguredServerUrl(configFile).orElse(""));
+                replyJson(exchange, json);
+            } else if (action.equals("server-url/set")) {
+                if (localAppProps.isEmpty()) {
+                    exchange.sendResponseHeaders(404, 0);
+                    exchange.close();
+                    return;
+                }
+                String encoded = params.containsKey("url") ? last.apply("url") : "";
+                String newServerUrl = validateServerUrl(URLDecoder.decode(encoded, StandardCharsets.UTF_8));
+                UserService.LocalAppProperties props = localAppProps.get();
+                saveServerUrl(props.peergosDir.resolve("config"), newServerUrl);
+                Map<String, Object> json = new LinkedHashMap<>();
+                json.put("serverUrl", newServerUrl);
+                json.put("restartRequired", true);
+                replyJson(exchange, json);
             } else {
                 LOG.info("Unknown config handler: " +exchange.getRequestURI());
                 exchange.sendResponseHeaders(404, 0);


### PR DESCRIPTION
## Summary

The desktop app and `proxy` command currently default to `peergos.net` with no way for the user to persistently choose a different server on first launch. Self-hosted operators have to pass `-peergos-url` on every invocation, and the packaged native app exposes no such flag at all.

This PR adds:

1. **`server-url` arg + config file support** — if `~/.peergos/config` contains `server-url`, the proxy uses it instead of the hardcoded default. CLI flags still take precedence.
2. **`server-url/get` and `server-url/set` HTTP API** in `ConfigHandler` — the web UI can read and persist the server URL without touching the filesystem directly. Localhost-only, with URL validation (https required for non-loopback hosts).
3. **`LocalAppProperties`** in `UserService` — carries the peergos dir path and current server URL to `ConfigHandler`.

### What changed

| File | Change |
|------|--------|
| `Main.java` | New `ARG_SERVER_URL`; `getAppServerUrl()` reads CLI → config → default; wired into PROXY and MAIN commands |
| `UserService.java` | `LocalAppProperties` record; constructor overload to pass it to `ConfigHandler` |
| `ConfigHandler.java` | `server-url/get` and `server-url/set` endpoints; config read/write; URL validation |
| `README.md` | Usage instructions for `-server-url` and config file |

### Backwards compatibility

- **No breaking changes.** Default remains `https://peergos.net`.
- The `peergos-url` arg still works; `server-url` takes precedence when both are present.
- Config file format (`key = value`) is unchanged.

### Companion PR

Frontend changes (server URL panel on login screen, settings option, loopback mixin): https://github.com/Peergos/web-ui — same branch name `feat/self-hosted-desktop-app`.

### How to test

```bash
# CLI flag
java -jar Peergos.jar -server-url https://my.server.com

# Config file
echo "server-url = https://my.server.com" >> ~/.peergos/config
java -jar Peergos.jar

# The login screen on localhost shows a "Desktop server" panel to configure this via UI.
```