### PR TITLE
Fix Base36 corrupting high-bit leading bytes and all-zero input

### DIFF
--- a/src/peergos/server/tests/MultibaseTests.java
+++ b/src/peergos/server/tests/MultibaseTests.java
@@ -37,6 +37,26 @@ public class MultibaseTests {
     }
 
     @Test
+    public void base36Test() {
+        // a leading byte >= 0x80 gains a sign byte in BigInteger.toByteArray()
+        for (int leadingByte = 0x80; leadingByte <= 0xFF; leadingByte++) {
+            byte[] original = new byte[]{(byte) leadingByte, 0x01};
+            String encoded = Multibase.encode(Multibase.Base.Base36, original);
+            assertArrayEquals(original, Multibase.decode(encoded));
+        }
+    }
+
+    @Test
+    public void zeroBytesBase36() {
+        for (int i=0; i < 32; i++) {
+            String encoded = Multibase.encode(Multibase.Base.Base36, new byte[i]);
+            byte[] output = Multibase.decode(encoded);
+            if (! Arrays.equals(output, new byte[i]))
+                throw new IllegalStateException("Failed to round trip zero array of length " + i);
+        }
+    }
+
+    @Test
     public void base16Test() {
         List<String> examples = Arrays.asList("f234abed8debede",
                 "f87ad873defc2b288",

--- a/src/peergos/shared/io/ipfs/bases/Base36.java
+++ b/src/peergos/shared/io/ipfs/bases/Base36.java
@@ -5,20 +5,24 @@ import java.math.*;
 public class Base36 {
 
     public static byte[] decode(String in) {
-        byte[] withoutLeadingZeroes = new BigInteger(in, 36).toByteArray();
         int zeroPrefixLength = zeroPrefixLength(in);
-        byte[] res = new byte[zeroPrefixLength + withoutLeadingZeroes.length];
-        System.arraycopy(withoutLeadingZeroes, 0, res, zeroPrefixLength, withoutLeadingZeroes.length);
+        if (zeroPrefixLength == in.length())
+            return new byte[zeroPrefixLength];
+        byte[] withoutLeadingZeroes = new BigInteger(in, 36).toByteArray();
+        // toByteArray() is 2s complement, and prepends a 0 sign byte when the top bit of the magnitude is set
+        int magnitudeStart = withoutLeadingZeroes.length > 1 && withoutLeadingZeroes[0] == 0 ? 1 : 0;
+        byte[] res = new byte[zeroPrefixLength + withoutLeadingZeroes.length - magnitudeStart];
+        System.arraycopy(withoutLeadingZeroes, magnitudeStart, res, zeroPrefixLength, withoutLeadingZeroes.length - magnitudeStart);
         return res;
     }
 
     public static String encode(byte[] in) {
-        String withoutLeadingZeroes = new BigInteger(1, in).toString(36);
         int zeroPrefixLength = zeroPrefixLength(in);
         StringBuilder b = new StringBuilder();
         for (int i=0; i < zeroPrefixLength; i++)
             b.append("0");
-        b.append(withoutLeadingZeroes);
+        if (zeroPrefixLength < in.length) // an all zero input is already fully encoded by the zero prefix
+            b.append(new BigInteger(1, in).toString(36));
         return b.toString();
     }
 


### PR DESCRIPTION
## Summary
Two related bugs in `Base36.decode`/`encode`:
- `BigInteger.toByteArray()` is two's-complement and prepends a spurious `0x00` sign byte whenever the true magnitude's high bit is set; this was never stripped, corrupting roughly half of all round trips (e.g. `[0xFF]` round-tripped to `[0x00, 0xFF]`)
- Separately, all-zero-byte input grew by 2 bytes on every round trip
- Reachable from any base36-multibase (`'k'`-prefixed) value; there was no existing test coverage for this codec

## Testing
- Added `MultibaseTests.base36Test` and `MultibaseTests.zeroBytesBase36`
- Both confirmed failing on the pre-fix code, passing with the fix