### PR TITLE
Add machine-readable sync state for the desktop tray

### DIFF
--- a/src/peergos/server/DesktopApp.java
+++ b/src/peergos/server/DesktopApp.java
@@ -18,8 +18,10 @@ public class DesktopApp {
 
         try {
             if (flatpak) {
+                // The window hides to the tray when closed, so this only exits
+                // when the user picks "Close Peergos" (or has no tray at all).
                 ProcessBuilder pb = new ProcessBuilder(
-                        "flatpak.sh",
+                        "peergos-window",
                         Integer.toString(port)
                 );
                 pb.inheritIO();

--- a/src/peergos/server/net/SyncConfigHandler.java
+++ b/src/peergos/server/net/SyncConfigHandler.java
@@ -9,6 +9,7 @@ import peergos.server.sync.PairLogger;
 import peergos.server.sync.PairStatus;
 import peergos.server.sync.SyncConfig;
 import peergos.server.sync.SyncRunner;
+import peergos.server.sync.SyncStatus;
 import peergos.server.util.Args;
 import peergos.server.util.HttpUtil;
 import peergos.server.util.Logging;
@@ -293,12 +294,11 @@ public class SyncConfigHandler implements HttpHandler {
                 resp.write(res);
                 exchange.close();
             } else if (action.equals("status")) {
-                LinkedHashMap<Object, Object> reply = new LinkedHashMap<>();
-                reply.put("msg", syncer.getStatusHolder().getStatusAndTime());
-                Optional<String> error = syncer.getStatusHolder().getError();
-                error.ifPresent(err -> reply.put("error", err));
+                SyncRunner.StatusHolder global = syncer.getStatusHolder();
+                Optional<String> error = global.getError();
                 SyncConfig cfg = getUpdatedArgs();
                 List<Object> pairs = new ArrayList<>();
+                List<SyncStatus> pairStates = new ArrayList<>();
                 for (int i = 0; i < cfg.links.size(); i++) {
                     String link = cfg.links.get(i);
                     String label = link.substring(link.lastIndexOf("/", link.indexOf("#")) + 1, link.indexOf("#"));
@@ -307,9 +307,16 @@ public class SyncConfigHandler implements HttpHandler {
                     LinkedHashMap<String, Object> p = new LinkedHashMap<>();
                     p.put("label", label);
                     p.put("msg", ps.getStatusAndTime());
+                    p.put("state", ps.getStatus().name());
                     ps.getError().ifPresent(err -> p.put("error", err));
                     pairs.add(p);
+                    pairStates.add(ps.getStatus());
                 }
+                LinkedHashMap<Object, Object> reply = new LinkedHashMap<>();
+                reply.put("msg", global.getStatusAndTime());
+                boolean globalError = error.isPresent() || global.getStatus() == SyncStatus.ERROR;
+                reply.put("state", SyncStatus.aggregate(pairStates, globalError).name());
+                error.ifPresent(err -> reply.put("error", err));
                 reply.put("pairs", pairs);
                 byte[] res = JSONParser.toString(reply).getBytes(StandardCharsets.UTF_8);
                 exchange.sendResponseHeaders(200, res.length);

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -227,6 +227,7 @@ public class DirectorySync {
         while (true) {
             LOG.accept("Syncing " + links.size() + " pairs of directories: " + IntStream.range(0, links.size()).mapToObj(i -> Arrays.asList(localDirs.get(i), linkPaths.get(i))).collect(Collectors.toList()));
             boolean errored = false;
+            status.setStatus(SyncStatus.SYNCING);
             for (int i=0; i < links.size(); i++) {
                 SyncState syncedState = null;
                 PairLogger pairLog = pairLoggers.get(i);
@@ -246,6 +247,7 @@ public class DirectorySync {
                     Path remoteDir = PathUtil.get(linkPaths.get(i));
                     syncedState = syncedStates.get(i).get();
                     perPairLog.accept("Syncing " + localDir + " to+from " + remoteDir);
+                    pairStatus.setStatus(SyncStatus.SYNCING);
                     long t0 = System.currentTimeMillis();
                     String username = remoteDir.getName(0).toString();
                     PublicKeyHash owner = network.coreNode.getPublicKeyHash(username).join().get();
@@ -256,6 +258,7 @@ public class DirectorySync {
                         perPairLog.accept(isFlatpak ?
                                 "Restart Peergos to start syncing " + localDirs.get(i) :
                                 "Local dir does not exist! Please remove and recreate the sync.");
+                        pairStatus.setStatus(SyncStatus.ERROR);
                         errored = true;
                     } else {
                         SyncFilesystem local = localBuilder.apply(localDirs.get(i));
@@ -265,6 +268,7 @@ public class DirectorySync {
                         long t1 = System.currentTimeMillis();
                         perPairLog.accept("Dir sync took " + (t1 - t0) / 1000 + "s");
                         pairStatus.setError(null);
+                        pairStatus.setStatus(SyncStatus.SYNCED);
                     }
                 } catch (Exception e) {
                     errored = true;
@@ -272,6 +276,7 @@ public class DirectorySync {
                     if (pairLog != null)
                         pairLog.error(e.getMessage());
                     pairStatus.setError(e.getMessage());
+                    pairStatus.setStatus(SyncStatus.ERROR);
                     e.printStackTrace();
                     DirectorySync.LOG.log(Level.WARNING, e, e::getMessage);
                 } finally {
@@ -283,6 +288,7 @@ public class DirectorySync {
                         }
                 }
             }
+            status.setStatus(errored ? SyncStatus.ERROR : SyncStatus.SYNCED);
             if (!errored)
                 ERROR.accept(null);
             if (oneRun)

--- a/src/peergos/server/sync/PairStatus.java
+++ b/src/peergos/server/sync/PairStatus.java
@@ -21,6 +21,7 @@ public class PairStatus {
     private String status;
     private LocalDateTime updateTime;
     private Optional<String> error = Optional.empty();
+    private SyncStatus state = SyncStatus.SYNCED;
 
     public PairStatus(Path peergosDir, String pairHash) {
         this.pairHash = pairHash;
@@ -47,6 +48,9 @@ public class PairStatus {
             updateTime = t == null ? null : LocalDateTime.parse(t.toString(), TS);
             Object e = json.get("error");
             error = e == null || e.toString().isEmpty() ? Optional.empty() : Optional.of(e.toString());
+            // status files written by older versions have no state
+            Object s = json.get("state");
+            state = SyncStatus.parseOrDefault(s == null ? null : s.toString(), SyncStatus.SYNCED);
         } catch (Exception ex) {
             // Corrupt or unreadable status file — start fresh, don't crash sync.
             System.err.println("Failed to load sync status " + file + ": " + ex.getMessage());
@@ -62,6 +66,15 @@ public class PairStatus {
     public synchronized void setError(String err) {
         error = err == null || err.isEmpty() ? Optional.empty() : Optional.of(err);
         persist();
+    }
+
+    public synchronized void setStatus(SyncStatus newState) {
+        state = newState;
+        persist();
+    }
+
+    public synchronized SyncStatus getStatus() {
+        return state;
     }
 
     public synchronized String getStatusAndTime() {
@@ -88,6 +101,7 @@ public class PairStatus {
             LinkedHashMap<String, Object> json = new LinkedHashMap<>();
             json.put("msg", status == null ? "" : status);
             json.put("error", error.orElse(""));
+            json.put("state", state.name());
             json.put("time", updateTime == null ? "" : updateTime.format(TS));
             byte[] bytes = JSONParser.toString(json).getBytes(StandardCharsets.UTF_8);
             Path tmp = file.resolveSibling(file.getFileName() + ".tmp");

--- a/src/peergos/server/sync/SyncRunner.java
+++ b/src/peergos/server/sync/SyncRunner.java
@@ -37,6 +37,7 @@ public interface SyncRunner {
         private String status;
         private LocalDateTime updateTime;
         private Optional<String> error = Optional.empty();
+        private SyncStatus state = SyncStatus.SYNCED;
         private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
         public synchronized void cancel() {
@@ -60,6 +61,14 @@ public interface SyncRunner {
             this.error = error == null || error.isEmpty() ?
                     Optional.empty() :
                     Optional.of(error);
+        }
+
+        public synchronized void setStatus(SyncStatus newState) {
+            state = newState;
+        }
+
+        public synchronized SyncStatus getStatus() {
+            return state;
         }
 
         public synchronized String getStatusAndTime() {

--- a/src/peergos/server/sync/SyncStatus.java
+++ b/src/peergos/server/sync/SyncStatus.java
@@ -1,0 +1,40 @@
+package peergos.server.sync;
+
+import java.util.List;
+
+/** The machine readable state of a sync, reported alongside the human readable status message.
+ *  Clients (the desktop tray icon, the web ui) should switch on this rather than parsing messages.
+ *  (Not to be confused with {@link SyncState}, which is the local file tree db.)
+ */
+public enum SyncStatus {
+    /** No sync pairs are configured, so there is nothing to report. Only ever the global aggregate. */
+    NONE,
+    SYNCED,
+    SYNCING,
+    ERROR;
+
+    public static SyncStatus parseOrDefault(String name, SyncStatus fallback) {
+        if (name == null)
+            return fallback;
+        for (SyncStatus s : values()) {
+            if (s.name().equals(name))
+                return s;
+        }
+        return fallback;
+    }
+
+    /** Combine the per pair states into the single global state a tray icon can display.
+     *
+     * @param pairStates the state of every configured sync pair
+     * @param globalError whether the global status holder is reporting an error
+     */
+    public static SyncStatus aggregate(List<SyncStatus> pairStates, boolean globalError) {
+        if (pairStates.isEmpty())
+            return NONE;
+        if (globalError || pairStates.contains(ERROR))
+            return ERROR;
+        if (pairStates.contains(SYNCING))
+            return SYNCING;
+        return SYNCED;
+    }
+}

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -693,4 +693,42 @@ public class SyncTests {
         Snapshot s = synced.getSnapshot("/some/dir");
         Assert.assertTrue(s.equals(original));
     }
+
+    @Test
+    public void syncStatusAggregation() {
+        // no pairs configured => nothing to report, rather than "all good"
+        Assert.assertEquals(SyncStatus.NONE, SyncStatus.aggregate(Collections.emptyList(), false));
+        Assert.assertEquals(SyncStatus.NONE, SyncStatus.aggregate(Collections.emptyList(), true));
+
+        Assert.assertEquals(SyncStatus.SYNCED, SyncStatus.aggregate(List.of(SyncStatus.SYNCED, SyncStatus.SYNCED), false));
+        Assert.assertEquals(SyncStatus.SYNCING, SyncStatus.aggregate(List.of(SyncStatus.SYNCED, SyncStatus.SYNCING), false));
+        // an error anywhere wins over a sync in progress
+        Assert.assertEquals(SyncStatus.ERROR, SyncStatus.aggregate(List.of(SyncStatus.SYNCING, SyncStatus.ERROR), false));
+        // a global error with all pairs happy still reports an error
+        Assert.assertEquals(SyncStatus.ERROR, SyncStatus.aggregate(List.of(SyncStatus.SYNCED), true));
+    }
+
+    @Test
+    public void pairStatusState() throws IOException {
+        Path peergosDir = Files.createTempDirectory("peergos-sync-test");
+        String hash = "1234";
+        PairStatus status = new PairStatus(peergosDir, hash);
+        Assert.assertEquals(SyncStatus.SYNCED, status.getStatus());
+
+        status.setStatus("Syncing /local to+from /remote");
+        status.setStatus(SyncStatus.SYNCING);
+        Assert.assertEquals(SyncStatus.SYNCING, status.getStatus());
+
+        // the state survives a round trip through disk
+        Assert.assertEquals(SyncStatus.SYNCING, new PairStatus(peergosDir, hash).getStatus());
+        status.setStatus(SyncStatus.ERROR);
+        Assert.assertEquals(SyncStatus.ERROR, new PairStatus(peergosDir, hash).getStatus());
+
+        // a status file written by an older version has no state, and defaults to SYNCED
+        Path file = PairStatus.statusPath(peergosDir, hash);
+        Files.write(file, "{\"msg\":\"Dir sync took 3s\",\"error\":\"\",\"time\":\"2026-07-17T11:04:22\"}".getBytes(StandardCharsets.UTF_8));
+        PairStatus old = new PairStatus(peergosDir, hash);
+        Assert.assertEquals(SyncStatus.SYNCED, old.getStatus());
+        Assert.assertEquals("Dir sync took 3s", old.getMessage());
+    }
 }


### PR DESCRIPTION
- new SyncStatus enum, persisted per pair and tracked globally
- sync/status returns a top level and per pair "state"
- flatpak launches peergos-window instead of flatpak.sh