### PR TITLE
atomic multi-writer commit

### DIFF
--- a/src/peergos/server/corenode/JdbcIpnsAndSocial.java
+++ b/src/peergos/server/corenode/JdbcIpnsAndSocial.java
@@ -228,6 +228,47 @@ public class JdbcIpnsAndSocial {
         }
     }
 
+    public synchronized CompletableFuture<Boolean> setPointers(List<Optional<byte[]>> existing, List<SignedPointerUpdate> updates) {
+        Connection conn = this.conn.get();
+        try {
+            conn.setAutoCommit(false);
+            conn.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
+            if (existing.size() != updates.size())
+                throw new IllegalStateException("Argument mismatch!");
+            for (int i=0; i < updates.size(); i++) {
+                SignedPointerUpdate u = updates.get(i);
+                String writerKey = new String(Base64.getEncoder().encode(u.writer.serialize()));
+                Optional<byte[]> current = existing.get(i);
+                if (current.isPresent()) {
+                    try (PreparedStatement stmt = conn.prepareStatement(IPNS_UPDATE)) {
+                        stmt.setString(1, new String(Base64.getEncoder().encode(u.signed)));
+                        stmt.setString(2, writerKey);
+                        stmt.setString(3, new String(Base64.getEncoder().encode(current.get())));
+                        int changed = stmt.executeUpdate();
+                        if (changed == 0) {
+                            conn.rollback();
+                            conn.setAutoCommit(true);
+                            return CompletableFuture.completedFuture(false);
+                        }
+                    }
+                } else {
+                    try (PreparedStatement stmt = conn.prepareStatement(IPNS_CREATE)) {
+                        stmt.setString(1, writerKey);
+                        stmt.setString(2, new String(Base64.getEncoder().encode(u.signed)));
+                        stmt.executeUpdate();
+                    }
+                }
+            }
+            conn.commit();
+            conn.setAutoCommit(true);
+            return CompletableFuture.completedFuture(true);
+        } catch (SQLException sqe) {
+            try { conn.rollback(); conn.setAutoCommit(true); } catch (SQLException ignored) {}
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            return Futures.errored(new RuntimeException(sqe));
+        }
+    }
+
     public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash writingKey) {
         try (Connection conn = getConnection();
              PreparedStatement stmt = conn.prepareStatement(IPNS_GET)) {

--- a/src/peergos/server/corenode/UserRepository.java
+++ b/src/peergos/server/corenode/UserRepository.java
@@ -17,6 +17,7 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 public class UserRepository implements SocialNetwork, MutablePointers {
     public static final int MAX_POINTER_SIZE = TweetNaCl.SIGNATURE_SIZE_BYTES + 2 + 2*36 + 9; // Signature overhead + 2 cids + 2 (cbor list[3]) + cbor long
@@ -95,6 +96,46 @@ public class UserRepository implements SocialNetwork, MutablePointers {
                             }
                         }));
 
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        // Validate all signatures and CAS constraints concurrently, then write atomically.
+        List<CompletableFuture<Optional<byte[]>>> validations = updates.stream()
+                .map(u -> validateUpdate(owner, u))
+                .collect(Collectors.toList());
+        return Futures.combineAllInOrder(validations)
+                .thenCompose(current -> store.setPointers(current, updates));
+    }
+
+    private CompletableFuture<Optional<byte[]>> validateUpdate(PublicKeyHash owner, SignedPointerUpdate u) {
+        return getPointer(owner, u.writer)
+                .thenCompose(current -> ipfs.getSigningKey(owner, u.writer)
+                        .thenCompose(writerOpt -> {
+                            try {
+                                if (u.signed.length > MAX_POINTER_SIZE)
+                                    throw new IllegalStateException("Pointer update too big! " + u.signed.length);
+                                if (!writerOpt.isPresent())
+                                    throw new IllegalStateException("Couldn't retrieve writer key from ipfs with hash " + u.writer);
+                                PublicSigningKey writerKey = writerOpt.get();
+                                byte[] bothHashes = writerKey.unsignMessage(u.signed).join();
+                                PointerUpdate cas = PointerUpdate.fromCbor(CborObject.fromByteArray(bothHashes));
+                                return MutablePointers.isValidUpdate(writerKey, current, cas.original, cas.sequence)
+                                        .thenCompose(x -> {
+                                            if (cas.updated.isPresent()) {
+                                                Multihash newHash = cas.updated.get();
+                                                CommittedWriterData newWriterData = DeletableContentAddressedStorage
+                                                        .getWriterData(us, owner, (Cid) newHash, cas.sequence, false, (Cid) us.get(0), hasher, ipfs).join();
+                                                if (!newWriterData.props.get().controller.equals(u.writer))
+                                                    throw new IllegalStateException("WriterData controller mismatch for " + u.writer);
+                                            }
+                                            return Futures.of(current);
+                                        });
+                            } catch (TweetNaCl.InvalidSignatureException e) {
+                                System.err.println("Invalid signature during setPointers for writer: " + u.writer);
+                                return Futures.<Optional<byte[]>>errored(e);
+                            }
+                        }));
     }
 
     @Override

--- a/src/peergos/server/mutable/BlockingMutablePointers.java
+++ b/src/peergos/server/mutable/BlockingMutablePointers.java
@@ -5,6 +5,7 @@ import peergos.shared.mutable.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 public class BlockingMutablePointers implements MutablePointers {
     private final MutablePointers source;
@@ -22,6 +23,18 @@ public class BlockingMutablePointers implements MutablePointers {
         CompletableFuture<Boolean> res = new CompletableFuture<>();
         res.completeExceptionally(new IllegalStateException("This Peergos subspace has been banned from this server"));
         return res;
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        for (SignedPointerUpdate u : updates) {
+            if (!blacklist.isAllowed(u.writer)) {
+                CompletableFuture<Boolean> res = new CompletableFuture<>();
+                res.completeExceptionally(new IllegalStateException("This Peergos subspace has been banned from this server"));
+                return res;
+            }
+        }
+        return source.setPointers(owner, updates);
     }
 
     @Override

--- a/src/peergos/server/mutable/MutableEventPropagator.java
+++ b/src/peergos/server/mutable/MutableEventPropagator.java
@@ -35,6 +35,22 @@ public class MutableEventPropagator implements MutablePointers {
     }
 
     @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        return target.setPointers(owner, updates)
+                .thenApply(res -> {
+                    if (res) {
+                        for (SignedPointerUpdate u : updates) {
+                            MutableEvent event = new MutableEvent(owner, u.writer, u.signed);
+                            for (Consumer<? super MutableEvent> listener : listeners) {
+                                listener.accept(event);
+                            }
+                        }
+                    }
+                    return res;
+                });
+    }
+
+    @Override
     public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash owner, PublicKeyHash writer) {
         return target.getPointer(owner, writer);
     }

--- a/src/peergos/server/mutable/NonWriteThroughMutablePointers.java
+++ b/src/peergos/server/mutable/NonWriteThroughMutablePointers.java
@@ -4,9 +4,11 @@ import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.mutable.*;
 import peergos.shared.storage.*;
+import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 public class NonWriteThroughMutablePointers implements MutablePointers {
 
@@ -49,6 +51,27 @@ public class NonWriteThroughMutablePointers implements MutablePointers {
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
         }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        // Validate all updates first (all-or-nothing), then apply
+        try {
+            for (SignedPointerUpdate u : updates) {
+                if (!modifications.containsKey(u.writer)) {
+                    Optional<byte[]> existing = source.getPointer(owner, u.writer).get();
+                    existing.ifPresent(val -> modifications.put(u.writer, val));
+                }
+                Optional<PublicSigningKey> opt = storage.getSigningKey(owner, u.writer).get();
+                if (!opt.isPresent())
+                    throw new IllegalStateException("Couldn't retrieve signing key!");
+                MutablePointers.isValidUpdate(opt.get(), Optional.ofNullable(modifications.get(u.writer)), u.signed).get();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+        updates.forEach(u -> modifications.put(u.writer, u.signed));
+        return Futures.of(true);
     }
 
     @Override

--- a/src/peergos/server/net/MutationHandler.java
+++ b/src/peergos/server/net/MutationHandler.java
@@ -3,6 +3,7 @@ package peergos.server.net;
 import com.sun.net.httpserver.*;
 import peergos.server.*;
 import peergos.server.util.*;
+import peergos.shared.cbor.CborObject;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.mutable.*;
 import peergos.shared.util.*;
@@ -42,7 +43,6 @@ public class MutationHandler implements HttpHandler {
 
         Map<String, List<String>> params = HttpUtil.parseQuery(exchange.getRequestURI().getQuery());
         PublicKeyHash owner = PublicKeyHash.fromString(params.get("owner").get(0));
-        PublicKeyHash writer = PublicKeyHash.fromString(params.get("writer").get(0));
         try {
             if (! HttpUtil.allowedQuery(exchange, isPublicServer)) {
                 exchange.sendResponseHeaders(405, 0);
@@ -50,17 +50,28 @@ public class MutationHandler implements HttpHandler {
             }
 
             switch (method) {
-                case "setPointer":
+                case "setPointer": {
                     AggregatedMetrics.MUTABLE_POINTERS_SET.inc();
+                    PublicKeyHash writer = PublicKeyHash.fromString(params.get("writer").get(0));
                     byte[] signedPayload = Serialize.readFully(din, 1024);
                     boolean isAdded = mutable.setPointer(owner, writer, signedPayload).get();
                     dout.writeBoolean(isAdded);
                     break;
-                case "getPointer":
+                }
+                case "setPointers": {
+                    AggregatedMetrics.MUTABLE_POINTERS_SET.inc();
+                    MultiWriterCommit updates = MultiWriterCommit.fromCbor(CborObject.read(din, 1024*1024));
+                    boolean isAdded = mutable.setPointers(owner, updates.updates).get();
+                    dout.writeBoolean(isAdded);
+                    break;
+                }
+                case "getPointer": {
                     AggregatedMetrics.MUTABLE_POINTERS_GET.inc();
+                    PublicKeyHash writer = PublicKeyHash.fromString(params.get("writer").get(0));
                     byte[] metadataBlob = mutable.getPointer(owner, writer).get().orElse(new byte[0]);
                     dout.write(metadataBlob);
                     break;
+                }
                 default:
                     throw new IOException("Unknown method in mutable pointers!");
             }

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -26,6 +26,7 @@ import peergos.shared.crypto.asymmetric.mlkem.HybridCurve25519MLKEMPublicKey;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.server.*;
+import peergos.shared.hamt.ChampWrapper;
 import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.io.ipfs.bases.Charsets;
@@ -2302,6 +2303,110 @@ public abstract class UserTests {
         Assert.assertTrue("File truncated", nonZeroBytes == bytes.length);
 
 
+    }
+
+    @Test
+    public void deleteWithOwnSubtreeWriterLeavesNoOrphanedChampEntries() throws Exception {
+        String username = generateUsername();
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, "test01", network, crypto);
+        FileWrapper userRoot = context.getUserRoot().get();
+
+        // Create toDelete/ and give it its own signing key (writer W) so this becomes a
+        // multi-writer delete
+        userRoot.mkdir("toDelete", context.network, false, userRoot.mirrorBatId(), context.crypto).get();
+        String toDeletePath = "/" + username + "/toDelete";
+        context.shareWriteAccessWith(PathUtil.get(toDeletePath), Collections.emptySet()).join();
+
+        // Upload files after shareWriteAccessWith so they live in W's CHAMP, not P's.
+        FileWrapper freshToDelete = context.getByPath(toDeletePath).get().get();
+        byte[] data = "hello".getBytes();
+        uploadFileSection(freshToDelete, "a.txt", new AsyncReader.ArrayBacked(data), 0, data.length,
+                context.network, context.crypto, l -> {}).get();
+        uploadFileSection(freshToDelete, "b.txt", new AsyncReader.ArrayBacked(data), 0, data.length,
+                context.network, context.crypto, l -> {}).get();
+
+        // Build a network backed by the same storage but with a mutable-pointer layer that
+        // throws after the FIRST successful setPointer call, simulating a crash between the
+        // two sequential writer pointer updates in BufferedNetworkAccess.commit().
+        AtomicInteger pointerCommits = new AtomicInteger(0);
+        MutablePointers failAfterFirst = new MutablePointers() {
+            @Override
+            public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash owner, PublicKeyHash writer) {
+                return service.mutable.getPointer(owner, writer);
+            }
+            @Override
+            public CompletableFuture<Boolean> setPointer(PublicKeyHash owner, PublicKeyHash writer, byte[] signed) {
+                if (pointerCommits.incrementAndGet() > 1)
+                    return Futures.errored(new RuntimeException("Simulated crash after 1st pointer commit"));
+                return service.mutable.setPointer(owner, writer, signed);
+            }
+            @Override
+            public MutablePointers clearCache() {
+                return this;
+            }
+        };
+        NetworkAccess deleteNetwork = NetworkAccess.buildBuffered(service.storage, service.bats,
+                service.coreNode, service.account, failAfterFirst, 0, service.social,
+                service.controller, service.usage, service.serverMessages,
+                crypto.hasher, Arrays.asList("peergos"), false);
+        UserContext deleteContext = PeergosNetworkUtils.ensureSignedUp(username, "test01", deleteNetwork, crypto);
+
+        FileWrapper deleteParent = deleteContext.getByPath("/" + username).get().get();
+        FileWrapper deleteToDelete = deleteContext.getByPath(toDeletePath).get().get();
+        PublicKeyHash owner = deleteParent.owner();
+        PublicKeyHash writerW = deleteToDelete.writer();
+
+        // Run the actual delete — it must throw after the first pointer commit.
+        try {
+            FileWrapper.deleteChildren(deleteParent, Collections.singleton(deleteToDelete),
+                    PathUtil.get("/" + username), deleteContext).get();
+            Assert.fail("Expected delete to fail after first pointer commit");
+        } catch (ExecutionException expected) { }
+
+        // Enumerate all CHAMP entries committed for writer W
+        Set<ByteArrayWrapper> champKeysW = getAllChampKeys(owner, writerW, deleteContext);
+
+        // Enumerate every map key reachable by DFS from the filesystem root
+        FileWrapper updatedRoot = deleteContext.getByPath("/" + username).get().get();
+        Set<ByteArrayWrapper> reachableKeys = collectReachableMapKeys(updatedRoot,
+                deleteContext.crypto.hasher, deleteContext.network);
+
+        // Any key in W's CHAMP not reachable from the filesystem root is an orphan
+        Set<ByteArrayWrapper> orphaned = new HashSet<>(champKeysW);
+        orphaned.removeAll(reachableKeys);
+
+        Assert.assertTrue("No orphaned CHAMP entries in W's tree after partial delete",
+                orphaned.isEmpty());
+    }
+
+    private static Set<ByteArrayWrapper> getAllChampKeys(PublicKeyHash owner, PublicKeyHash writer, UserContext ctx) {
+        WriterData wd = WriterData.getWriterData(owner, writer, ctx.network.mutable, ctx.network.dhtClient).join().props.get();
+        if (!wd.tree.isPresent())
+            return Collections.emptySet();
+        Set<ByteArrayWrapper> keys = new HashSet<>();
+        ChampWrapper.create(owner, (Cid) wd.tree.get(), Optional.empty(),
+                k -> Futures.of(k.data),
+                ctx.network.dhtClient, ctx.crypto.hasher,
+                c -> (CborObject.CborMerkleLink) c).join()
+                .applyToAllMappings(owner, pair -> {
+                    keys.add(pair.left);
+                    return Futures.of(true);
+                }).join();
+        return keys;
+    }
+
+    private static Set<ByteArrayWrapper> collectReachableMapKeys(FileWrapper f, Hasher hasher, NetworkAccess network) {
+        Set<ByteArrayWrapper> result = new HashSet<>();
+        result.add(new ByteArrayWrapper(f.getPointer().capability.getMapKey()));
+        if (f.isDirectory()) {
+            try {
+                f.getChildren(hasher, network).join()
+                        .forEach(child -> result.addAll(collectReachableMapKeys(child, hasher, network)));
+            } catch (Exception e) {
+                // directory entry exists in listing but its blocks are gone — dead reference, not orphan
+            }
+        }
+        return result;
     }
 
     public static String randomString() {

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -2341,6 +2341,13 @@ public abstract class UserTests {
                 return service.mutable.setPointer(owner, writer, signed);
             }
             @Override
+            public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+                // Simulate an old server: apply sequentially, crashing after the first commit
+                return Futures.reduceAll(updates, true,
+                        (b, u) -> setPointer(owner, u.writer, u.signed),
+                        (a, b) -> a && b);
+            }
+            @Override
             public MutablePointers clearCache() {
                 return this;
             }

--- a/src/peergos/shared/BufferedNetworkAccess.java
+++ b/src/peergos/shared/BufferedNetworkAccess.java
@@ -20,6 +20,7 @@ import peergos.shared.util.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
+import java.util.stream.*;
 
 /** This will buffer block writes, and mutable pointer updates and commit in bulk
  *
@@ -171,6 +172,45 @@ public class BufferedNetworkAccess extends NetworkAccess {
         return Futures.of(true);
     }
 
+    /** Commit a single writer's pointer with CAS merge fallback */
+    private CompletableFuture<Boolean> commitPointerWithMerge(
+            PublicKeyHash owner,
+            Pair<BufferedPointers.WriterUpdate, Optional<CommittedWriterData>> u,
+            Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> writers,
+            TransactionId tid) {
+        return Futures.asyncExceptionally(
+                () -> pointerBuffer.commit(owner, writers.get(u.left.writer),
+                        new PointerUpdate(u.left.prevHash, u.left.currentHash, u.left.currentSequence)),
+                conflictT -> {
+                    Throwable conflictCause = Exceptions.getRootCause(conflictT);
+                    if (!(conflictCause instanceof PointerCasException))
+                        return Futures.errored(conflictT);
+                    PointerCasException cas = (PointerCasException) conflictCause;
+                    MaybeMultihash actualExisting = cas.existing;
+                    if (actualExisting.equals(u.left.currentHash))
+                        return Futures.of(true);
+                    return WriterData.getWriterData(owner, (Cid) u.left.prevHash.get(), Optional.empty(), blockBuffer)
+                            .thenCompose(original -> WriterData.getWriterData(owner, (Cid) u.left.currentHash.get(), Optional.empty(), blockBuffer)
+                                    .thenCompose(updated -> WriterData.getWriterData(owner, (Cid) actualExisting.get(), Optional.empty(), blockBuffer)
+                                            .thenCompose(remote -> ChampUtil.merge(owner, writers.get(u.left.writer),
+                                                            MaybeMultihash.of(original.props.get().tree.get()),
+                                                            MaybeMultihash.of(updated.props.get().tree.get()),
+                                                            MaybeMultihash.of(remote.props.get().tree.get()),
+                                                            Optional.empty(), tid, ChampWrapper.BIT_WIDTH,
+                                                            ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, y -> Futures.of(y.data),
+                                                            c -> (CborObject.CborMerkleLink) c, blockBuffer, hasher)
+                                                    .thenApply(p -> remote.props.get().withChamp(p.right)))))
+                            .thenCompose(newWD -> {
+                                Optional<Long> seq = cas.sequence;
+                                return blockBuffer.put(owner, writers.get(u.left.writer), newWD.serialize(), hasher, tid)
+                                        .thenCompose(mergedRoot -> blockBuffer.signBlocks(writers)
+                                                .thenCompose(signedMore -> blockBuffer.commit(owner, u.left.writer, tid, signedMore))
+                                                .thenCompose(z -> pointerBuffer.commit(owner, writers.get(u.left.writer),
+                                                        new PointerUpdate(actualExisting, MaybeMultihash.of(mergedRoot), seq.map(s -> s + 1)))));
+                            });
+                });
+    }
+
     @Override
     public synchronized CompletableFuture<Boolean> commit(PublicKeyHash owner, Supplier<Boolean> commitWatcher) {
         List<BufferedPointers.WriterUpdate> writerUpdates = pointerBuffer.getUpdates();
@@ -183,57 +223,52 @@ public class BufferedNetworkAccess extends NetworkAccess {
         blockBuffer.gc(roots);
         Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> writers = pointerBuffer.getSigners();
         List<Pair<BufferedPointers.WriterUpdate, Optional<CommittedWriterData>>> writes = blockBuffer.getAllWriterData(writerUpdates);
+
+        boolean hasNewWriters = writes.stream().anyMatch(u -> !u.left.prevHash.isPresent());
+
         CompletableFuture<Boolean> res = new CompletableFuture<>();
         blockBuffer.signBlocks(writers)
                 .thenCompose(signed -> blockBuffer.target().startTransaction(owner)
-                        .thenCompose(tid -> Futures.reduceAll(writes.stream(), true, (a,u) ->
-                                        blockBuffer.commit(owner, u.left.writer, tid, signed)
-                                                .thenCompose(b -> Futures.asyncExceptionally(
-                                                                () -> pointerBuffer.commit(owner, writers.get(u.left.writer),
-                                                                        new PointerUpdate(u.left.prevHash, u.left.currentHash, u.left.currentSequence)),
-                                                                t -> {
-                                                                    Throwable cause = Exceptions.getRootCause(t);
-                                                                    if (cause instanceof PointerCasException) {
-                                                                        PointerCasException cas = (PointerCasException) cause;
-                                                                        MaybeMultihash actualExisting = cas.existing;
-                                                                        // Server is already at the hash we wanted to set: a previous timed-out attempt succeeded
-                                                                        if (actualExisting.equals(u.left.currentHash))
-                                                                            return Futures.of(true);
-                                                                        return WriterData.getWriterData(owner, (Cid) u.left.prevHash.get(), Optional.empty(), blockBuffer)
-                                                                                .thenCompose(original -> WriterData.getWriterData(owner, (Cid) u.left.currentHash.get(), Optional.empty(), blockBuffer)
-                                                                                        .thenCompose(updated -> WriterData.getWriterData(owner, (Cid) actualExisting.get(), Optional.empty(), blockBuffer)
-                                                                                                .thenCompose(remote -> ChampUtil.merge(owner, writers.get(u.left.writer),
-                                                                                                                MaybeMultihash.of(original.props.get().tree.get()),
-                                                                                                                MaybeMultihash.of(updated.props.get().tree.get()),
-                                                                                                                MaybeMultihash.of(remote.props.get().tree.get()),
-                                                                                                                Optional.empty(), tid, ChampWrapper.BIT_WIDTH,
-                                                                                                                ChampWrapper.MAX_HASH_COLLISIONS_PER_LEVEL, x -> Futures.of(x.data),
-                                                                                                                c -> (CborObject.CborMerkleLink)c, blockBuffer, hasher)
-                                                                                                        .thenApply(p -> remote.props.get().withChamp(p.right)))))
-                                                                                .thenCompose(newWD -> {
-                                                                                    // 1. write the new writer data for the merged champs
-                                                                                    // 2. flush the blocks
-                                                                                    // 3. commit the new pointer
-                                                                                    Optional<Long> seq = cas.sequence;
-                                                                                    return blockBuffer.put(owner, writers.get(u.left.writer), newWD.serialize(), hasher, tid)
-                                                                                            .thenCompose(mergedRoot -> blockBuffer.signBlocks(writers)
-                                                                                                    .thenCompose(signedMore -> blockBuffer.commit(owner, u.left.writer, tid, signedMore))
-                                                                                                    .thenCompose(x -> pointerBuffer.commit(owner, writers.get(u.left.writer),
-                                                                                                            new PointerUpdate(actualExisting, MaybeMultihash.of(mergedRoot), seq.map(s -> s + 1)))));
-                                                                                });
-                                                                    }
-                                                                    return Futures.errored(t);
-                                                                }
-                                                        )
-                                                        .thenCompose(x -> u.right
-                                                                .map(cwd -> synchronizer.updateWriterState(owner, u.left.writer, new Snapshot(u.left.writer, cwd)))
-                                                                .orElse(Futures.of(true)))), (x,y) -> x && y)
-                                .thenCompose(x -> blockBuffer.target().closeTransaction(owner, tid))
-                                .thenApply(x -> {
-                                    pointerBuffer.clear();
-                                    blockBuffer.clear();
-                                    return commitWatcher.get();
-                                }))).thenApply(res::complete)
+                        .thenCompose(tid -> (hasNewWriters
+                                // Sequential path: preserves the invariant that parent pointer commits before child blocks
+                                ? Futures.reduceAll(writes.stream(), true,
+                                        (a, u) -> blockBuffer.commit(owner, u.left.writer, tid, signed)
+                                                .thenCompose(b -> commitPointerWithMerge(owner, u, writers, tid)),
+                                        (x, y) -> x && y)
+                                // Atomic path: no new writers, commit all pointer updates in one transaction
+                                : Futures.reduceAll(writes.stream(), true,
+                                        (a, u) -> blockBuffer.commit(owner, u.left.writer, tid, signed),
+                                        (x, y) -> x && y)
+                                .thenCompose(x -> Futures.combineAllInOrder(writes.stream()
+                                        .map(u -> writers.get(u.left.writer).secret
+                                                .signMessage(new PointerUpdate(u.left.prevHash, u.left.currentHash, u.left.currentSequence).serialize())
+                                                .thenApply(sig -> new SignedPointerUpdate(u.left.writer, sig)))
+                                        .collect(Collectors.toList())))
+                                .thenCompose(batch -> Futures.asyncExceptionally(
+                                        () -> mutable.setPointers(owner, batch).thenApply(ok -> {
+                                            pointerBuffer.recordCommitted(writes.stream().map(u -> u.left).collect(Collectors.toList()));
+                                            return ok;
+                                        }),
+                                        t -> {
+                                            Throwable cause = Exceptions.getRootCause(t);
+                                            if (!(cause instanceof PointerCasException))
+                                                return Futures.errored(t);
+                                            return Futures.reduceAll(writes.stream(), true,
+                                                    (a, u) -> commitPointerWithMerge(owner, u, writers, tid),
+                                                    (x, y) -> x && y);
+                                        }
+                                )))
+                        .thenCompose(ok -> Futures.reduceAll(writes.stream(), true,
+                                (a, u) -> u.right
+                                        .map(cwd -> synchronizer.updateWriterState(owner, u.left.writer, new Snapshot(u.left.writer, cwd)))
+                                        .orElse(Futures.of(true)),
+                                (x, y) -> x && y))
+                        .thenCompose(x -> blockBuffer.target().closeTransaction(owner, tid))
+                        .thenApply(x -> {
+                            pointerBuffer.clear();
+                            blockBuffer.clear();
+                            return commitWatcher.get();
+                        }))).thenApply(res::complete)
                 .exceptionally(t -> {
                     pointerBuffer.clear();
                     blockBuffer.clear();

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -44,6 +44,12 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     }
 
     @Override
+    public synchronized CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        updates.forEach(u -> operations.add(Either.a(new PointerWrite(u.writer, u.signed))));
+        return Futures.of(true);
+    }
+
+    @Override
     public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash owner, PublicKeyHash writer) {
         for (int i= operations.size() - 1; i>=0; i--) {
             Either<PointerWrite, BlockWrite> op = operations.get(i);

--- a/src/peergos/shared/mutable/BufferedPointers.java
+++ b/src/peergos/shared/mutable/BufferedPointers.java
@@ -136,6 +136,11 @@ public class BufferedPointers implements MutablePointers {
         throw new IllegalStateException("Shouldn't get here!");
     }
 
+    @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        throw new IllegalStateException("Shouldn't get here!");
+    }
+
     public List<Cid> getRoots() {
         synchronized (writerUpdates) {
             return writerUpdates.stream()
@@ -160,6 +165,10 @@ public class BufferedPointers implements MutablePointers {
     @Override
     public MutablePointers clearCache() {
         return new BufferedPointers(target.clearCache());
+    }
+
+    public void recordCommitted(List<WriterUpdate> updates) {
+        updates.forEach(u -> lastCommits.put(u.writer, u));
     }
 
     public void clear() {

--- a/src/peergos/shared/mutable/CachingPointers.java
+++ b/src/peergos/shared/mutable/CachingPointers.java
@@ -85,6 +85,24 @@ public class CachingPointers implements MutablePointers {
     }
 
     @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        synchronized (cache) {
+            updates.forEach(u -> cache.remove(u.writer));
+        }
+        synchronized (targetCache) {
+            updates.forEach(u -> targetCache.remove(u.writer));
+        }
+        return target.setPointers(owner, updates).thenApply(res -> {
+            if (res) {
+                synchronized (cache) {
+                    updates.forEach(u -> cache.put(u.writer, new Pair<>(Optional.of(u.signed), System.currentTimeMillis())));
+                }
+            }
+            return res;
+        });
+    }
+
+    @Override
     public MutablePointers clearCache() {
         synchronized (cache) {
             cache.clear();

--- a/src/peergos/shared/mutable/HttpMutablePointers.java
+++ b/src/peergos/shared/mutable/HttpMutablePointers.java
@@ -10,6 +10,7 @@ import peergos.shared.util.*;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 public class HttpMutablePointers implements MutablePointersProxy {
 	private static final Logger LOG = Logger.getLogger(HttpMutablePointers.class.getName());
@@ -107,6 +108,31 @@ public class HttpMutablePointers implements MutablePointersProxy {
             if (LOGGING)
                 LOG.info("HttpMutablePointers.get took " + (t2 -t1) + "mS for (" + owner + ", " + writer + ")");
         }
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        return setPointers(directUrlPrefix, direct, owner, updates);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> setPointers(Multihash targetId, PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        return setPointers(getProxyUrlPrefix(targetId), p2p, owner, updates);
+    }
+
+    private CompletableFuture<Boolean> setPointers(String urlPrefix,
+                                                   HttpPoster poster,
+                                                   PublicKeyHash owner,
+                                                   List<SignedPointerUpdate> updates) {
+        return poster.postUnzip(urlPrefix + Constants.MUTABLE_POINTERS_URL + "setPointers?owner=" + owner,
+                new MultiWriterCommit(updates).serialize(), 60_000).thenApply(res -> {
+            DataInputStream din = new DataInputStream(new ByteArrayInputStream(res));
+            try {
+                return din.readBoolean();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
     }
 
     @Override

--- a/src/peergos/shared/mutable/MultiWriterCommit.java
+++ b/src/peergos/shared/mutable/MultiWriterCommit.java
@@ -1,0 +1,30 @@
+package peergos.shared.mutable;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class MultiWriterCommit implements Cborable {
+    public final List<SignedPointerUpdate> updates;
+
+    public MultiWriterCommit(List<SignedPointerUpdate> updates) {
+        this.updates = updates;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("p", new CborObject.CborList(updates));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static MultiWriterCommit fromCbor(Cborable cbor) {
+        if (!(cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for MultiWriterCommit! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new MultiWriterCommit(m.getList("p", SignedPointerUpdate::fromCbor));
+    }
+}

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -12,6 +12,7 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.stream.*;
 
 public interface MutablePointers {
 
@@ -23,6 +24,11 @@ public interface MutablePointers {
      * @return True when successfully completed
      */
     CompletableFuture<Boolean> setPointer(PublicKeyHash owner, PublicKeyHash writer, byte[] writerSignedBtreeRootHash);
+
+    /** Atomically update the hashes for a set of writers under the same owner.
+     *  All updates succeed or none do.
+     */
+    CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates);
 
     default CompletableFuture<Boolean> setPointer(PublicKeyHash owner, SigningPrivateKeyAndPublicHash writer, PointerUpdate casUpdate) {
         return writer.secret.signMessage(casUpdate.serialize())

--- a/src/peergos/shared/mutable/MutablePointersProxy.java
+++ b/src/peergos/shared/mutable/MutablePointersProxy.java
@@ -29,4 +29,6 @@ public interface MutablePointersProxy extends MutablePointers {
      */
     CompletableFuture<Optional<byte[]>> getPointer(Multihash targetServerId, PublicKeyHash owner, PublicKeyHash writer);
 
+    CompletableFuture<Boolean> setPointers(Multihash targetServerId, PublicKeyHash owner, List<SignedPointerUpdate> updates);
+
 }

--- a/src/peergos/shared/mutable/OfflinePointerCache.java
+++ b/src/peergos/shared/mutable/OfflinePointerCache.java
@@ -34,6 +34,19 @@ public class OfflinePointerCache implements MutablePointers {
     }
 
     @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        return target.setPointers(owner, updates).thenApply(res -> {
+            if (res) {
+                updates.forEach(u -> {
+                    ramCache.put(u.writer, u.signed);
+                    cache.put(owner, u.writer, u.signed);
+                });
+            }
+            return res;
+        });
+    }
+
+    @Override
     public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash owner, PublicKeyHash writer) {
         return Futures.asyncExceptionally(() -> {
                     if (online.isOnline()) {

--- a/src/peergos/shared/mutable/ProxyingMutablePointers.java
+++ b/src/peergos/shared/mutable/ProxyingMutablePointers.java
@@ -31,6 +31,15 @@ public class ProxyingMutablePointers implements MutablePointers {
     }
 
     @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        return Proxy.redirectCall(core,
+                serverIds,
+                owner,
+                () -> local.setPointers(owner, updates),
+                target -> p2p.setPointers(target, owner, updates));
+    }
+
+    @Override
     public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash owner, PublicKeyHash writer) {
         return Proxy.redirectCall(core,
                 serverIds,

--- a/src/peergos/shared/mutable/RetryMutablePointers.java
+++ b/src/peergos/shared/mutable/RetryMutablePointers.java
@@ -69,6 +69,11 @@ public class RetryMutablePointers implements MutablePointers {
     }
 
     @Override
+    public CompletableFuture<Boolean> setPointers(PublicKeyHash owner, List<SignedPointerUpdate> updates) {
+        return runWithRetry(() -> target.setPointers(owner, updates));
+    }
+
+    @Override
     public CompletableFuture<Optional<byte[]>> getPointer(PublicKeyHash owner, PublicKeyHash writer) {
         return runWithRetry(() -> target.getPointer(owner, writer));
     }

--- a/src/peergos/shared/mutable/SignedPointerUpdate.java
+++ b/src/peergos/shared/mutable/SignedPointerUpdate.java
@@ -1,0 +1,33 @@
+package peergos.shared.mutable;
+
+import peergos.shared.cbor.CborObject;
+import peergos.shared.cbor.Cborable;
+import peergos.shared.crypto.hash.PublicKeyHash;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class SignedPointerUpdate implements Cborable {
+    public final PublicKeyHash writer;
+    public final byte[] signed;
+
+    public SignedPointerUpdate(PublicKeyHash writer, byte[] signed) {
+        this.writer = writer;
+        this.signed = signed;
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("w", writer);
+        state.put("s", new CborObject.CborByteArray(signed));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static SignedPointerUpdate fromCbor(Cborable cbor) {
+        if (! (cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for SignedPointerUpdate! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new SignedPointerUpdate(m.get("w", PublicKeyHash::fromCbor), m.get("s", c -> ((CborObject.CborByteArray)c).value));
+    }
+}

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -2572,67 +2572,95 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                             Optional<byte[]> streamSecret = props.streamSecret;
 
                             boolean normalFile = ! chunk.isDirectory() && streamSecret.isPresent();
-                            return (normalFile ?
-                                    deleteFileChunks(props.streamSecret.get(), props.chunkCount(), currentCap, ourSigner, tid, hasher, network, current, committer) :
-                                    network.deleteChunk(current, committer, chunk, currentCap.owner,
-                                                    currentCap.getMapKey(), ourSigner, tid)
-                                            .thenCompose(deletedVersion -> {
-                                                return chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
-                                                        currentCap.getMapKey(), currentCap.bat, hasher).thenCompose(nextChunkMapKeyAndBat ->
-                                                        deleteAllChunks(currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right), ourSigner, tid, hasher,
-                                                                network, deletedVersion, committer));
-                                            }))
-                                    .thenCompose(updatedVersion -> {
-                                        if (! chunk.isDirectory())
-                                            return CompletableFuture.completedFuture(updatedVersion);
-                                        return chunk.getDirectChildrenCapabilities(currentCap, current, network).thenCompose(childCaps -> {
-                                            List<AbsoluteCapability> childCapList = childCaps.stream()
-                                                    .map(c -> c.cap).collect(Collectors.toList());
-                                            return network.retrieveAllMetadata(childCapList, current)
-                                                    .thenCompose(retrieved -> {
-                                                        Map<ByteArrayWrapper, RetrievedCapability> retrievedMap = new HashMap<>();
-                                                        for (RetrievedCapability rc : retrieved.left)
-                                                            retrievedMap.put(new ByteArrayWrapper(rc.capability.getMapKey()), rc);
+                            if (normalFile)
+                                return deleteFileChunks(props.streamSecret.get(), props.chunkCount(), currentCap, ourSigner, tid, hasher, network, current, committer)
+                                        .thenCompose(s -> removeSigningKey(ourSigner, signer, currentCap.owner, network, s, committer));
+                            if (! chunk.isDirectory())
+                                // legacy file without stream secret
+                                return network.deleteChunk(current, committer, chunk, currentCap.owner,
+                                                        currentCap.getMapKey(), ourSigner, tid)
+                                                .thenCompose(deletedVersion -> chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
+                                                                currentCap.getMapKey(), currentCap.bat, hasher)
+                                                        .thenCompose(nextChunkMapKeyAndBat ->
+                                                                deleteAllChunks(currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right), ourSigner, tid, hasher,
+                                                                        network, deletedVersion, committer)))
+                                        .thenCompose(s -> removeSigningKey(ourSigner, signer, currentCap.owner, network, s, committer));
+                            // Directory: bottom-up. Collect children from ALL chunks first so that
+                            // descendants are committed before the directory's own CHAMP entries.
+                            // Any partial commit then leaves only reachable entries in the CHAMP.
+                            return chunk.getAllChildrenCapabilities(current, currentCap, hasher, network)
+                                    .thenCompose(childCaps -> {
+                                        List<AbsoluteCapability> childCapList = childCaps.stream()
+                                                .map(c -> c.cap).collect(Collectors.toList());
+                                        return network.retrieveAllMetadata(childCapList, current)
+                                                .thenCompose(retrieved -> {
+                                                    Map<ByteArrayWrapper, RetrievedCapability> retrievedMap = new HashMap<>();
+                                                    for (RetrievedCapability rc : retrieved.left)
+                                                        retrievedMap.put(new ByteArrayWrapper(rc.capability.getMapKey()), rc);
 
-                                                        List<NamedAbsoluteCapability> otherCaps = new ArrayList<>();
-                                                        List<CompletableFuture<List<Pair<byte[], Optional<Bat>>>>> locationFutures = new ArrayList<>();
-                                                        Map<ByteArrayWrapper, MaybeMultihash> knownValues = new HashMap<>();
+                                                    List<NamedAbsoluteCapability> otherCaps = new ArrayList<>();
+                                                    List<CompletableFuture<List<Pair<byte[], Optional<Bat>>>>> locationFutures = new ArrayList<>();
+                                                    Map<ByteArrayWrapper, MaybeMultihash> knownValues = new HashMap<>();
 
-                                                        for (NamedAbsoluteCapability namedCap : childCaps) {
-                                                            WritableAbsoluteCapability wcap = (WritableAbsoluteCapability) namedCap.cap;
-                                                            RetrievedCapability rc = retrievedMap.get(new ByteArrayWrapper(wcap.getMapKey()));
-                                                            if (rc != null) {
-                                                                FileProperties childProps = rc.getProperties();
-                                                                boolean isNormalFile = !rc.fileAccess.isDirectory() && childProps.streamSecret.isPresent();
-                                                                SigningPrivateKeyAndPublicHash childSigner = rc.fileAccess.getSigner(wcap.rBaseKey, wcap.wBaseKey.get(), Optional.of(ourSigner));
-                                                                if (isNormalFile && childSigner.publicKeyHash.equals(ourSigner.publicKeyHash)) {
-                                                                    MaybeMultihash hash = rc.fileAccess.committedHash();
-                                                                    if (hash.isPresent())
-                                                                        knownValues.put(new ByteArrayWrapper(wcap.getMapKey()), hash);
-                                                                    locationFutures.add(getAllChunkLocations(wcap.getMapKey(), wcap.bat, childProps.streamSecret.get(), childProps.chunkCount(), hasher));
-                                                                    continue;
-                                                                }
+                                                    for (NamedAbsoluteCapability namedCap : childCaps) {
+                                                        WritableAbsoluteCapability wcap = (WritableAbsoluteCapability) namedCap.cap;
+                                                        RetrievedCapability rc = retrievedMap.get(new ByteArrayWrapper(wcap.getMapKey()));
+                                                        if (rc != null) {
+                                                            FileProperties childProps = rc.getProperties();
+                                                            boolean isNormalFile = !rc.fileAccess.isDirectory() && childProps.streamSecret.isPresent();
+                                                            SigningPrivateKeyAndPublicHash childSigner = rc.fileAccess.getSigner(wcap.rBaseKey, wcap.wBaseKey.get(), Optional.of(ourSigner));
+                                                            if (isNormalFile && childSigner.publicKeyHash.equals(ourSigner.publicKeyHash)) {
+                                                                MaybeMultihash hash = rc.fileAccess.committedHash();
+                                                                if (hash.isPresent())
+                                                                    knownValues.put(new ByteArrayWrapper(wcap.getMapKey()), hash);
+                                                                locationFutures.add(getAllChunkLocations(wcap.getMapKey(), wcap.bat, childProps.streamSecret.get(), childProps.chunkCount(), hasher));
+                                                                continue;
                                                             }
-                                                            otherCaps.add(namedCap);
                                                         }
+                                                        otherCaps.add(namedCap);
+                                                    }
 
-                                                        return Futures.combineAllInOrder(locationFutures)
-                                                                .thenCompose(allLocLists -> {
-                                                                    List<Pair<byte[], Optional<Bat>>> allLocs = allLocLists.stream()
-                                                                            .flatMap(List::stream)
-                                                                            .collect(Collectors.toList());
-                                                                    CompletableFuture<Snapshot> batchDone = allLocs.isEmpty() ?
-                                                                            Futures.of(updatedVersion) :
-                                                                            network.deleteAllChunksIfPresent(updatedVersion, committer, currentCap.owner, ourSigner, allLocs, knownValues, tid);
-                                                                    return batchDone.thenCompose(v -> Futures.reduceAll(otherCaps, v,
-                                                                            (s, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, ourSigner,
-                                                                                    tid, hasher, network, s, committer),
-                                                                            (x, y) -> y));
-                                                                });
-                                                    });
-                                        });
+                                                    // 1. Cross-writer / dir children first
+                                                    return Futures.reduceAll(otherCaps, current,
+                                                                    (s, cap) -> deleteAllChunks((WritableAbsoluteCapability) cap.cap, ourSigner,
+                                                                            tid, hasher, network, s, committer),
+                                                                    (x, y) -> y)
+                                                            // 2. Same-writer batchable files second
+                                                            .thenCompose(v -> Futures.combineAllInOrder(locationFutures)
+                                                                    .thenCompose(allLocLists -> {
+                                                                        List<Pair<byte[], Optional<Bat>>> allLocs = allLocLists.stream()
+                                                                                .flatMap(List::stream)
+                                                                                .collect(Collectors.toList());
+                                                                        return allLocs.isEmpty() ? Futures.of(v) :
+                                                                                network.deleteAllChunksIfPresent(v, committer, currentCap.owner, ourSigner, allLocs, knownValues, tid);
+                                                                    }))
+                                                            // 3. Own chunk chain last
+                                                            .thenCompose(v -> deleteChunkChain(currentCap, ourSigner, chunk, streamSecret, tid, hasher, network, v, committer));
+                                                });
                                     })
                                     .thenCompose(s -> removeSigningKey(ourSigner, signer, currentCap.owner, network, s, committer));
+                        }));
+    }
+
+    private static CompletableFuture<Snapshot> deleteChunkChain(WritableAbsoluteCapability currentCap,
+                                                                SigningPrivateKeyAndPublicHash ourSigner,
+                                                                CryptreeNode chunk,
+                                                                Optional<byte[]> streamSecret,
+                                                                TransactionId tid,
+                                                                Hasher hasher,
+                                                                NetworkAccess network,
+                                                                Snapshot version,
+                                                                Committer committer) {
+        return network.deleteChunk(version, committer, chunk, currentCap.owner, currentCap.getMapKey(), ourSigner, tid)
+                .thenCompose(v -> chunk.getNextChunkLocation(currentCap.rBaseKey, streamSecret,
+                                currentCap.getMapKey(), currentCap.bat, hasher)
+                        .thenCompose(next -> {
+                            WritableAbsoluteCapability nextCap = currentCap.withMapKey(next.left, next.right);
+                            return v.withWriter(nextCap.owner, nextCap.writer, network)
+                                    .thenCompose(vs -> network.getMetadata(vs.get(nextCap.writer), nextCap)
+                                            .thenCompose(nextChunk -> nextChunk.isPresent() ?
+                                                    deleteChunkChain(nextCap, ourSigner, nextChunk.get(), streamSecret, tid, hasher, network, v, committer) :
+                                                    Futures.of(v)));
                         }));
     }
 
@@ -2713,32 +2741,38 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                     if (hash.isPresent())
                                         knownValues.put(new ByteArrayWrapper(rc.capability.getMapKey()), hash);
                                 }
-                                return parent.pointer.fileAccess
-                                        .removeChildren(v2, c, childrenToDelete.stream()
-                                                        .map(f -> f.isLink() ? f.linkPointer.get().capability : f.getPointer().capability)
-                                                        .collect(Collectors.toList()),
-                                                parent.writableFilePointer(),
-                                                parent.entryWriter, network, context.crypto.random, hasher)
-                                        .thenCompose(v3 -> Futures.combineAllInOrder(batchableFiles.stream()
-                                                        .map(f -> {
-                                                            WritableAbsoluteCapability cap = f.writableFilePointer();
-                                                            FileProperties props = f.getFileProperties();
-                                                            return getAllChunkLocations(cap.getMapKey(), cap.bat,
-                                                                    props.streamSecret.get(), props.chunkCount(), hasher);
-                                                        })
-                                                        .collect(Collectors.toList()))
-                                                .thenApply(allLocs -> allLocs.stream().flatMap(List::stream).collect(Collectors.toList()))
+                                // Pre-compute chunk locations (read-only key derivation, no network writes)
+                                CompletableFuture<List<Pair<byte[], Optional<Bat>>>> allLocsFuture =
+                                        Futures.combineAllInOrder(batchableFiles.stream()
+                                                .map(f -> {
+                                                    WritableAbsoluteCapability cap = f.writableFilePointer();
+                                                    FileProperties props = f.getFileProperties();
+                                                    return getAllChunkLocations(cap.getMapKey(), cap.bat,
+                                                            props.streamSecret.get(), props.chunkCount(), hasher);
+                                                })
+                                                .collect(Collectors.toList()))
+                                        .thenApply(allLocs -> allLocs.stream().flatMap(List::stream).collect(Collectors.toList()));
+                                // 1. Cross-writer / dir children first (puts W in pointerBuffer before P)
+                                return Futures.reduceAll(otherChildren, v2,
+                                                (s, f) -> deleteChild(owner, parent, parentPath, f, s, c, context),
+                                                (a, b) -> a.mergeAndOverwriteWith(b))
+                                        // 2. Same-writer batchable files second
+                                        .thenCompose(v3 -> allLocsFuture
                                                 .thenCompose(allKeys -> allKeys.isEmpty() ? Futures.of(v3) :
                                                         IpfsTransaction.call(owner,
                                                                 tid -> network.deleteAllChunksIfPresent(v3, c, owner, parentSigner, allKeys, knownValues, tid),
-                                                                network.dhtClient))
-                                                .thenCompose(v4 -> context.isSecretLink() ? Futures.of(v4) :
-                                                        Futures.reduceAll(batchableFiles, v4,
-                                                                (s, f) -> context.sharedWithCache.clearSharedWith(parentPath.resolve(f.getName()), s, c, network),
-                                                                (a, b) -> a.mergeAndOverwriteWith(b)))
-                                                .thenCompose(v4 -> Futures.reduceAll(otherChildren, v4,
-                                                        (s, f) -> deleteChild(owner, parent, parentPath, f, s, c, context),
-                                                        (a, b) -> a.mergeAndOverwriteWith(b))));
+                                                                network.dhtClient)))
+                                        // 3. Parent listing update last
+                                        .thenCompose(v4 -> parent.pointer.fileAccess
+                                                .removeChildren(v4, c, childrenToDelete.stream()
+                                                                .map(f -> f.isLink() ? f.linkPointer.get().capability : f.getPointer().capability)
+                                                                .collect(Collectors.toList()),
+                                                        parent.writableFilePointer(),
+                                                        parent.entryWriter, network, context.crypto.random, hasher))
+                                        .thenCompose(v5 -> context.isSecretLink() ? Futures.of(v5) :
+                                                Futures.reduceAll(batchableFiles, v5,
+                                                        (s, f) -> context.sharedWithCache.clearSharedWith(parentPath.resolve(f.getName()), s, c, network),
+                                                        (a, b) -> a.mergeAndOverwriteWith(b)));
                             });
                 }))
                 .thenCompose(s -> parent.getUpdated(s, network));
@@ -2791,21 +2825,21 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                             .flatMap(e -> e.getValue().stream().map(p -> new Pair<>(swe.getKey().resolve(e.getKey()), p)))), v0,
                                             (v, linkp) -> context.deleteSecretLink(linkp.right.label, linkp.left, v, c),
                                             (a, b) -> a.mergeAndOverwriteWith(b))))
-                            .thenCompose(v1 -> (writableParent ? v1.withWriter(owner(), parent.writer(), network)
-                                    .thenCompose(v2 -> parent.pointer.fileAccess
-                                            .removeChildren(v2, c, Arrays.asList(isLink() ? linkPointer.get().capability : getPointer().capability), parent.writableFilePointer(),
-                                                    parent.entryWriter, network, context.crypto.random, hasher)) :
-                                    Futures.of(v1)))
-                            .thenCompose(v -> IpfsTransaction.call(owner(),
+                            .thenCompose(v1 -> IpfsTransaction.call(owner(),
                                             tid -> FileWrapper.deleteAllChunks(
                                                     isLink() ?
                                                             (WritableAbsoluteCapability) getLinkPointer().capability :
                                                             writableFilePointer(),
                                                     writableParent ?
                                                             parent.signingPair() :
-                                                            signingPair(), tid, hasher, network, v, c), network.dhtClient)
-                                    .thenCompose(s -> context.isSecretLink() ? Futures.of(s) :
-                                            context.sharedWithCache.clearSharedWith(ourPath, s, c, network)));
+                                                            signingPair(), tid, hasher, network, v1, c), network.dhtClient))
+                            .thenCompose(v2 -> (writableParent ? v2.withWriter(owner(), parent.writer(), network)
+                                    .thenCompose(v3 -> parent.pointer.fileAccess
+                                            .removeChildren(v3, c, Arrays.asList(isLink() ? linkPointer.get().capability : getPointer().capability), parent.writableFilePointer(),
+                                                    parent.entryWriter, network, context.crypto.random, hasher)) :
+                                    Futures.of(v2)))
+                            .thenCompose(s -> context.isSecretLink() ? Futures.of(s) :
+                                    context.sharedWithCache.clearSharedWith(ourPath, s, c, network));
                 })
                 .thenCompose(s -> parent.getUpdated(s, network));
     }


### PR DESCRIPTION
First fix large deletes with subtrees in different writing spaces. Previously we could easily end up with data in the champ taking up space but unreachable from the filesystem. We fix this by deleting up the descendant tree, not down. Then the worst case if a multi writer delete is interrupted is a danglng link in a dir, but no unreachable blocks. We remove the possibility for dangling links by finally implementing atomic multi-writer commits. This is a new api call. In BufferedNetwork we use the multi writer commit unless there are new writers, in which case we fall back to sequential commit. 