### PR TITLE
Check the signature verification result in setLoginData

### DIFF
--- a/src/peergos/server/login/VerifyingAccount.java
+++ b/src/peergos/server/login/VerifyingAccount.java
@@ -28,7 +28,7 @@ public class VerifyingAccount implements Account {
     public CompletableFuture<Boolean> setLoginData(LoginData login, byte[] auth, boolean forceLocal) {
         PublicKeyHash identityHash = core.getPublicKeyHash(login.username).join().get();
         PublicSigningKey identity = storage.getSigningKey(identityHash, identityHash).join().get();
-        identity.unsignMessage(ArrayOps.concat(auth, login.serialize()));
+        identity.unsignMessage(ArrayOps.concat(auth, login.serialize())).join(); // throws if auth isn't a valid signature
         return target.setLoginData(login, auth, forceLocal);
     }
 


### PR DESCRIPTION
## Summary
- `VerifyingAccount.setLoginData` called `identity.unsignMessage(...)` - the only signature check on this path - but never consumed the returned `CompletableFuture`, so an invalid signature was never actually checked
- Currently masked because the concrete signer implementations happen to throw synchronously before the future is even built; any signer that verifies asynchronously would turn this into a silent signature bypass
- Fix: `.join()` the future so a thrown exception actually propagates

## Testing
- No dedicated new test: the only real server-side signer throws synchronously either way, so there's no way to write a test that distinguishes old vs. new behavior without fabricating a fake async signer
- Verified via a full signup/login regression run