### PR TITLE
Implement bulk delete from champ

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -233,7 +233,7 @@
   </target>
 
   <target name="gwtc" depends="javac" description="GWT compile to JavaScript (production mode)">
-    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="4g">
+    <java failonerror="true" fork="true" classname="com.google.gwt.dev.Compiler" maxmemory="8g">
       <classpath>
         <pathelement location="src"/>
         <path refid="project.class.path"/>

--- a/src/peergos/server/tests/ChampTests.java
+++ b/src/peergos/server/tests/ChampTests.java
@@ -476,6 +476,127 @@ public class ChampTests {
         }
     }
 
+    @Test
+    public void bulkDelete() throws Exception {
+        RAMStorage storage = new RAMStorage(crypto.hasher);
+        int bitWidth = 5;
+        int maxCollisions = 3;
+        SigningPrivateKeyAndPublicHash user = createUser(storage, crypto);
+        PublicKeyHash owner = user.publicKeyHash;
+        Random r = new Random(42);
+
+        Supplier<Multihash> randomHash = () -> {
+            byte[] hash = new byte[32];
+            r.nextBytes(hash);
+            return new Multihash(Multihash.Type.sha2_256, hash);
+        };
+        TransactionId tid = storage.startTransaction(owner).get();
+
+        int nKeys = 1000;
+        List<ByteArrayWrapper> keys = new ArrayList<>();
+        List<CborObject.CborMerkleLink> values = new ArrayList<>();
+
+        Champ<CborObject.CborMerkleLink> current = Champ.empty(c -> (CborObject.CborMerkleLink) c);
+        Multihash currentHash = storage.put(owner, user, current.serialize(), writeHasher, tid).get();
+
+        for (int i = 0; i < nKeys; i++) {
+            ByteArrayWrapper key = new ByteArrayWrapper(randomHash.get().toBytes());
+            CborObject.CborMerkleLink value = new CborObject.CborMerkleLink(randomHash.get());
+            Pair<Champ<CborObject.CborMerkleLink>, Multihash> updated = current.put(owner, user, key,
+                    hasher.apply(key).join(), 0, Optional.empty(), Optional.of(value),
+                    bitWidth, maxCollisions, Optional.empty(), hasher, tid, storage, writeHasher, currentHash).get();
+            current = updated.left;
+            currentHash = updated.right;
+            keys.add(key);
+            values.add(value);
+        }
+        Assert.assertEquals(nKeys, (long) current.size(owner, 0, storage).get());
+
+        Map<ByteArrayWrapper, Optional<CborObject.CborMerkleLink>> expectedAll = new HashMap<>();
+        for (int i = 0; i < nKeys; i++) expectedAll.put(keys.get(i), Optional.of(values.get(i)));
+
+        // --- Full bulk delete ---
+        List<Pair<ByteArrayWrapper, byte[]>> allKeysAndHashes = keys.stream()
+                .map(k -> new Pair<>(k, hasher.apply(k).join()))
+                .collect(Collectors.toList());
+
+        Pair<Champ<CborObject.CborMerkleLink>, Multihash> afterBulk = current.removeAll(owner, user,
+                allKeysAndHashes, expectedAll, 0, bitWidth, maxCollisions, Optional.empty(),
+                tid, storage, writeHasher, currentHash).get();
+
+        Assert.assertEquals("tree must be empty after full bulk delete", 0L,
+                (long) afterBulk.left.size(owner, 0, storage).get());
+        for (ByteArrayWrapper key : keys) {
+            Optional<CborObject.CborMerkleLink> res = afterBulk.left.get(owner, key,
+                    hasher.apply(key).join(), 0, bitWidth, storage).get();
+            Assert.assertEquals(Optional.empty(), res);
+        }
+
+        // Root must match the result of sequential removes (canonical structure)
+        Champ<CborObject.CborMerkleLink> seqCurrent = current;
+        Multihash seqHash = currentHash;
+        for (int i = 0; i < nKeys; i++) {
+            ByteArrayWrapper key = keys.get(i);
+            seqCurrent = seqCurrent.remove(owner, user, key, hasher.apply(key).join(), 0,
+                    Optional.of(values.get(i)), bitWidth, maxCollisions, Optional.empty(),
+                    tid, storage, writeHasher, seqHash).get().left;
+            seqHash = seqCurrent.equals(Champ.empty(c -> (CborObject.CborMerkleLink) c))
+                    ? seqHash  // will be recomputed below
+                    : seqHash; // placeholder — we just need the final seqHash
+        }
+        // Recompute seqHash properly
+        seqCurrent = current;
+        seqHash = currentHash;
+        for (int i = 0; i < nKeys; i++) {
+            ByteArrayWrapper key = keys.get(i);
+            Pair<Champ<CborObject.CborMerkleLink>, Multihash> step = seqCurrent.remove(owner, user,
+                    key, hasher.apply(key).join(), 0, Optional.of(values.get(i)),
+                    bitWidth, maxCollisions, Optional.empty(), tid, storage, writeHasher, seqHash).get();
+            seqCurrent = step.left;
+            seqHash = step.right;
+        }
+        Assert.assertEquals("full bulkDelete root must match sequential remove", seqHash, afterBulk.right);
+
+        // --- Partial bulk delete: remove the first half, keep the second half ---
+        int half = nKeys / 2;
+        List<Pair<ByteArrayWrapper, byte[]>> partialKeysAndHashes = keys.subList(0, half).stream()
+                .map(k -> new Pair<>(k, hasher.apply(k).join()))
+                .collect(Collectors.toList());
+        Map<ByteArrayWrapper, Optional<CborObject.CborMerkleLink>> partialExpected = new HashMap<>();
+        for (int i = 0; i < half; i++) partialExpected.put(keys.get(i), Optional.of(values.get(i)));
+
+        Pair<Champ<CborObject.CborMerkleLink>, Multihash> afterPartial = current.removeAll(owner, user,
+                partialKeysAndHashes, partialExpected, 0, bitWidth, maxCollisions, Optional.empty(),
+                tid, storage, writeHasher, currentHash).get();
+
+        Assert.assertEquals("size must be half after partial bulk delete", (long) half,
+                (long) afterPartial.left.size(owner, 0, storage).get());
+
+        for (int i = 0; i < half; i++) {
+            Optional<CborObject.CborMerkleLink> res = afterPartial.left.get(owner, keys.get(i),
+                    hasher.apply(keys.get(i)).join(), 0, bitWidth, storage).get();
+            Assert.assertEquals("deleted key must be absent", Optional.empty(), res);
+        }
+        for (int i = half; i < nKeys; i++) {
+            Optional<CborObject.CborMerkleLink> res = afterPartial.left.get(owner, keys.get(i),
+                    hasher.apply(keys.get(i)).join(), 0, bitWidth, storage).get();
+            Assert.assertEquals("kept key must still be present", Optional.of(values.get(i)), res);
+        }
+
+        // Partial bulk-remove root must match sequential removes of the same keys
+        Champ<CborObject.CborMerkleLink> seqPartial = current;
+        Multihash seqPartialHash = currentHash;
+        for (int i = 0; i < half; i++) {
+            ByteArrayWrapper key = keys.get(i);
+            Pair<Champ<CborObject.CborMerkleLink>, Multihash> step = seqPartial.remove(owner, user,
+                    key, hasher.apply(key).join(), 0, Optional.of(values.get(i)),
+                    bitWidth, maxCollisions, Optional.empty(), tid, storage, writeHasher, seqPartialHash).get();
+            seqPartial = step.left;
+            seqPartialHash = step.right;
+        }
+        Assert.assertEquals("partial bulkDelete root must match sequential remove", seqPartialHash, afterPartial.right);
+    }
+
     private static byte[] randomKey(byte[] startingWith, int extraBytes, Random r) {
         byte[] suffix = new byte[extraBytes];
         r.nextBytes(suffix);

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -856,69 +856,104 @@ public class NetworkAccess {
                                                                 SigningPrivateKeyAndPublicHash writer,
                                                                 List<Pair<byte[], Optional<Bat>>> mapKeysAndBats,
                                                                 TransactionId tid) {
+        return deleteAllChunksIfPresent(current, committer, owner, writer, mapKeysAndBats, Collections.emptyMap(), tid);
+    }
+
+    /**
+     * Delete all chunks identified by mapKeysAndBats from the writer's CHAMP.
+     *
+     * knownValues maps a chunk's map-key to its pre-known existing CHAMP value (the block CID stored
+     * under that key).  When every key in the call has a known value the entire getChampLookup round-trip
+     * is skipped, saving one batch of network calls per 50 keys.  Callers that already hold the
+     * FileWrapper (and therefore its committedHash) should populate this map for the first chunk of
+     * each file; subsequent chunks of multi-chunk files can be omitted and will be looked up normally.
+     */
+    public CompletableFuture<Snapshot> deleteAllChunksIfPresent(Snapshot current,
+                                                                Committer committer,
+                                                                PublicKeyHash owner,
+                                                                SigningPrivateKeyAndPublicHash writer,
+                                                                List<Pair<byte[], Optional<Bat>>> mapKeysAndBats,
+                                                                Map<ByteArrayWrapper, MaybeMultihash> knownValues,
+                                                                TransactionId tid) {
         if (mapKeysAndBats.isEmpty())
             return Futures.of(current);
         CommittedWriterData version = current.get(writer);
         if (version.props.isEmpty() || version.props.get().tree.isEmpty())
             return Futures.of(current);
         Cid root = (Cid) version.props.get().tree.get();
-        return Futures.combineAllInOrder(mapKeysAndBats.stream()
-                        .map(p -> p.right.map(b -> b.calculateId(hasher)
-                                        .thenApply(id -> Optional.of(new BatWithId(b, id.id))))
-                                .orElse(Futures.of(Optional.<BatWithId>empty()))
-                                .thenApply(bid -> new ChunkMirrorCap(p.left, bid)))
-                        .collect(Collectors.toList()))
-                .thenCompose(caps -> {
-                    List<List<ChunkMirrorCap>> grouped = new ArrayList<>();
-                    for (int i = 0; i < caps.size(); i += ContentAddressedStorage.MAX_CHAMP_GETS)
-                        grouped.add(caps.subList(i, Math.min(i + ContentAddressedStorage.MAX_CHAMP_GETS, caps.size())));
-                    // Pass the committed WriterData CID as committedRoot so BufferedStorage can resolve
-                    // the committed CHAMP root when the current root is still in the write buffer.
-                    return getLastCommittedRoot(writer.publicKeyHash, version)
-                            .thenCompose(committedWdHash -> Futures.combineAllInOrder(grouped.stream()
-                                    .map(group -> Futures.asyncExceptionally(
-                                            () -> dhtClient.getChampLookup(owner, root, group, committedWdHash),
-                                            t -> dhtClient.getChampLookup(owner, root, group, committedWdHash, hasher)))
-                                    .collect(Collectors.toList())))
-                            .thenApply(all -> all.stream().flatMap(List::stream).collect(Collectors.toList()))
-                            .thenCompose(blocks -> LocalRamStorage.build(hasher, blocks))
-                            .thenCompose(bstore -> {
-                                // Combined storage: pre-fetched committed blocks (fast) with dhtClient fallback
-                                // for any buffered nodes (new CHAMP nodes from previous deletions in this session).
-                                ContentAddressedStorage combined = new DelegatingStorage(dhtClient) {
-                                    @Override
-                                    public CompletableFuture<Optional<byte[]>> getRaw(PublicKeyHash o, Cid hash, Optional<BatWithId> bat) {
-                                        return bstore.getRaw(o, hash, bat)
-                                                .thenCompose(opt -> opt.isPresent() ? Futures.of(opt) : dhtClient.getRaw(o, hash, bat));
-                                    }
-                                    @Override
-                                    public ContentAddressedStorage directToOrigin() {
-                                        return dhtClient.directToOrigin();
-                                    }
-                                    @Override
-                                    public CompletableFuture<Optional<CborObject>> get(PublicKeyHash o, Cid hash, Optional<BatWithId> bat) {
-                                        return getRaw(o, hash, bat).thenApply(opt -> opt.map(CborObject::fromByteArray));
-                                    }
-                                };
-                                return ChampWrapper.create(owner, root, Optional.empty(),
-                                        x -> Futures.of(x.data), combined, hasher, c -> (CborObject.CborMerkleLink) c);
-                            })
-                            .thenCompose(champ -> {
-                    List<CompletableFuture<Pair<byte[], MaybeMultihash>>> withValues = mapKeysAndBats.stream()
-                            .map(p -> champ.get(p.left)
-                                    .thenApply(opt -> new Pair<>(p.left,
-                                            opt.map(x -> MaybeMultihash.of(x.target)).orElse(MaybeMultihash.empty()))))
-                            .collect(Collectors.toList());
-                    return Futures.reduceAll(withValues, version.props,
-                                    (wd, f) -> f.thenCompose(p -> p.right.isPresent() ?
-                                            tree.remove(wd.get(), owner, writer, p.left, p.right, tid).thenApply(Optional::of) :
-                                            Futures.of(wd)),
-                                    (a, b) -> b)
-                            .thenCompose(wd -> wd.equals(version.props) ?
-                                    Futures.of(current) :
-                                    committer.commit(owner, writer, wd, version, tid))
-                            .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
-                });
+
+        // Keys whose existing CHAMP value is not already known and must be fetched remotely.
+        List<Pair<byte[], Optional<Bat>>> unknownKeys = mapKeysAndBats.stream()
+                .filter(p -> !knownValues.containsKey(new ByteArrayWrapper(p.left)))
+                .collect(Collectors.toList());
+
+        CompletableFuture<Map<ByteArrayWrapper, MaybeMultihash>> resolvedValues;
+        if (unknownKeys.isEmpty()) {
+            // All values are pre-known — skip getChampLookup entirely.
+            resolvedValues = Futures.of(knownValues);
+        } else {
+            resolvedValues = Futures.combineAllInOrder(unknownKeys.stream()
+                            .map(p -> p.right.map(b -> b.calculateId(hasher)
+                                            .thenApply(id -> Optional.of(new BatWithId(b, id.id))))
+                                    .orElse(Futures.of(Optional.<BatWithId>empty()))
+                                    .thenApply(bid -> new ChunkMirrorCap(p.left, bid)))
+                            .collect(Collectors.toList()))
+                    .thenCompose(caps -> {
+                        List<List<ChunkMirrorCap>> grouped = new ArrayList<>();
+                        for (int i = 0; i < caps.size(); i += ContentAddressedStorage.MAX_CHAMP_GETS)
+                            grouped.add(caps.subList(i, Math.min(i + ContentAddressedStorage.MAX_CHAMP_GETS, caps.size())));
+                        // Pass the committed WriterData CID as committedRoot so BufferedStorage can resolve
+                        // the committed CHAMP root when the current root is still in the write buffer.
+                        return getLastCommittedRoot(writer.publicKeyHash, version)
+                                .thenCompose(committedWdHash -> Futures.combineAllInOrder(grouped.stream()
+                                        .map(group -> Futures.asyncExceptionally(
+                                                () -> dhtClient.getChampLookup(owner, root, group, committedWdHash),
+                                                t -> dhtClient.getChampLookup(owner, root, group, committedWdHash, hasher)))
+                                        .collect(Collectors.toList())))
+                                .thenApply(all -> all.stream().flatMap(List::stream).collect(Collectors.toList()))
+                                .thenCompose(blocks -> LocalRamStorage.build(hasher, blocks))
+                                .thenCompose(bstore -> {
+                                    ContentAddressedStorage combined = new DelegatingStorage(dhtClient) {
+                                        @Override
+                                        public CompletableFuture<Optional<byte[]>> getRaw(PublicKeyHash o, Cid hash, Optional<BatWithId> bat) {
+                                            return bstore.getRaw(o, hash, bat)
+                                                    .thenCompose(opt -> opt.isPresent() ? Futures.of(opt) : dhtClient.getRaw(o, hash, bat));
+                                        }
+                                        @Override
+                                        public ContentAddressedStorage directToOrigin() {
+                                            return dhtClient.directToOrigin();
+                                        }
+                                        @Override
+                                        public CompletableFuture<Optional<CborObject>> get(PublicKeyHash o, Cid hash, Optional<BatWithId> bat) {
+                                            return getRaw(o, hash, bat).thenApply(opt -> opt.map(CborObject::fromByteArray));
+                                        }
+                                    };
+                                    return ChampWrapper.create(owner, root, Optional.empty(),
+                                            x -> Futures.of(x.data), combined, hasher, c -> (CborObject.CborMerkleLink) c);
+                                })
+                                .thenCompose(champ -> Futures.combineAllInOrder(unknownKeys.stream()
+                                        .map(p -> champ.get(p.left)
+                                                .thenApply(opt -> new Pair<>(new ByteArrayWrapper(p.left),
+                                                        opt.map(x -> MaybeMultihash.of(x.target)).orElse(MaybeMultihash.empty()))))
+                                        .collect(Collectors.toList())))
+                                .thenApply(lookedUp -> {
+                                    Map<ByteArrayWrapper, MaybeMultihash> combined2 = new HashMap<>(knownValues);
+                                    lookedUp.forEach(p -> combined2.put(p.left, p.right));
+                                    return combined2;
+                                });
+                    });
+        }
+
+        return resolvedValues.thenCompose(allValues -> {
+            List<Pair<byte[], MaybeMultihash>> keysAndValues = mapKeysAndBats.stream()
+                    .map(p -> new Pair<>(p.left, allValues.getOrDefault(new ByteArrayWrapper(p.left), MaybeMultihash.empty())))
+                    .filter(p -> p.right.isPresent())
+                    .collect(Collectors.toList());
+            if (keysAndValues.isEmpty())
+                return Futures.of(current);
+            return tree.removeAll(version.props.get(), owner, writer, keysAndValues, tid)
+                    .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid))
+                    .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
         });
     }
 

--- a/src/peergos/shared/hamt/Champ.java
+++ b/src/peergos/shared/hamt/Champ.java
@@ -550,6 +550,176 @@ public class Champ<V extends Cborable> implements Cborable {
         return CompletableFuture.completedFuture(new Pair<>(this, ourHash));
     }
 
+    /**
+     * Remove all specified keys from the CHAMP in a single recursive descent,
+     * substantially faster than N individual {@link #remove} calls.
+     *
+     * @param keysAndHashes each pair is (key, hash-of-key)
+     * @param expectedValues maps key → expected current value; unused for CAS here, reserved for callers
+     */
+    public CompletableFuture<Pair<Champ<V>, Multihash>> removeAll(
+            PublicKeyHash owner,
+            SigningPrivateKeyAndPublicHash writer,
+            List<Pair<ByteArrayWrapper, byte[]>> keysAndHashes,
+            Map<ByteArrayWrapper, Optional<V>> expectedValues,
+            int depth,
+            int bitWidth,
+            int maxCollisions,
+            Optional<BatId> mirrorBat,
+            TransactionId tid,
+            ContentAddressedStorage storage,
+            Hasher writeHasher,
+            Multihash ourHash) {
+
+        if (keysAndHashes.isEmpty())
+            return CompletableFuture.completedFuture(new Pair<>(this, ourHash));
+
+        // Group keys by bitpos at the current depth
+        Map<Integer, List<Pair<ByteArrayWrapper, byte[]>>> byBitpos = new HashMap<>();
+        for (Pair<ByteArrayWrapper, byte[]> kh : keysAndHashes) {
+            int bitpos = mask(kh.right, depth, bitWidth);
+            byBitpos.computeIfAbsent(bitpos, k -> new ArrayList<>()).add(kh);
+        }
+
+        // Phase 1: Process inline data removals; build new data section in ascending bitpos order.
+        BitSet newDataMap = new BitSet();
+        Map<Integer, HashPrefixPayload<V>> newDataByBitpos = new LinkedHashMap<>();
+        {
+            int di = 0;
+            for (int bp = dataMap.nextSetBit(0); bp >= 0; bp = dataMap.nextSetBit(bp + 1)) {
+                HashPrefixPayload<V> payload = contents[di++];
+                List<Pair<ByteArrayWrapper, byte[]>> toRemove = byBitpos.get(bp);
+                if (toRemove == null) {
+                    newDataMap.set(bp);
+                    newDataByBitpos.put(bp, payload);
+                } else {
+                    Set<ByteArrayWrapper> removing = new HashSet<>();
+                    for (Pair<ByteArrayWrapper, byte[]> kh : toRemove) removing.add(kh.left);
+                    List<KeyElement<V>> remaining = new ArrayList<>();
+                    for (KeyElement<V> elem : payload.mappings)
+                        if (!removing.contains(elem.key)) remaining.add(elem);
+                    if (!remaining.isEmpty()) {
+                        newDataMap.set(bp);
+                        newDataByBitpos.put(bp, new HashPrefixPayload<>(remaining.toArray(new KeyElement[0])));
+                    }
+                }
+            }
+        }
+
+        // Phase 2: Collect nodeMap hits for async processing.
+        Map<Integer, List<Pair<ByteArrayWrapper, byte[]>>> nodeMapHits = new HashMap<>();
+        for (Map.Entry<Integer, List<Pair<ByteArrayWrapper, byte[]>>> e : byBitpos.entrySet())
+            if (nodeMap.get(e.getKey()))
+                nodeMapHits.put(e.getKey(), e.getValue());
+
+        if (nodeMapHits.isEmpty()) {
+            // Only data changes — build and write updated node.
+            return buildAndWrite(owner, writer, newDataMap, newDataByBitpos,
+                    BitSet.valueOf(nodeMap.toByteArray()), Collections.emptyMap(),
+                    mirrorBat, depth, storage, writeHasher, tid);
+        }
+
+        // Phase 3: Recurse into affected children in parallel.
+        List<CompletableFuture<Pair<Integer, Pair<Champ<V>, Multihash>>>> childFutures = new ArrayList<>();
+        for (Map.Entry<Integer, List<Pair<ByteArrayWrapper, byte[]>>> e : nodeMapHits.entrySet()) {
+            final int bp = e.getKey();
+            final List<Pair<ByteArrayWrapper, byte[]>> childKeys = e.getValue();
+            int nodeIdx = contents.length - 1 - getIndex(nodeMap, bp);
+            Multihash childHash = contents[nodeIdx].link.get();
+            childFutures.add(
+                storage.get(owner, (Cid) childHash, Optional.empty())
+                    .thenCompose(rawOpt -> {
+                        Champ<V> child = Champ.fromCbor(rawOpt.get(), fromCbor);
+                        return child.removeAll(owner, writer, childKeys, expectedValues, depth + 1,
+                                bitWidth, maxCollisions, mirrorBat, tid, storage, writeHasher, childHash);
+                    })
+                    .thenApply(result -> new Pair<>(bp, result))
+            );
+        }
+
+        return Futures.combineAllInOrder(childFutures)
+                .thenCompose(childResults -> {
+                    // Phase 4: Integrate child results into data/node sections.
+                    BitSet newNodeMap = BitSet.valueOf(nodeMap.toByteArray());
+                    Map<Integer, MaybeMultihash> nodeUpdates = new HashMap<>();
+                    for (Pair<Integer, Pair<Champ<V>, Multihash>> r : childResults) {
+                        int bp = r.left;
+                        Champ<V> newChild = r.right.left;
+                        Multihash newChildHash = r.right.right;
+                        if (newChild.keyCount() == 0 && newChild.nodeCount() == 0) {
+                            // Child became empty — remove it entirely.
+                            newNodeMap.set(bp, false);
+                        } else if (newChild.nodeCount() == 0 && newChild.keyCount() <= maxCollisions) {
+                            // Child is inlineable — migrate into data section.
+                            newNodeMap.set(bp, false);
+                            newDataMap.set(bp);
+                            newDataByBitpos.put(bp, new HashPrefixPayload<>(collectAllMappings(newChild)));
+                        } else {
+                            // Update the child link.
+                            nodeUpdates.put(bp, MaybeMultihash.of(newChildHash));
+                        }
+                    }
+                    return buildAndWrite(owner, writer, newDataMap, newDataByBitpos,
+                            newNodeMap, nodeUpdates, mirrorBat, depth, storage, writeHasher, tid);
+                });
+    }
+
+    /**
+     * Assemble a new CHAMP node from the supplied data and node sections and write it to storage.
+     * {@code nodeUpdates} maps bitpos → updated child link for changed children; unchanged children
+     * are read directly from {@code this.contents} using {@code this.nodeMap}.
+     */
+    private CompletableFuture<Pair<Champ<V>, Multihash>> buildAndWrite(
+            PublicKeyHash owner,
+            SigningPrivateKeyAndPublicHash writer,
+            BitSet newDataMap,
+            Map<Integer, HashPrefixPayload<V>> newDataByBitpos,
+            BitSet newNodeMap,
+            Map<Integer, MaybeMultihash> nodeUpdates,
+            Optional<BatId> mirrorBat,
+            int depth,
+            ContentAddressedStorage storage,
+            Hasher writeHasher,
+            TransactionId tid) {
+
+        // Data payloads in ascending bitpos order
+        List<HashPrefixPayload<V>> dataPayloads = new ArrayList<>();
+        for (int bp = newDataMap.nextSetBit(0); bp >= 0; bp = newDataMap.nextSetBit(bp + 1))
+            dataPayloads.add(newDataByBitpos.get(bp));
+
+        // Node links in ascending bitpos order (stored reversed at end of contents)
+        List<MaybeMultihash> nodeLinks = new ArrayList<>();
+        for (int bp = newNodeMap.nextSetBit(0); bp >= 0; bp = newNodeMap.nextSetBit(bp + 1)) {
+            if (nodeUpdates.containsKey(bp)) {
+                nodeLinks.add(nodeUpdates.get(bp));
+            } else {
+                // Unchanged node — look up original position via this.nodeMap / this.contents
+                nodeLinks.add(contents[contents.length - 1 - getIndex(nodeMap, bp)].link);
+            }
+        }
+
+        int D = dataPayloads.size(), N = nodeLinks.size();
+        HashPrefixPayload<V>[] fc = new HashPrefixPayload[D + N];
+        for (int i = 0; i < D; i++) fc[i] = dataPayloads.get(i);
+        // Node entries at end in REVERSE bitpos order (first bitpos ↔ last index)
+        for (int i = 0; i < N; i++) fc[D + N - 1 - i] = new HashPrefixPayload<>(nodeLinks.get(i));
+
+        Champ<V> updated = new Champ<>(newDataMap, newNodeMap, fc, fromCbor, mirrorBat).withMirrorBat(mirrorBat, depth);
+        return storage.put(owner, writer, updated.serialize(), writeHasher, tid)
+                .thenApply(h -> new Pair<>(updated, h));
+    }
+
+    /** Collect all inline key-element mappings from a node that has no child nodes. */
+    @SuppressWarnings("unchecked")
+    private KeyElement<V>[] collectAllMappings(Champ<V> node) {
+        List<KeyElement<V>> all = new ArrayList<>();
+        for (HashPrefixPayload<V> payload : node.contents)
+            if (!payload.isShard())
+                Collections.addAll(all, payload.mappings);
+        all.sort(Comparator.comparing(x -> x.key));
+        return all.toArray(new KeyElement[0]);
+    }
+
     private Champ<V> copyAndMigrateFromNodeToInline(final int bitpos, final Champ<V> node) {
 
         final int oldIndex = this.contents.length - 1 - getIndex(nodeMap, bitpos);

--- a/src/peergos/shared/hamt/ChampWrapper.java
+++ b/src/peergos/shared/hamt/ChampWrapper.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.stream.*;
 
 public class ChampWrapper<V extends Cborable> implements ImmutableTree<V>
 {
@@ -127,6 +128,30 @@ public class ChampWrapper<V extends Cborable> implements ImmutableTree<V>
         return keyHasher.apply(key)
                 .thenCompose(keyHash -> root.left.remove(owner, writer, key, keyHash, 0, existing,
                         BIT_WIDTH, MAX_HASH_COLLISIONS_PER_LEVEL, mirrorBat, tid, storage, writeHasher, root.right))
+                .thenCompose(newRoot -> commit(writer, newRoot));
+    }
+
+    public CompletableFuture<Multihash> removeAll(
+            PublicKeyHash owner,
+            SigningPrivateKeyAndPublicHash writer,
+            List<Pair<byte[], Optional<V>>> keysAndExpected,
+            Optional<BatId> mirrorBat,
+            TransactionId tid) {
+        if (keysAndExpected.isEmpty())
+            return CompletableFuture.completedFuture(root.right);
+        List<CompletableFuture<Pair<ByteArrayWrapper, byte[]>>> hashFutures = keysAndExpected.stream()
+                .map(p -> {
+                    ByteArrayWrapper key = new ByteArrayWrapper(p.left);
+                    return keyHasher.apply(key).thenApply(h -> new Pair<>(key, h));
+                })
+                .collect(Collectors.toList());
+        Map<ByteArrayWrapper, Optional<V>> expectedMap = new HashMap<>();
+        for (Pair<byte[], Optional<V>> p : keysAndExpected)
+            expectedMap.put(new ByteArrayWrapper(p.left), p.right);
+        return Futures.combineAllInOrder(hashFutures)
+                .thenCompose(keysAndHashes ->
+                    root.left.removeAll(owner, writer, keysAndHashes, expectedMap, 0, BIT_WIDTH,
+                            MAX_HASH_COLLISIONS_PER_LEVEL, mirrorBat, tid, storage, writeHasher, root.right))
                 .thenCompose(newRoot -> commit(writer, newRoot));
     }
 

--- a/src/peergos/shared/user/MutableTree.java
+++ b/src/peergos/shared/user/MutableTree.java
@@ -7,7 +7,9 @@ import peergos.shared.MaybeMultihash;
 import peergos.shared.storage.*;
 
 import java.io.*;
+import java.util.List;
 import java.util.concurrent.*;
+import peergos.shared.util.Pair;
 
 public interface MutableTree {
 
@@ -54,5 +56,15 @@ public interface MutableTree {
                                          byte[] mapKey,
                                          MaybeMultihash existing,
                                          TransactionId tid);
+
+    /**
+     * Remove all specified keys from the writer's CHAMP in a single batch operation.
+     * Substantially faster than N individual {@link #remove} calls.
+     */
+    CompletableFuture<WriterData> removeAll(WriterData base,
+                                             PublicKeyHash owner,
+                                             SigningPrivateKeyAndPublicHash sharingKey,
+                                             List<Pair<byte[], MaybeMultihash>> keysAndExisting,
+                                             TransactionId tid);
 
 }

--- a/src/peergos/shared/user/MutableTreeImpl.java
+++ b/src/peergos/shared/user/MutableTreeImpl.java
@@ -15,6 +15,7 @@ import peergos.shared.util.*;
 
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.stream.*;
 
 public class MutableTreeImpl implements MutableTree {
 	private static final Logger LOG = Logger.getGlobal();
@@ -84,5 +85,22 @@ public class MutableTreeImpl implements MutableTree {
                 .thenApply(root -> LOGGING ? log(root, "TREE.rm " + writer.publicKeyHash + " :== ("
                         + ArrayOps.bytesToHex(mapKey) + ", " + existing + ") CAS(" + base.tree.get() + ", " + root + ")") : root)
                 .thenApply(newTreeRoot -> base.withChamp(newTreeRoot));
+    }
+
+    @Override
+    public CompletableFuture<WriterData> removeAll(WriterData base,
+                                                    PublicKeyHash owner,
+                                                    SigningPrivateKeyAndPublicHash writer,
+                                                    List<Pair<byte[], MaybeMultihash>> keysAndExisting,
+                                                    TransactionId tid) {
+        if (! base.tree.isPresent())
+            throw new IllegalStateException("Tree root not present!");
+        List<Pair<byte[], Optional<CborObject.CborMerkleLink>>> champKeys = keysAndExisting.stream()
+                .map(p -> new Pair<>(p.left, p.right.map(CborObject.CborMerkleLink::new)))
+                .collect(Collectors.toList());
+        return ChampWrapper.create(owner, (Cid) base.tree.get(), Optional.empty(), hasher, dht, writeHasher,
+                        c -> (CborObject.CborMerkleLink) c)
+                .thenCompose(tree -> tree.removeAll(owner, writer, champKeys, Optional.empty(), tid))
+                .thenApply(base::withChamp);
     }
 }

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -2585,15 +2585,51 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                     .thenCompose(updatedVersion -> {
                                         if (! chunk.isDirectory())
                                             return CompletableFuture.completedFuture(updatedVersion);
-                                        return chunk.getDirectChildrenCapabilities(currentCap, updatedVersion, network).thenCompose(childCaps -> {
+                                        return chunk.getDirectChildrenCapabilities(currentCap, current, network).thenCompose(childCaps -> {
                                             List<AbsoluteCapability> childCapList = childCaps.stream()
                                                     .map(c -> c.cap).collect(Collectors.toList());
-                                            return network.retrieveAllMetadata(childCapList, updatedVersion)
-                                                    .thenCompose(ignored -> Futures.reduceAll(childCaps,
-                                                            updatedVersion,
-                                                            (v, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, ourSigner,
-                                                                    tid, hasher, network, v, committer),
-                                                            (x, y) -> y));
+                                            return network.retrieveAllMetadata(childCapList, current)
+                                                    .thenCompose(retrieved -> {
+                                                        Map<ByteArrayWrapper, RetrievedCapability> retrievedMap = new HashMap<>();
+                                                        for (RetrievedCapability rc : retrieved.left)
+                                                            retrievedMap.put(new ByteArrayWrapper(rc.capability.getMapKey()), rc);
+
+                                                        List<NamedAbsoluteCapability> otherCaps = new ArrayList<>();
+                                                        List<CompletableFuture<List<Pair<byte[], Optional<Bat>>>>> locationFutures = new ArrayList<>();
+                                                        Map<ByteArrayWrapper, MaybeMultihash> knownValues = new HashMap<>();
+
+                                                        for (NamedAbsoluteCapability namedCap : childCaps) {
+                                                            WritableAbsoluteCapability wcap = (WritableAbsoluteCapability) namedCap.cap;
+                                                            RetrievedCapability rc = retrievedMap.get(new ByteArrayWrapper(wcap.getMapKey()));
+                                                            if (rc != null) {
+                                                                FileProperties childProps = rc.getProperties();
+                                                                boolean isNormalFile = !rc.fileAccess.isDirectory() && childProps.streamSecret.isPresent();
+                                                                SigningPrivateKeyAndPublicHash childSigner = rc.fileAccess.getSigner(wcap.rBaseKey, wcap.wBaseKey.get(), Optional.of(ourSigner));
+                                                                if (isNormalFile && childSigner.publicKeyHash.equals(ourSigner.publicKeyHash)) {
+                                                                    MaybeMultihash hash = rc.fileAccess.committedHash();
+                                                                    if (hash.isPresent())
+                                                                        knownValues.put(new ByteArrayWrapper(wcap.getMapKey()), hash);
+                                                                    locationFutures.add(getAllChunkLocations(wcap.getMapKey(), wcap.bat, childProps.streamSecret.get(), childProps.chunkCount(), hasher));
+                                                                    continue;
+                                                                }
+                                                            }
+                                                            otherCaps.add(namedCap);
+                                                        }
+
+                                                        return Futures.combineAllInOrder(locationFutures)
+                                                                .thenCompose(allLocLists -> {
+                                                                    List<Pair<byte[], Optional<Bat>>> allLocs = allLocLists.stream()
+                                                                            .flatMap(List::stream)
+                                                                            .collect(Collectors.toList());
+                                                                    CompletableFuture<Snapshot> batchDone = allLocs.isEmpty() ?
+                                                                            Futures.of(updatedVersion) :
+                                                                            network.deleteAllChunksIfPresent(updatedVersion, committer, currentCap.owner, ourSigner, allLocs, knownValues, tid);
+                                                                    return batchDone.thenCompose(v -> Futures.reduceAll(otherCaps, v,
+                                                                            (s, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, ourSigner,
+                                                                                    tid, hasher, network, s, committer),
+                                                                            (x, y) -> y));
+                                                                });
+                                                    });
                                         });
                                     })
                                     .thenCompose(s -> removeSigningKey(ourSigner, signer, currentCap.owner, network, s, committer));
@@ -2644,48 +2680,67 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
         parent.setModified();
         network.disableCommits();
         PublicKeyHash owner = parent.owner();
-        return network.synchronizer.applyComplexUpdate(owner, parent.signingPair(),
+        SigningPrivateKeyAndPublicHash parentSigner = parent.signingPair();
+        // Partition children before the lambda so we can look up CHAMP values using the
+        // pre-removeChildren snapshot (v2). Plain files sharing the parent's writer can be
+        // batch-deleted; directories, links, and cross-writer files are handled per-child.
+        Map<Boolean, List<FileWrapper>> partitioned = childrenToDelete.stream()
+                .collect(Collectors.partitioningBy(f -> !f.isDirectory() && !f.isLink()
+                        && f.getFileProperties() != null
+                        && f.getFileProperties().streamSecret.isPresent()
+                        && f.writableFilePointer().writer.equals(parentSigner.publicKeyHash)));
+        List<FileWrapper> batchableFiles = partitioned.get(true);
+        List<FileWrapper> otherChildren = partitioned.get(false);
+        return network.synchronizer.applyComplexUpdate(owner, parentSigner,
                 (version, c) -> version.withWriter(owner, parent.writer(), network)
-                .thenCompose(v2 -> parent.pointer.fileAccess
-                        .removeChildren(v2, c, childrenToDelete.stream()
-                                        .map(f -> f.isLink() ? f.linkPointer.get().capability : f.getPointer().capability)
-                                        .collect(Collectors.toList()), parent.writableFilePointer(),
-                                parent.entryWriter, network, context.crypto.random, hasher))
-                        .thenCompose(v3 -> {
-                            SigningPrivateKeyAndPublicHash parentSigner = parent.signingPair();
-                            // Partition children: plain files sharing the parent's writer can be batch-deleted
-                            // in a single deleteAllChunksIfPresent call (50 caps per getChampLookup batch).
-                            // Directories, links, and files with a different writer are handled per-child.
-                            Map<Boolean, List<FileWrapper>> partitioned = childrenToDelete.stream()
-                                    .collect(Collectors.partitioningBy(f -> !f.isDirectory() && !f.isLink()
-                                            && f.getFileProperties() != null
-                                            && f.getFileProperties().streamSecret.isPresent()
-                                            && f.writableFilePointer().writer.equals(parentSigner.publicKeyHash)));
-                            List<FileWrapper> batchableFiles = partitioned.get(true);
-                            List<FileWrapper> otherChildren = partitioned.get(false);
-
-                            // Compute all chunk locations for batchable files (pure crypto, no network calls)
-                            return Futures.combineAllInOrder(batchableFiles.stream()
-                                            .map(f -> {
-                                                WritableAbsoluteCapability cap = f.writableFilePointer();
-                                                FileProperties props = f.getFileProperties();
-                                                return getAllChunkLocations(cap.getMapKey(), cap.bat,
-                                                        props.streamSecret.get(), props.chunkCount(), hasher);
-                                            })
-                                            .collect(Collectors.toList()))
-                                    .thenApply(allLocs -> allLocs.stream().flatMap(List::stream).collect(Collectors.toList()))
-                                    .thenCompose(allKeys -> allKeys.isEmpty() ? Futures.of(v3) :
-                                            IpfsTransaction.call(owner,
-                                                    tid -> network.deleteAllChunksIfPresent(v3, c, owner, parentSigner, allKeys, tid),
-                                                    network.dhtClient))
-                                    .thenCompose(v4 -> context.isSecretLink() ? Futures.of(v4) :
-                                            Futures.reduceAll(batchableFiles, v4,
-                                                    (s, f) -> context.sharedWithCache.clearSharedWith(parentPath.resolve(f.getName()), s, c, network),
-                                                    (a, b) -> a.mergeAndOverwriteWith(b)))
-                                    .thenCompose(v4 -> Futures.reduceAll(otherChildren, v4,
-                                            (s, f) -> deleteChild(owner, parent, parentPath, f, s, c, context),
-                                            (a, b) -> a.mergeAndOverwriteWith(b)));
-                        }))
+                .thenCompose(v2 -> {
+                    // Look up committed CHAMP values for batchable files BEFORE removeChildren
+                    // changes the CHAMP root.  retrieveAllMetadata uses the CryptreeCache —
+                    // if the directory was recently displayed this costs 0 network calls (cache
+                    // hits).  The returned RetrievedCapability objects are proper Java objects
+                    // whose committedHash() is guaranteed to return the correct CID, avoiding a
+                    // second bulk getChampLookup round-trip inside deleteAllChunksIfPresent.
+                    // CIDs from R0 remain valid for CAS at R1/R2 because removeChildren only
+                    // updates directory chunk entries, not individual file entries.
+                    return network.retrieveAllMetadata(
+                                    batchableFiles.stream()
+                                            .map(f -> (AbsoluteCapability) f.writableFilePointer())
+                                            .collect(Collectors.toList()), v2)
+                            .thenCompose(retrieved -> {
+                                Map<ByteArrayWrapper, MaybeMultihash> knownValues = new HashMap<>();
+                                for (RetrievedCapability rc : retrieved.left) {
+                                    MaybeMultihash hash = rc.fileAccess.committedHash();
+                                    if (hash.isPresent())
+                                        knownValues.put(new ByteArrayWrapper(rc.capability.getMapKey()), hash);
+                                }
+                                return parent.pointer.fileAccess
+                                        .removeChildren(v2, c, childrenToDelete.stream()
+                                                        .map(f -> f.isLink() ? f.linkPointer.get().capability : f.getPointer().capability)
+                                                        .collect(Collectors.toList()),
+                                                parent.writableFilePointer(),
+                                                parent.entryWriter, network, context.crypto.random, hasher)
+                                        .thenCompose(v3 -> Futures.combineAllInOrder(batchableFiles.stream()
+                                                        .map(f -> {
+                                                            WritableAbsoluteCapability cap = f.writableFilePointer();
+                                                            FileProperties props = f.getFileProperties();
+                                                            return getAllChunkLocations(cap.getMapKey(), cap.bat,
+                                                                    props.streamSecret.get(), props.chunkCount(), hasher);
+                                                        })
+                                                        .collect(Collectors.toList()))
+                                                .thenApply(allLocs -> allLocs.stream().flatMap(List::stream).collect(Collectors.toList()))
+                                                .thenCompose(allKeys -> allKeys.isEmpty() ? Futures.of(v3) :
+                                                        IpfsTransaction.call(owner,
+                                                                tid -> network.deleteAllChunksIfPresent(v3, c, owner, parentSigner, allKeys, knownValues, tid),
+                                                                network.dhtClient))
+                                                .thenCompose(v4 -> context.isSecretLink() ? Futures.of(v4) :
+                                                        Futures.reduceAll(batchableFiles, v4,
+                                                                (s, f) -> context.sharedWithCache.clearSharedWith(parentPath.resolve(f.getName()), s, c, network),
+                                                                (a, b) -> a.mergeAndOverwriteWith(b)))
+                                                .thenCompose(v4 -> Futures.reduceAll(otherChildren, v4,
+                                                        (s, f) -> deleteChild(owner, parent, parentPath, f, s, c, context),
+                                                        (a, b) -> a.mergeAndOverwriteWith(b))));
+                            });
+                }))
                 .thenCompose(s -> parent.getUpdated(s, network));
     }
 


### PR DESCRIPTION
This makes deletion of large folders/files 10x faster. Deleting a folder with 1000 children and an empty local cache has dropped from 260s to 26s.

Future speed up:

*  Push delete to server, which returns all the changed champ blocks, the client verifies, then signs the new root.
