### PR TITLE
Escape control characters in JSON string serialization

### DIFF
--- a/src/peergos/server/net/MountConfigHandler.java
+++ b/src/peergos/server/net/MountConfigHandler.java
@@ -318,10 +318,6 @@ public class MountConfigHandler implements HttpHandler {
         }
     }
 
-    private static boolean isLinux() {
-        return System.getProperty("os.name", "").toLowerCase().contains("linux");
-    }
-
     private static void openInFileExplorer(String mountPoint) throws IOException {
         // Android isn't handled here — the host app exposes a JS bridge
         // (MainActivity.openMountInFiles) that fires a SAF browse intent with the
@@ -405,10 +401,7 @@ public class MountConfigHandler implements HttpHandler {
                 String peergosUsername = (String) body.get("peergosUsername");
                 String peergosPassword = (String) body.get("peergosPassword");
                 boolean autoMount = body.get("autoMount") instanceof Boolean ? (Boolean) body.get("autoMount") : true;
-                // gvfs's dav backend (used by the Linux gio-mount path) rejects the mount as
-                // "Location is not mountable" under digest auth — webdavMountReadWrite in
-                // WebdavTests only exercises basic auth on Linux for exactly this reason.
-                String authType = isLinux() ? "basic" : "digest";
+                String authType = "digest";
                 String webdavUsername = generateToken();
                 String webdavPassword = generateToken();
                 int webdavPort = findFreePort();

--- a/src/peergos/server/net/MountConfigHandler.java
+++ b/src/peergos/server/net/MountConfigHandler.java
@@ -318,6 +318,10 @@ public class MountConfigHandler implements HttpHandler {
         }
     }
 
+    private static boolean isLinux() {
+        return System.getProperty("os.name", "").toLowerCase().contains("linux");
+    }
+
     private static void openInFileExplorer(String mountPoint) throws IOException {
         // Android isn't handled here — the host app exposes a JS bridge
         // (MainActivity.openMountInFiles) that fires a SAF browse intent with the
@@ -401,7 +405,10 @@ public class MountConfigHandler implements HttpHandler {
                 String peergosUsername = (String) body.get("peergosUsername");
                 String peergosPassword = (String) body.get("peergosPassword");
                 boolean autoMount = body.get("autoMount") instanceof Boolean ? (Boolean) body.get("autoMount") : true;
-                String authType = "digest";
+                // gvfs's dav backend (used by the Linux gio-mount path) rejects the mount as
+                // "Location is not mountable" under digest auth — webdavMountReadWrite in
+                // WebdavTests only exercises basic auth on Linux for exactly this reason.
+                String authType = isLinux() ? "basic" : "digest";
                 String webdavUsername = generateToken();
                 String webdavPassword = generateToken();
                 int webdavPort = findFreePort();

--- a/src/peergos/shared/io/ipfs/api/JSONParser.java
+++ b/src/peergos/shared/io/ipfs/api/JSONParser.java
@@ -286,9 +286,27 @@ public class JSONParser
         for (int i=0; i<s.length(); i++)
         {
             char ch = s.charAt(i);
-            if ((ch == '"') || (ch == '\\'))
-                buf.append('\\');
-            buf.append(ch);
+            switch (ch)
+            {
+                case '"': buf.append("\\\""); break;
+                case '\\': buf.append("\\\\"); break;
+                case '\n': buf.append("\\n"); break;
+                case '\r': buf.append("\\r"); break;
+                case '\t': buf.append("\\t"); break;
+                case '\b': buf.append("\\b"); break;
+                case '\f': buf.append("\\f"); break;
+                default:
+                    if (ch < 0x20)
+                    {
+                        String hex = Integer.toHexString(ch);
+                        buf.append("\\u");
+                        for (int pad = hex.length(); pad < 4; pad++)
+                            buf.append('0');
+                        buf.append(hex);
+                    }
+                    else
+                        buf.append(ch);
+            }
         }
         buf.append('"');
     }


### PR DESCRIPTION
JSONParser.escapeString() didn't escape control characters. A mount error
message containing a newline produced invalid JSON in the
`/mount/get-config` response. The browser's `responseType='json'` XHR
silently turns that into `null`, so Mount.vue's poll loop threw trying to
read `.error` off `null` and retried forever instead of surfacing the actual
error — looked like an infinite "Mounting drive..." spinner with no
feedback.

Found this while debugging a mount failure on Linux that turned out to be
unrelated: Arch/CachyOS doesn't ship `gvfsd-dav` in the base `gvfs` package
(it's in `gvfs-dnssd` there; `gvfs-backends` on Debian/Ubuntu; already
included on Fedora) — a distro packaging issue, not something fixable here,
but worth knowing if "Location is not mountable" shows up again.