### PR TITLE
Fix AsyncReader dropping CBOR records that straddle a chunk boundary

### DIFF
--- a/src/peergos/server/tests/CborObjects.java
+++ b/src/peergos/server/tests/CborObjects.java
@@ -3,8 +3,10 @@ package peergos.server.tests;
 import org.junit.*;
 import peergos.shared.cbor.*;
 import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.user.fs.AsyncReader;
 import peergos.shared.util.*;
 
+import java.io.*;
 import java.util.*;
 
 public class CborObjects {
@@ -104,6 +106,27 @@ public class CborObjects {
         list.add(new CborObject.CborBoolean(true));
         CborObject.CborList cborList = new CborObject.CborList(list);
         compatibleAndIdempotentSerialization(cborList);
+    }
+
+    @Test
+    public void parseStreamAcrossChunkBoundary() throws Exception {
+        // these sizes make the second object straddle a Chunk.MAX_SIZE read boundary, which used to
+        // result in the third object being dropped
+        List<CborObject> objects = new ArrayList<>();
+        objects.add(new CborObject.CborByteArray(random(2_000_000)));
+        objects.add(new CborObject.CborByteArray(random(4_000_000)));
+        objects.add(new CborObject.CborByteArray(random(500_000)));
+
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        for (CborObject o : objects)
+            bout.write(o.toByteArray());
+        byte[] serialized = bout.toByteArray();
+
+        List<CborObject> parsed = new ArrayList<>();
+        new AsyncReader.ArrayBacked(serialized).parseStream(c -> (CborObject) c, parsed::add, serialized.length).join();
+
+        Assert.assertEquals("All objects parsed", objects.size(), parsed.size());
+        Assert.assertEquals(objects, parsed);
     }
 
     public void compatibleAndIdempotentSerialization(CborObject value) {

--- a/src/peergos/shared/user/fs/AsyncReader.java
+++ b/src/peergos/shared/user/fs/AsyncReader.java
@@ -59,19 +59,20 @@ public interface AsyncReader extends AutoCloseable {
     default <T> CompletableFuture<Long> parseStreamRecurse(byte[] prefix, Function<Cborable, T> fromCbor, Consumer<T> accumulator, long maxBytesToRead) {
         if (maxBytesToRead == 0)
             return CompletableFuture.completedFuture(0L);
-        byte[] buf = new byte[Chunk.MAX_SIZE];
+        int toRead = (int) Math.min(Chunk.MAX_SIZE - prefix.length, maxBytesToRead);
+        byte[] buf = new byte[prefix.length + toRead];
         System.arraycopy(prefix, 0, buf, 0, prefix.length);
         ByteArrayInputStream in = new ByteArrayInputStream(buf);
-        return readIntoArray(buf, prefix.length, (int) Math.min((long)(buf.length - prefix.length), maxBytesToRead))
+        return readIntoArray(buf, prefix.length, toRead)
                 .thenCompose(bytesRead -> {
-                    for (int localOffset = 0; localOffset < bytesRead;) {
+                    for (int localOffset = 0; localOffset < prefix.length + bytesRead;) {
                         try {
-                            CborObject readObject = CborObject.read(in, bytesRead);
+                            CborObject readObject = CborObject.read(in, prefix.length + bytesRead);
                             accumulator.accept(fromCbor.apply(readObject));
                             localOffset += readObject.toByteArray().length;
                         } catch (RuntimeException e) {
                             int fromThisChunk = localOffset;
-                            return parseStreamRecurse(Arrays.copyOfRange(buf, localOffset, bytesRead), fromCbor, accumulator,
+                            return parseStreamRecurse(Arrays.copyOfRange(buf, localOffset, prefix.length + bytesRead), fromCbor, accumulator,
                                     maxBytesToRead - bytesRead)
                                     .thenApply(rest -> rest + fromThisChunk);
                         }


### PR DESCRIPTION
## Summary
- `parseStreamRecurse` sized/bounded its read buffer using only the freshly-read byte count (`bytesRead`), ignoring a carried-over `prefix` from a prior partial read
- A CBOR record straddling a 5MiB chunk boundary could cause subsequent records to be silently dropped - affects friend-capability sharing records and social feed parsing once accumulated data exceeds ~5MiB
- The sibling method `parseLimitedStreamRecurse` already accounts for this correctly; this fix mirrors its buffer/offset handling

## Testing
- Added `CborObjects.parseStreamAcrossChunkBoundary` with object sizes chosen to deterministically straddle the boundary
- Confirmed it loses 2 of 3 objects on the pre-fix code and recovers all 3 with the fix