### PR TITLE
Make usage updates atomic

### DIFF
--- a/src/peergos/server/ServerAdmin.java
+++ b/src/peergos/server/ServerAdmin.java
@@ -319,7 +319,10 @@ public class ServerAdmin {
                 List<Multihash> storageIds = storage.ids().join().stream().map(c -> (Cid) c).collect(Collectors.toList());
                 for (PublicKeyHash writer : writers) {
                     WriterUsage wUsage = usage.getUsage(writer);
-                    System.out.println(writer + " usage: " + wUsage.directRetainedStorage() + ", reachable: " + reachable.contains(writer));
+                    boolean isReachable = reachable.contains(writer);
+                    if (! isReachable)
+                        rawPointers.removePointer(writer);
+                    System.out.println(writer + " usage: " + wUsage.directRetainedStorage() + ", reachable: " + isReachable);
                     MaybeMultihash target = localPointers.getPointerTarget(id, writer, storage).join().updated;
                     if (! target.equals(wUsage.target()))
                         System.out.println("Different target in pointers! Recalculating usage");

--- a/src/peergos/server/ServerAdmin.java
+++ b/src/peergos/server/ServerAdmin.java
@@ -327,11 +327,10 @@ public class ServerAdmin {
                     long fresh = target.isPresent() ?
                             storage.getRecursiveBlockSizeSync(id, (Cid) target.get(), storageIds) : 0;
                     freshTotal += fresh;
-                    if (fresh != currentWriterUsage) {
+                    if (fresh != currentWriterUsage)
                         System.out.println("Updating writer usage for " + writer + " from " + currentWriterUsage + " to " + fresh + "(" + fresh/1_000_000_000L + " GB)");
-                        usage.updateWriterUsage(writer, target, Collections.emptySet(), Collections.emptySet(), fresh);
-                    }
-                    usage.confirmUsage(username, writer, 0, false);
+                    usage.updateWriterUsageAtomically(writer, wUsage.target(), target,
+                            Collections.emptySet(), Collections.emptySet(), fresh, 0, false);
                 }
                 long correction = freshTotal - currentTotal;
                 if (correction != 0) {

--- a/src/peergos/server/ServerAdmin.java
+++ b/src/peergos/server/ServerAdmin.java
@@ -294,6 +294,7 @@ public class ServerAdmin {
                 CoreNode core = Builder.buildCorenode(a, storage, transactions, rawPointers, localPointers, proxingMutable,
                         rawSocial, usage, userQuotas, rawAccount, batStore, account, linkCounts, crypto);
                 storage.setPki(core);
+                boolean pointerGC = a.getBoolean("pointer-gc", false);
 
                 PublicKeyHash id = core.getPublicKeyHash(username).join().get();
                 Deque<PublicKeyHash> queue = new ArrayDeque<>();
@@ -320,7 +321,7 @@ public class ServerAdmin {
                 for (PublicKeyHash writer : writers) {
                     WriterUsage wUsage = usage.getUsage(writer);
                     boolean isReachable = reachable.contains(writer);
-                    if (! isReachable)
+                    if (! isReachable && pointerGC)
                         rawPointers.removePointer(writer);
                     System.out.println(writer + " usage: " + wUsage.directRetainedStorage() + ", reachable: " + isReachable);
                     MaybeMultihash target = localPointers.getPointerTarget(id, writer, storage).join().updated;

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -432,7 +432,14 @@ public class MirrorCoreNode implements CoreNode {
             rawPointers.setPointer(remote.pkiKey, existingPointer, remoteState.right)
                     .orTimeout(30, TimeUnit.SECONDS).join();
             transactions.closeTransaction(pkiOwnerIdentity, tid);
-
+            // Preserve any entries added to state concurrently by signup() that may have been
+            // missed if they were put into current.chains during or after the putAll in load().
+            current.chains.forEach(updated.chains::putIfAbsent);
+            current.reverseLookup.forEach(updated.reverseLookup::putIfAbsent);
+            for (String u : current.usernames) {
+                if (! updated.chains.containsKey(u))
+                    updated.usernames.add(u);
+            }
             state = updated;
             Logging.LOG().info("... finished updating pki mirror state.");
             return true;

--- a/src/peergos/server/space/JdbcUsageStore.java
+++ b/src/peergos/server/space/JdbcUsageStore.java
@@ -581,28 +581,6 @@ public class JdbcUsageStore implements UsageStore {
     }
 
     @Override
-    public void updateWriterUsage(PublicKeyHash writer,
-                                  MaybeMultihash target,
-                                  Set<PublicKeyHash> removedOwnedKeys,
-                                  Set<PublicKeyHash> addedOwnedKeys,
-                                  long retainedStorage) {
-        try (Connection conn = getConnection(true, false);
-             PreparedStatement insert = conn.prepareStatement("UPDATE writerusage SET target=?, direct_size=? WHERE writer_id = ?;")) {
-            int writerId = getWriterId(writer, conn);
-            insert.setBytes(1, target.isPresent() ? target.get().toBytes() : null);
-            insert.setLong(2, retainedStorage);
-            insert.setInt(3, writerId);
-            int count = insert.executeUpdate();
-            if (count != 1)
-                throw new IllegalStateException("Didn't update one record!");
-            updateOwnedKeys(writerId, removedOwnedKeys, addedOwnedKeys, conn);
-        } catch (SQLException sqe) {
-            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
-            throw new RuntimeException(sqe);
-        }
-    }
-
-    @Override
     public boolean updateWriterUsageAtomically(PublicKeyHash writer,
                                                MaybeMultihash oldTarget,
                                                MaybeMultihash newTarget,

--- a/src/peergos/server/space/JdbcUsageStore.java
+++ b/src/peergos/server/space/JdbcUsageStore.java
@@ -553,25 +553,13 @@ public class JdbcUsageStore implements UsageStore {
 
     }
 
-    @Override
-    public void updateWriterUsage(PublicKeyHash writer,
-                                  MaybeMultihash target,
-                                  Set<PublicKeyHash> removedOwnedKeys,
-                                  Set<PublicKeyHash> addedOwnedKeys,
-                                  long retainedStorage) {
-        try (Connection conn = getConnection(true, false);
-             PreparedStatement insert = conn.prepareStatement("UPDATE writerusage SET target=?, direct_size=? WHERE writer_id = ?;");
-             PreparedStatement writerSelect = conn.prepareStatement("SELECT id FROM writers WHERE key_hash = ?;");
+    private void updateOwnedKeys(int writerId,
+                                 Set<PublicKeyHash> removedOwnedKeys,
+                                 Set<PublicKeyHash> addedOwnedKeys,
+                                 Connection conn) throws SQLException {
+        try (PreparedStatement writerSelect = conn.prepareStatement("SELECT id FROM writers WHERE key_hash = ?;");
              PreparedStatement deleteOwned = conn.prepareStatement("DELETE FROM ownedkeys WHERE owned_id = ?;");
              PreparedStatement insertOwned = conn.prepareStatement("INSERT INTO ownedkeys (parent_id, owned_id) VALUES(?, ?);")) {
-            int writerId = getWriterId(writer, conn);
-            insert.setBytes(1, target.isPresent() ? target.get().toBytes() : null);
-            insert.setLong(2, retainedStorage);
-            insert.setInt(3, writerId);
-            int count = insert.executeUpdate();
-            if (count != 1)
-                throw new IllegalStateException("Didn't update one record!");
-
             for (PublicKeyHash removed : removedOwnedKeys) {
                 writerSelect.setBytes(1, removed.toBytes());
                 ResultSet writerRes = writerSelect.executeQuery();
@@ -580,7 +568,6 @@ public class JdbcUsageStore implements UsageStore {
                 deleteOwned.setInt(1, ownedId);
                 deleteOwned.executeUpdate();
             }
-
             for (PublicKeyHash added : addedOwnedKeys) {
                 writerSelect.setBytes(1, added.toBytes());
                 ResultSet writerRes = writerSelect.executeQuery();
@@ -590,9 +577,91 @@ public class JdbcUsageStore implements UsageStore {
                 insertOwned.setInt(2, ownedId);
                 insertOwned.execute();
             }
+        }
+    }
+
+    @Override
+    public void updateWriterUsage(PublicKeyHash writer,
+                                  MaybeMultihash target,
+                                  Set<PublicKeyHash> removedOwnedKeys,
+                                  Set<PublicKeyHash> addedOwnedKeys,
+                                  long retainedStorage) {
+        try (Connection conn = getConnection(true, false);
+             PreparedStatement insert = conn.prepareStatement("UPDATE writerusage SET target=?, direct_size=? WHERE writer_id = ?;")) {
+            int writerId = getWriterId(writer, conn);
+            insert.setBytes(1, target.isPresent() ? target.get().toBytes() : null);
+            insert.setLong(2, retainedStorage);
+            insert.setInt(3, writerId);
+            int count = insert.executeUpdate();
+            if (count != 1)
+                throw new IllegalStateException("Didn't update one record!");
+            updateOwnedKeys(writerId, removedOwnedKeys, addedOwnedKeys, conn);
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
             throw new RuntimeException(sqe);
+        }
+    }
+
+    @Override
+    public boolean updateWriterUsageAtomically(PublicKeyHash writer,
+                                               MaybeMultihash oldTarget,
+                                               MaybeMultihash newTarget,
+                                               Set<PublicKeyHash> removedOwnedKeys,
+                                               Set<PublicKeyHash> addedOwnedKeys,
+                                               long newDirectSize,
+                                               long delta,
+                                               boolean errored) {
+        Connection conn = getConnection(false, true);
+        try {
+            conn.setAutoCommit(false);
+            int writerId = getWriterId(writer, conn);
+
+            try (PreparedStatement casUpdate = conn.prepareStatement(
+                    "UPDATE writerusage SET direct_size=?, target=? WHERE writer_id=? AND target IS NOT DISTINCT FROM ?")) {
+                casUpdate.setLong(1, newDirectSize);
+                casUpdate.setBytes(2, newTarget.isPresent() ? newTarget.get().toBytes() : null);
+                casUpdate.setInt(3, writerId);
+                casUpdate.setBytes(4, oldTarget.isPresent() ? oldTarget.get().toBytes() : null);
+                int count = casUpdate.executeUpdate();
+                if (count == 0) {
+                    conn.rollback();
+                    return false;
+                }
+            }
+
+            long userId;
+            try (PreparedStatement getUser = conn.prepareStatement(
+                    "SELECT user_id FROM writerusage WHERE writer_id=?")) {
+                getUser.setInt(1, writerId);
+                ResultSet rs = getUser.executeQuery();
+                rs.next();
+                userId = rs.getLong(1);
+            }
+
+            try (PreparedStatement updateUsage = conn.prepareStatement(
+                    "UPDATE userusage SET total_bytes=total_bytes+?, errored=? WHERE user_id=?")) {
+                updateUsage.setLong(1, delta);
+                updateUsage.setBoolean(2, errored);
+                updateUsage.setLong(3, userId);
+                updateUsage.executeUpdate();
+            }
+
+            try (PreparedStatement resetPending = conn.prepareStatement(
+                    "UPDATE pendingusage SET pending_bytes=0 WHERE writer_id=? AND user_id=?")) {
+                resetPending.setInt(1, writerId);
+                resetPending.setLong(2, userId);
+                resetPending.executeUpdate();
+            }
+
+            updateOwnedKeys(writerId, removedOwnedKeys, addedOwnedKeys, conn);
+            conn.commit();
+            return true;
+        } catch (Exception e) {
+            try { conn.rollback(); } catch (SQLException re) { LOG.log(Level.WARNING, re.getMessage(), re); }
+            LOG.log(Level.WARNING, e.getMessage(), e);
+            throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
+        } finally {
+            try { conn.setAutoCommit(true); conn.close(); } catch (SQLException e) { LOG.log(Level.WARNING, e.getMessage(), e); }
         }
     }
 

--- a/src/peergos/server/space/JdbcUsageStore.java
+++ b/src/peergos/server/space/JdbcUsageStore.java
@@ -589,23 +589,19 @@ public class JdbcUsageStore implements UsageStore {
                                                long newDirectSize,
                                                long delta,
                                                boolean errored) {
-        Connection conn = getConnection(false, true);
-        try {
-            conn.setAutoCommit(false);
+        try (Connection conn = getConnection(true, false)) {
             int writerId = getWriterId(writer, conn);
-
+            int casCount;
             try (PreparedStatement casUpdate = conn.prepareStatement(
                     "UPDATE writerusage SET direct_size=?, target=? WHERE writer_id=? AND target IS NOT DISTINCT FROM ?")) {
                 casUpdate.setLong(1, newDirectSize);
                 casUpdate.setBytes(2, newTarget.isPresent() ? newTarget.get().toBytes() : null);
                 casUpdate.setInt(3, writerId);
                 casUpdate.setBytes(4, oldTarget.isPresent() ? oldTarget.get().toBytes() : null);
-                int count = casUpdate.executeUpdate();
-                if (count == 0) {
-                    conn.rollback();
-                    return false;
-                }
+                casCount = casUpdate.executeUpdate();
             }
+            if (casCount == 0)
+                return false;
 
             long userId;
             try (PreparedStatement getUser = conn.prepareStatement(
@@ -632,14 +628,10 @@ public class JdbcUsageStore implements UsageStore {
             }
 
             updateOwnedKeys(writerId, removedOwnedKeys, addedOwnedKeys, conn);
-            conn.commit();
             return true;
-        } catch (Exception e) {
-            try { conn.rollback(); } catch (SQLException re) { LOG.log(Level.WARNING, re.getMessage(), re); }
-            LOG.log(Level.WARNING, e.getMessage(), e);
-            throw e instanceof RuntimeException ? (RuntimeException) e : new RuntimeException(e);
-        } finally {
-            try { conn.setAutoCommit(true); conn.close(); } catch (SQLException e) { LOG.log(Level.WARNING, e.getMessage(), e); }
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
         }
     }
 

--- a/src/peergos/server/space/SpaceCheckingKeyFilter.java
+++ b/src/peergos/server/space/SpaceCheckingKeyFilter.java
@@ -149,7 +149,6 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                     Logging.LOG().info("Root hash changed from " + writerUsage.target() + " to " + rootHash);
                     long updatedSize = dht.getRecursiveBlockSize(owner, (Cid)rootHash.get(), us).get();
                     long deltaUsage = updatedSize - writerUsage.directRetainedStorage();
-                    store.confirmUsage(writerUsage.owner, writerKey, deltaUsage, store.getUsage(writerUsage.owner).isErrored());
                     Set<PublicKeyHash> directOwnedKeys = DeletableContentAddressedStorage.getDirectOwnedKeys(owner, writerKey, mutable,
                             (h, s) -> DeletableContentAddressedStorage.getWriterData(us, owner, h, s, false, ourId, hasher, dht), dht, hasher).join();
                     List<PublicKeyHash> newOwnedKeys = directOwnedKeys.stream()
@@ -162,8 +161,11 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                     }
                     HashSet<PublicKeyHash> removedOwnedKeys = new HashSet<>(writerUsage.ownedKeys());
                     removedOwnedKeys.removeAll(directOwnedKeys);
-                    store.updateWriterUsage(writerKey, rootHash, removedOwnedKeys, new HashSet<>(newOwnedKeys), updatedSize);
-                    Logging.LOG().info("Updated space used by " + writerKey + " to " + updatedSize);
+                    boolean updated = store.updateWriterUsageAtomically(writerKey, writerUsage.target(), rootHash,
+                            removedOwnedKeys, new HashSet<>(newOwnedKeys), updatedSize, deltaUsage,
+                            store.getUsage(writerUsage.owner).isErrored());
+                    if (updated)
+                        Logging.LOG().info("Updated space used by " + writerKey + " to " + updatedSize);
                 }
             } catch (Throwable t) {
                 Logging.LOG().log(Level.WARNING, "Failed calculating usage for " + (tmpUsage == null ? writerKey : tmpUsage.owner), t);
@@ -286,8 +288,9 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                 return; // already processed by another thread
             if (! newRoot.isPresent()) {
                 LOG.info("Removing usage for (" + owner + ", " + writer + ") from " + current.directRetainedStorage());
-                state.confirmUsage(current.owner, writer, -current.directRetainedStorage(), state.getUsage(current.owner).isErrored());
-                state.updateWriterUsage(writer, MaybeMultihash.empty(), Collections.emptySet(), Collections.emptySet(), 0);
+                state.updateWriterUsageAtomically(writer, current.target(), MaybeMultihash.empty(),
+                        Collections.emptySet(), Collections.emptySet(), 0,
+                        -current.directRetainedStorage(), state.getUsage(current.owner).isErrored());
                 if (existingRoot.isPresent()) {
                     try {
                         // subtract data size from orphaned child keys (this assumes the keys form a tree without dupes)
@@ -318,17 +321,20 @@ public class SpaceCheckingKeyFilter implements SpaceUsage {
                 String username = current.owner;
                 long quota = getQuota(username, quotaAdmin);
                 boolean errored = initialErrored && usage.totalUsage() > quota;
-                state.confirmUsage(current.owner, writer, changeInStorage, errored);
-                UserUsage cached = getUsage(username, state);
-                cached.confirmUsage(writer, changeInStorage);
-                cached.setErrored(errored);
 
                 HashSet<PublicKeyHash> removedChildren = new HashSet<>(current.ownedKeys());
                 removedChildren.removeAll(updatedOwned);
                 processRemovedOwnedKeys(state, owner, removedChildren, mutable, quotaAdmin, dht, hasher);
                 HashSet<PublicKeyHash> addedOwnedKeys = new HashSet<>(updatedOwned);
                 addedOwnedKeys.removeAll(current.ownedKeys());
-                state.updateWriterUsage(writer, newRoot, removedChildren, addedOwnedKeys, current.directRetainedStorage() + changeInStorage);
+                boolean updated = state.updateWriterUsageAtomically(writer, current.target(), newRoot,
+                        removedChildren, addedOwnedKeys,
+                        current.directRetainedStorage() + changeInStorage, changeInStorage, errored);
+                if (updated) {
+                    UserUsage cached = getUsage(username, state);
+                    cached.confirmUsage(writer, changeInStorage);
+                    cached.setErrored(errored);
+                }
                 for (PublicKeyHash added : addedOwnedKeys) {
                     state.addWriter(current.owner, added);
                     WriterUsage currentAdded = state.getUsage(added);

--- a/src/peergos/server/space/WriterUsageStore.java
+++ b/src/peergos/server/space/WriterUsageStore.java
@@ -25,12 +25,6 @@ public interface WriterUsageStore {
 
     String getOwner(PublicKeyHash writer);
 
-    void updateWriterUsage(PublicKeyHash writer,
-                           MaybeMultihash target,
-                           Set<PublicKeyHash> removedOwnedKeys,
-                           Set<PublicKeyHash> addedOwnedKeys,
-                           long retainedStorage);
-
     /**
      * Atomically update writer size/target AND user total_bytes in a single SQL statement,
      * using a CAS on the writer's current target to prevent double-counting under concurrent access.

--- a/src/peergos/server/space/WriterUsageStore.java
+++ b/src/peergos/server/space/WriterUsageStore.java
@@ -31,6 +31,21 @@ public interface WriterUsageStore {
                            Set<PublicKeyHash> addedOwnedKeys,
                            long retainedStorage);
 
+    /**
+     * Atomically update writer size/target AND user total_bytes in a single SQL statement,
+     * using a CAS on the writer's current target to prevent double-counting under concurrent access.
+     *
+     * @return true if the CAS succeeded (update applied), false if the target had already changed
+     */
+    boolean updateWriterUsageAtomically(PublicKeyHash writer,
+                                        MaybeMultihash oldTarget,
+                                        MaybeMultihash newTarget,
+                                        Set<PublicKeyHash> removedOwnedKeys,
+                                        Set<PublicKeyHash> addedOwnedKeys,
+                                        long newDirectSize,
+                                        long delta,
+                                        boolean errored);
+
     // return current usage root, and username
     List<Triple<Multihash, String, PublicKeyHash>> getAllTargets();
 

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -88,7 +88,8 @@ public class GCTests {
         String username = "user";
         usage.addUserIfAbsent(username);
         usage.addWriter(username, writer);
-        usage.updateWriterUsage(writer, MaybeMultihash.of(randomCbor(new Random(42))), Collections.emptySet(), Collections.emptySet(), 1024*1024);
+        usage.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), MaybeMultihash.of(randomCbor(new Random(42))),
+                Collections.emptySet(), Collections.emptySet(), 1024*1024, 0, false);
         usage.confirmUsage(username, writer, 10*1024*1024, false);
 
         verifyAllReachableBlocksArePresent(pointers, metadb, storage);
@@ -172,7 +173,8 @@ public class GCTests {
         String username = "user";
         usage.addUserIfAbsent(username);
         usage.addWriter(username, writer);
-        usage.updateWriterUsage(writer, MaybeMultihash.of(randomCbor(new Random(42))), Collections.emptySet(), Collections.emptySet(), 1024*1024);
+        usage.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), MaybeMultihash.of(randomCbor(new Random(42))),
+                Collections.emptySet(), Collections.emptySet(), 1024*1024, 0, false);
         usage.confirmUsage(username, writer, 10*1024*1024, false);
         List<Pair<String, PublicKeyHash>> owners = usage.getAllOwners();
         Assert.assertTrue(! owners.isEmpty());
@@ -183,7 +185,8 @@ public class GCTests {
                 (b, kids) -> metadb.put(writer, b, null, new BlockMetadata(10, kids, Collections.emptyList())));
         byte[] signedCas = signer.signMessage(new PointerUpdate(MaybeMultihash.empty(), MaybeMultihash.of(root), Optional.of(1L)).serialize()).join();
         pointers.setPointer(writer, Optional.empty(), signedCas).join();
-        usage.updateWriterUsage(writer, MaybeMultihash.of(root), Collections.emptySet(), Collections.emptySet(), 1024*1024);
+        usage.updateWriterUsageAtomically(writer, MaybeMultihash.of(randomCbor(new Random(42))), MaybeMultihash.of(root),
+                Collections.emptySet(), Collections.emptySet(), 1024*1024, 0, false);
 
         verifyAllReachableBlocksArePresent(pointers, metadb, storage);
 
@@ -222,7 +225,8 @@ public class GCTests {
         Assert.assertEquals(bigSize, Files.size(dbFile));
 
         // Remove root so everything is GC'd and test db file size decreases
-        usage.updateWriterUsage(writer, MaybeMultihash.empty(), Collections.emptySet(), Collections.emptySet(), 1024*1024);
+        usage.updateWriterUsageAtomically(writer, MaybeMultihash.of(root), MaybeMultihash.empty(),
+                Collections.emptySet(), Collections.emptySet(), 1024*1024, 0, false);
         boolean setPointer = pointers.setPointer(writer, Optional.of(signedCas), signer.signMessage(new PointerUpdate(MaybeMultihash.of(root), MaybeMultihash.empty(), Optional.of(2L)).serialize()).join()).join();
         gc.collect(s -> Futures.of(true));
         long emptySize = Files.size(dbFile);
@@ -238,7 +242,8 @@ public class GCTests {
         byte[] signedCas2 = signer2.signMessage(new PointerUpdate(MaybeMultihash.empty(), MaybeMultihash.of(root2), Optional.of(1L)).serialize()).join();
         pointers.setPointer(writer2, Optional.empty(), signedCas2).join();
         usage.addWriter("user2", writer2);
-        usage.updateWriterUsage(writer2, MaybeMultihash.of(root2), Collections.emptySet(), Collections.emptySet(), 1024*1024);
+        usage.updateWriterUsageAtomically(writer2, MaybeMultihash.empty(), MaybeMultihash.of(root2),
+                Collections.emptySet(), Collections.emptySet(), 1024*1024, 0, false);
 
         gc.collect(s -> Futures.of(true));
         verifyAllReachableBlocksArePresent(pointers, metadb, storage);

--- a/src/peergos/server/tests/JdbcIpnsAndSocialTests.java
+++ b/src/peergos/server/tests/JdbcIpnsAndSocialTests.java
@@ -1,0 +1,143 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.server.*;
+import peergos.server.corenode.*;
+import peergos.server.sql.*;
+import peergos.server.util.Sqlite;
+import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
+import peergos.shared.io.ipfs.*;
+import peergos.shared.mutable.*;
+
+import java.sql.*;
+import java.util.*;
+
+public class JdbcIpnsAndSocialTests {
+
+    private JdbcIpnsAndSocial db;
+
+    @Before
+    public void setup() throws Exception {
+        SqlSupplier commands = new SqliteCommands();
+        Connection conn = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        db = new JdbcIpnsAndSocial(() -> conn, commands);
+    }
+
+    private static PublicKeyHash key(Crypto crypto) {
+        return new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+    }
+
+    @Test
+    public void setNewPointerRetrievable() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash writer = key(crypto);
+        byte[] value = {1, 2, 3};
+
+        boolean result = db.setPointers(List.of(Optional.empty()),
+                List.of(new SignedPointerUpdate(writer, value))).join();
+
+        Assert.assertTrue(result);
+        Optional<byte[]> retrieved = db.getPointer(writer).join();
+        Assert.assertTrue(retrieved.isPresent());
+        Assert.assertArrayEquals(value, retrieved.get());
+    }
+
+    @Test
+    public void updatePointerWithCorrectExpectedSucceeds() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash writer = key(crypto);
+        byte[] v1 = {1, 2, 3};
+        byte[] v2 = {4, 5, 6};
+        db.setPointers(List.of(Optional.empty()),
+                List.of(new SignedPointerUpdate(writer, v1))).join();
+
+        boolean result = db.setPointers(List.of(Optional.of(v1)),
+                List.of(new SignedPointerUpdate(writer, v2))).join();
+
+        Assert.assertTrue(result);
+        Assert.assertArrayEquals(v2, db.getPointer(writer).join().get());
+    }
+
+    @Test
+    public void updatePointerWithWrongExpectedFails() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash writer = key(crypto);
+        byte[] v1 = {1, 2, 3};
+        byte[] v2 = {4, 5, 6};
+        byte[] vWrong = {9, 9, 9};
+        db.setPointers(List.of(Optional.empty()),
+                List.of(new SignedPointerUpdate(writer, v1))).join();
+
+        boolean result = db.setPointers(List.of(Optional.of(vWrong)),
+                List.of(new SignedPointerUpdate(writer, v2))).join();
+
+        Assert.assertFalse(result);
+        Assert.assertArrayEquals(v1, db.getPointer(writer).join().get());
+    }
+
+    @Test
+    public void setNewPointerFailsWhenKeyAlreadyExists() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash writer = key(crypto);
+        byte[] v1 = {1, 2, 3};
+        byte[] v2 = {4, 5, 6};
+        db.setPointers(List.of(Optional.empty()),
+                List.of(new SignedPointerUpdate(writer, v1))).join();
+
+        // expected=empty means "new key", but it already exists — should fail
+        boolean result = db.setPointers(List.of(Optional.empty()),
+                List.of(new SignedPointerUpdate(writer, v2))).join();
+
+        Assert.assertFalse(result);
+        Assert.assertArrayEquals(v1, db.getPointer(writer).join().get());
+    }
+
+    @Test
+    public void atomicMultiPointerAllSucceed() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash w1 = key(crypto), w2 = key(crypto);
+        byte[] v1 = {1}, v2 = {2};
+
+        boolean result = db.setPointers(
+                List.of(Optional.empty(), Optional.empty()),
+                List.of(new SignedPointerUpdate(w1, v1), new SignedPointerUpdate(w2, v2))).join();
+
+        Assert.assertTrue(result);
+        Assert.assertArrayEquals(v1, db.getPointer(w1).join().get());
+        Assert.assertArrayEquals(v2, db.getPointer(w2).join().get());
+    }
+
+    @Test
+    public void atomicMultiPointerOneWrongCasLeavesNeitherUpdated() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash w1 = key(crypto), w2 = key(crypto);
+        byte[] v1init = {0};
+        byte[] v1new = {1};
+        byte[] v2 = {2};
+        db.setPointers(List.of(Optional.empty()),
+                List.of(new SignedPointerUpdate(w1, v1init))).join();
+
+        // w1: wrong expected, w2: new insert — both should be rolled back
+        boolean result = db.setPointers(
+                List.of(Optional.of(new byte[]{9}), Optional.empty()),
+                List.of(new SignedPointerUpdate(w1, v1new), new SignedPointerUpdate(w2, v2))).join();
+
+        Assert.assertFalse(result);
+        Assert.assertArrayEquals(v1init, db.getPointer(w1).join().get());
+        Assert.assertFalse("w2 should not have been inserted", db.getPointer(w2).join().isPresent());
+    }
+
+    @Test
+    public void getPointerReturnsEmptyForUnknownKey() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        PublicKeyHash unknown = key(crypto);
+        Assert.assertFalse(db.getPointer(unknown).join().isPresent());
+    }
+
+    @Test
+    public void emptyUpdateListSucceeds() {
+        boolean result = db.setPointers(List.of(), List.of()).join();
+        Assert.assertTrue(result);
+    }
+}

--- a/src/peergos/server/tests/JdbcUsageStoreTests.java
+++ b/src/peergos/server/tests/JdbcUsageStoreTests.java
@@ -120,4 +120,198 @@ public class JdbcUsageStoreTests {
         Assert.assertEquals("Usage should be 0 after deleting all data", 0, usage.totalUsage());
         Assert.assertFalse("Usage must not be negative after delete", usage.totalUsage() < 0);
     }
+
+    /** CAS from NULL target succeeds and updates total_bytes atomically */
+    @Test
+    public void atomicUpdateFromNullSucceeds() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        MaybeMultihash newTarget = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+
+        boolean updated = store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), newTarget,
+                Collections.emptySet(), Collections.emptySet(), 1000, 1000, false);
+
+        Assert.assertTrue(updated);
+        Assert.assertEquals(newTarget, store.getUsage(writer).target());
+        Assert.assertEquals(1000, store.getUsage(writer).directRetainedStorage());
+        Assert.assertEquals(1000, store.getUsage("alice").totalUsage());
+    }
+
+    /** CAS fails when provided old target doesn't match stored target; DB is unchanged */
+    @Test
+    public void atomicUpdateCasFailsOnWrongOldTarget() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+        MaybeMultihash target2 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{2}));
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Collections.emptySet(), 1000, 1000, false);
+
+        // Supply wrong old target (empty instead of target1)
+        boolean updated = store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target2,
+                Collections.emptySet(), Collections.emptySet(), 500, 500, false);
+
+        Assert.assertFalse(updated);
+        Assert.assertEquals(target1, store.getUsage(writer).target());
+        Assert.assertEquals(1000, store.getUsage(writer).directRetainedStorage());
+        Assert.assertEquals(1000, store.getUsage("alice").totalUsage());
+    }
+
+    /** Successful CAS update from one non-null target to another */
+    @Test
+    public void atomicUpdateFromNonNullSucceeds() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+        MaybeMultihash target2 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{2}));
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Collections.emptySet(), 1000, 1000, false);
+
+        boolean updated = store.updateWriterUsageAtomically(writer, target1, target2,
+                Collections.emptySet(), Collections.emptySet(), 1500, 500, false);
+
+        Assert.assertTrue(updated);
+        Assert.assertEquals(target2, store.getUsage(writer).target());
+        Assert.assertEquals(1500, store.getUsage(writer).directRetainedStorage());
+        Assert.assertEquals(1500, store.getUsage("alice").totalUsage());
+    }
+
+    /** Deleting a writer atomically clears target and subtracts its size from total */
+    @Test
+    public void atomicDeleteResetsToZero() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Collections.emptySet(), 1000, 1000, false);
+
+        boolean updated = store.updateWriterUsageAtomically(writer, target1, MaybeMultihash.empty(),
+                Collections.emptySet(), Collections.emptySet(), 0, -1000, false);
+
+        Assert.assertTrue(updated);
+        Assert.assertEquals(MaybeMultihash.empty(), store.getUsage(writer).target());
+        Assert.assertEquals(0, store.getUsage(writer).directRetainedStorage());
+        Assert.assertEquals(0, store.getUsage("alice").totalUsage());
+    }
+
+    /** Pending bytes are cleared to zero on a successful atomic update */
+    @Test
+    public void pendingUsageResetOnAtomicUpdate() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        store.addPendingUsage("alice", writer, 500);
+        Assert.assertEquals(500, store.getUsage("alice").getPending(writer));
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Collections.emptySet(), 1000, 1000, false);
+
+        Assert.assertEquals(0, store.getUsage("alice").getPending(writer));
+    }
+
+    /** Pending bytes are preserved when CAS fails */
+    @Test
+    public void pendingUsageNotResetOnFailedCas() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+        MaybeMultihash target2 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{2}));
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Collections.emptySet(), 1000, 1000, false);
+        store.addPendingUsage("alice", writer, 500);
+
+        // CAS with wrong old target
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target2,
+                Collections.emptySet(), Collections.emptySet(), 500, 500, false);
+
+        Assert.assertEquals(500, store.getUsage("alice").getPending(writer));
+    }
+
+    /** Owned keys added in atomic update are visible via getUsage */
+    @Test
+    public void atomicUpdateAddsOwnedKey() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        PublicKeyHash owned = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        store.addWriter("alice", owned);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Set.of(owned), 1000, 1000, false);
+
+        Assert.assertTrue(store.getUsage(writer).ownedKeys().contains(owned));
+    }
+
+    /** Owned keys removed in atomic update are no longer visible via getUsage */
+    @Test
+    public void atomicUpdateRemovesOwnedKey() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        PublicKeyHash owned = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        store.addWriter("alice", owned);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+        MaybeMultihash target2 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{2}));
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Set.of(owned), 1000, 1000, false);
+
+        store.updateWriterUsageAtomically(writer, target1, target2,
+                Set.of(owned), Collections.emptySet(), 1500, 500, false);
+
+        Assert.assertFalse(store.getUsage(writer).ownedKeys().contains(owned));
+    }
+
+    /** Owned keys are not changed when the CAS fails */
+    @Test
+    public void ownedKeysNotModifiedOnFailedCas() throws Exception {
+        Crypto crypto = Main.initCrypto();
+        Connection db = new Sqlite.UncloseableConnection(Sqlite.build(":memory:"));
+        JdbcUsageStore store = new JdbcUsageStore(() -> db, new SqliteCommands());
+        store.addUserIfAbsent("alice");
+        PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        PublicKeyHash owned = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
+        store.addWriter("alice", writer);
+        store.addWriter("alice", owned);
+        MaybeMultihash target1 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{1}));
+        MaybeMultihash target2 = MaybeMultihash.of(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, new byte[]{2}));
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target1,
+                Collections.emptySet(), Set.of(owned), 1000, 1000, false);
+
+        // CAS with wrong old target - should not remove the owned key
+        store.updateWriterUsageAtomically(writer, MaybeMultihash.empty(), target2,
+                Set.of(owned), Collections.emptySet(), 1500, 500, false);
+
+        Assert.assertTrue(store.getUsage(writer).ownedKeys().contains(owned));
+    }
 }

--- a/src/peergos/server/tests/JdbcUsageStoreTests.java
+++ b/src/peergos/server/tests/JdbcUsageStoreTests.java
@@ -25,8 +25,8 @@ public class JdbcUsageStoreTests {
         store.addWriter(username, owner);
         PublicKeyHash writer = new PublicKeyHash(Cid.buildCidV1(Cid.Codec.DagCbor, Multihash.Type.id, crypto.random.randomBytes(36)));
         store.addWriter(username, writer);
-        store.updateWriterUsage(owner, MaybeMultihash.empty(), Collections.emptySet(), Set.of(writer), 0);
-        store.updateWriterUsage(owner, MaybeMultihash.empty(), Collections.emptySet(), Set.of(owner), 0);
+        store.updateWriterUsageAtomically(owner, MaybeMultihash.empty(), MaybeMultihash.empty(), Collections.emptySet(), Set.of(writer), 0, 0, false);
+        store.updateWriterUsageAtomically(owner, MaybeMultihash.empty(), MaybeMultihash.empty(), Collections.emptySet(), Set.of(owner), 0, 0, false);
 
         Set<PublicKeyHash> allWriters = store.getAllWriters(owner);
         Assert.assertTrue(allWriters.size() == 2);

--- a/src/peergos/server/util/Sqlite.java
+++ b/src/peergos/server/util/Sqlite.java
@@ -113,7 +113,9 @@ public class Sqlite {
 
         @Override
         public void setTransactionIsolation(int i) throws SQLException {
-            target.setTransactionIsolation(i);
+            // In non-shared-cache SQLite (our usage), PRAGMA read_uncommitted is a no-op.
+            // Forwarding the call executes it as a SQL statement, which causes SQLITE_BUSY
+            // when another thread has a statement in progress on this shared connection.
         }
 
         @Override


### PR DESCRIPTION
Previously a race could result in double counting storage changes. The races were easy to hit with large changes too, hitting different servers. 