### PR TITLE
Close FileOutputStream in get

### DIFF
--- a/src/peergos/server/cli/CLI.java
+++ b/src/peergos/server/cli/CLI.java
@@ -257,17 +257,18 @@ public class CLI implements Runnable {
 
             AsyncReader reader = peergosFileSystem.reader(remotePath);
             byte[] buf = new byte[Chunk.MAX_SIZE];
-            FileOutputStream fout = new FileOutputStream(localPath.toFile());
-            long fileSize = stat.fileProperties().size;
-            for (long offset = 0; offset < fileSize;) {
-                int read = reader.readIntoArray(buf, 0, Math.min(buf.length, (int) (fileSize - offset))).join();
-                fout.write(buf, 0, read);
-                offset += read;
-                progressConsumer.accept(offset, fileSize);
+            try (FileOutputStream fout = new FileOutputStream(localPath.toFile())) {
+                long fileSize = stat.fileProperties().size;
+                for (long offset = 0; offset < fileSize;) {
+                    int read = reader.readIntoArray(buf, 0, Math.min(buf.length, (int) (fileSize - offset))).join();
+                    fout.write(buf, 0, read);
+                    offset += read;
+                    progressConsumer.accept(offset, fileSize);
+                }
+                writerForProgress.println();
+                writerForProgress.flush();
+                return "Downloaded " + remotePath + " to " + localPath;
             }
-            writerForProgress.println();
-            writerForProgress.flush();
-            return "Downloaded " + remotePath + " to " + localPath;
         }
     }
 


### PR DESCRIPTION
The current code in src/peergos/server/cli/CLI.java likely works fine most of the time, but The resource opened there can leak if get exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Close this if it’s not worth it.
Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.