### PR TITLE
Detect EOF in Multihash.readVarint instead of returning a garbage value

### DIFF
--- a/src/peergos/server/tests/VarintTests.java
+++ b/src/peergos/server/tests/VarintTests.java
@@ -15,4 +15,21 @@ public class VarintTests {
             throw new RuntimeException("Should throw for non minimal encoding");
         } catch (IllegalStateException e) {}
     }
+
+    @Test
+    public void truncated() throws IOException {
+        try {
+            // 0x81 promises a continuation byte that never arrives
+            Multihash.readVarint(new ByteArrayInputStream(new byte[]{(byte) 0x81}));
+            throw new RuntimeException("Should throw for a truncated varint");
+        } catch (EOFException e) {}
+    }
+
+    @Test
+    public void emptyStream() throws IOException {
+        try {
+            Multihash.readVarint(new ByteArrayInputStream(new byte[0]));
+            throw new RuntimeException("Should throw for an empty stream");
+        } catch (EOFException e) {}
+    }
 }

--- a/src/peergos/shared/io/ipfs/Multihash.java
+++ b/src/peergos/shared/io/ipfs/Multihash.java
@@ -159,6 +159,8 @@ public class Multihash implements Comparable<Multihash> {
         int s=0;
         for (int i=0; i < 10; i++) {
             int b = in.read();
+            if (b == -1)
+                throw new EOFException();
             if (b < 0x80) {
                 if (i == 9 && b > 1) {
                     throw new IllegalStateException("Overflow reading varint!");


### PR DESCRIPTION
## Summary
- `readVarint` only checked `b < 0x80` and `b == 0`, so `in.read()` returning `-1` (EOF) on a truncated stream was silently treated as a data byte, producing a bogus value instead of an error
- The sibling `Protocol.readVarint` already has an explicit EOF check

## Testing
- Added `VarintTests.truncated` and `VarintTests.emptyStream`
- Both confirmed failing on the pre-fix code, passing with the fix