### PR TITLE
Fix orphaned chunk leak when truncating a file into its first chunk

### DIFF
--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -1480,9 +1480,15 @@ public abstract class UserTests {
 
         // truncate to first chunk
         int truncateLength2 = 1 * 1024 * 1024;
+        Pair<byte[], Optional<Bat>> secondChunkLabel = truncated.getMapKey(6 * 1024 * 1024, network, crypto).join();
         FileWrapper truncated2 = truncated.truncate(truncateLength2, network, crypto).join();
         checkFileContents(Arrays.copyOfRange(data, 0, truncateLength2), truncated2, context);
         Assert.assertTrue("File has correct size", truncated2.getFileProperties().size == truncateLength2);
+        // check we can't get the second chunk any more
+        WritableAbsoluteCapability pointer2 = truncated.writableFilePointer();
+        CommittedWriterData cwd2 = network.synchronizer.getValue(pointer2.owner, pointer2.writer).join().get(pointer2.writer);
+        Optional<CryptreeNode> secondChunk = network.getMetadata(cwd2, pointer2.withMapKey(secondChunkLabel.left, secondChunkLabel.right)).join();
+        Assert.assertTrue("Orphaned chunk is deleted", ! secondChunk.isPresent());
 
         // truncate within first chunk
         int truncateLength3 = 1024 * 1024 / 2;

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -633,9 +633,17 @@ public class FileWrapper {
                             return originalReader.seek(startOfLastChunk).thenCompose(seekedOriginal -> {
                                 byte[] lastChunk = new byte[(int)(newSize % Chunk.MAX_SIZE)];
                                 return seekedOriginal.readIntoArray(lastChunk, 0, lastChunk.length).thenCompose(read -> {
-                                    if (newSize <= Chunk.MAX_SIZE)
-                                        return CompletableFuture.completedFuture(snapshot);
                                     int currentChunk = (int) (newSize / Chunk.MAX_SIZE);
+                                    if (currentChunk == 0) {
+                                        if (props.chunkCount() <= 1)
+                                            return CompletableFuture.completedFuture(snapshot);
+                                        // chunk 0 is the file's entry point, so start deleting from chunk 1
+                                        return getMapKey(Chunk.MAX_SIZE, network, crypto).thenCompose(secondChunk ->
+                                                IpfsTransaction.call(owner(), tid ->
+                                                                deleteFileChunks(props.streamSecret.get(), props.chunkCount() - 1, writableFilePointer().withMapKey(secondChunk.left, secondChunk.right),
+                                                                        signingPair(), tid, crypto.hasher, network, snapshot, committer),
+                                                        network.dhtClient));
+                                    }
                                     return IpfsTransaction.call(owner(), tid ->
                                                     deleteFileChunks(props.streamSecret.get(), props.chunkCount() - currentChunk, writableFilePointer().withMapKey(endMapKey.left, endMapKey.right),
                                                             signingPair(), tid, crypto.hasher, network, snapshot, committer),


### PR DESCRIPTION
## Summary
- `FileWrapper.truncate()` skipped chunk deletion entirely whenever the new size fit within the first chunk, instead of just skipping deletion of chunk 0 itself
- The trailing chunks stayed reachable in the writer's CHAMP forever, and were never enumerated by the eventual file-delete path either, since chunk count is derived from the already-truncated size
- Fix: only skip deletion for genuinely single-chunk files; otherwise start deletion at chunk 1 (chunk 0 is the file's own entry point and must never be deleted here)

## Testing
- Extended `UserTests.truncate()` to assert the orphaned chunk is actually deleted after truncating a multi-chunk file down into its first chunk
- Confirmed the new assertion fails on the pre-fix code and passes with the fix