### PR TITLE
Implement equals and hashCode on Version

### DIFF
--- a/src/peergos/shared/util/Version.java
+++ b/src/peergos/shared/util/Version.java
@@ -39,6 +39,29 @@ public class Version implements Comparable<Version> {
         return suffix.compareTo(other.suffix);
     }
 
+    // Consistent with compareTo, which is 0 only when all four fields match.
+    // Without this two parses of the same version are unequal, and callers
+    // comparing a version read from a server with their own never match.
+    @Override
+    public boolean equals(Object other) {
+        if (this == other)
+            return true;
+        if (other == null || getClass() != other.getClass())
+            return false;
+        Version that = (Version) other;
+        return major == that.major && minor == that.minor && patch == that.patch
+                && suffix.equals(that.suffix);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = major;
+        result = 31 * result + minor;
+        result = 31 * result + patch;
+        result = 31 * result + suffix.hashCode();
+        return result;
+    }
+
     public static Version parse(String version) {
         int first = version.indexOf(".");
         int second = version.indexOf(".", first + 1);


### PR DESCRIPTION
### Problem

`Version` implements `Comparable` but not `equals`, so two `Version` objects
holding the same numbers are never equal. Any caller comparing a version it
parsed against one it built itself gets `false`.

This makes the `VersionInfo.equals` added in 7ce872d silently ineffective.
`VersionInfo.equals` compares its `Version` field with `Objects.equals`, which
falls through to identity, so it still always returns `false`.

The visible effect is in the desktop app. `Main` compares the running
instance's version with its own to decide whether an instance is already up:

```java
if (! running.equals(ourVersion))
    STOP.main(args);
else
    alreadyRunning = true;
```

Because the comparison never matches, every launch takes the `STOP` branch and
shuts down the running server, then starts another one. The server is torn down
and restarted on every launch, losing sync state and paying full startup cost,
and the window belonging to the stopped server is left behind.

### Fix

Compare the four fields. This is consistent with `compareTo`, which returns 0
only when all four match, so `compareTo(x) == 0` and `equals(x)` now agree.

Written without `java.util.Objects` to avoid adding an import to shared code
that GWT compiles. `suffix` is never null: `parse` always sets it, and both
`toString` and `compareTo` already dereference it.

### Testing

Built the flatpak and launched Peergos while it was already running. The
existing server and window survive, and the second launch reports "already
running, showing that window instead". Before this change the same test stopped
the server and replaced both processes.