### PR TITLE
Drive security keys through webauthn.dll on windows

### DIFF
--- a/src/peergos/server/net/WebAuthnHandler.java
+++ b/src/peergos/server/net/WebAuthnHandler.java
@@ -5,7 +5,7 @@ import com.sun.net.httpserver.HttpHandler;
 import peergos.server.util.HttpUtil;
 import peergos.server.util.Logging;
 import peergos.server.webauthn.Ctap2;
-import peergos.server.webauthn.CtapHid;
+import peergos.server.webauthn.SecurityKey;
 import peergos.shared.io.ipfs.api.JSONParser;
 import peergos.shared.util.Constants;
 import peergos.shared.util.Serialize;
@@ -14,23 +14,25 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /** Drives a security key on behalf of the local web ui.
  *
- *  The webview in the desktop app has no WebAuthn of its own, so the app is the
- *  user agent here, exactly as the android app is: it builds the clientDataJSON
- *  and asks the key to sign it. That is also what lets a key registered in a
- *  browser for peergos.net be used from localhost, which no browser will do,
- *  because the origin we claim follows the relying party rather than the window.
+ *  The webview in the desktop app either has no WebAuthn of its own, or has one that
+ *  can only mint credentials for rpId localhost, so the app is the user agent here,
+ *  exactly as the android app is: it builds the clientDataJSON and asks the key to
+ *  sign it. That is also what lets a key registered in a browser for peergos.net be
+ *  used from localhost, which no browser will do, because the origin we claim follows
+ *  the relying party rather than the window.
+ *
+ *  How we then reach the key is the one platform specific part, and lives behind
+ *  SecurityKey.
  */
 public class WebAuthnHandler implements HttpHandler {
     private static final Logger LOG = Logging.LOG();
@@ -39,11 +41,13 @@ public class WebAuthnHandler implements HttpHandler {
 
     private final String defaultRpId;
     private final int localPort;
+    private final SecurityKey key;
     private final Object oneAtATime = new Object();
 
     public WebAuthnHandler(String appServerUrl, int localPort) {
         this.defaultRpId = hostOf(appServerUrl);
         this.localPort = localPort;
+        this.key = SecurityKey.forThisPlatform();
     }
 
     private static String hostOf(String serverUrl) {
@@ -108,6 +112,12 @@ public class WebAuthnHandler implements HttpHandler {
             String action = path.substring(Constants.WEBAUTHN.length());
             Map<String, Object> body = (Map<String, Object>) JSONParser.parse(
                     new String(Serialize.readFully(exchange.getRequestBody()), StandardCharsets.UTF_8));
+
+            if (action.equals("host")) {
+                reply(exchange, setHostWindow(body));
+                return;
+            }
+
             Map<String, Object> options = (Map<String, Object>) body.get("publicKey");
             if (options == null)
                 throw new IllegalArgumentException("No publicKey options");
@@ -125,11 +135,7 @@ public class WebAuthnHandler implements HttpHandler {
                     return;
                 }
             }
-            byte[] reply = JSONParser.toString(result).getBytes(StandardCharsets.UTF_8);
-            exchange.sendResponseHeaders(200, reply.length);
-            try (OutputStream out = exchange.getResponseBody()) {
-                out.write(reply);
-            }
+            reply(exchange, result);
         } catch (Exception e) {
             LOG.log(Level.WARNING, e.getMessage(), e);
             HttpUtil.replyError(exchange, e);
@@ -147,15 +153,13 @@ public class WebAuthnHandler implements HttpHandler {
             throw new IllegalArgumentException("No user in the registration options");
         byte[] clientData = clientDataJson("webauthn.create", bytes(options.get("challenge")), rpId);
 
-        try (CtapHid key = openKey()) {
-            Ctap2.Credential credential = Ctap2.makeCredential(key, sha256(clientData), rpId, rpName,
-                    bytes(user.get("id")), string(user.get("name")), string(user.get("displayName")),
-                    algorithms(options), System.currentTimeMillis() + TOUCH_TIMEOUT_MILLIS);
-            Map<String, Object> response = new LinkedHashMap<>();
-            response.put("attestationObject", base64url(credential.attestationObject));
-            response.put("clientDataJSON", base64url(clientData));
-            return credentialJson(credential.credentialId, response);
-        }
+        Ctap2.Credential credential = key.makeCredential(clientData, rpId, rpName,
+                bytes(user.get("id")), string(user.get("name")), string(user.get("displayName")),
+                algorithms(options), System.currentTimeMillis() + TOUCH_TIMEOUT_MILLIS);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("attestationObject", base64url(credential.attestationObject));
+        response.put("clientDataJSON", base64url(clientData));
+        return credentialJson(credential.credentialId, response);
     }
 
     private Map<String, Object> authenticate(Map<String, Object> options) throws IOException {
@@ -168,24 +172,40 @@ public class WebAuthnHandler implements HttpHandler {
                 allowed.add(bytes(((Map<String, Object>) entry).get("id")));
         }
 
-        try (CtapHid key = openKey()) {
-            Ctap2.Credential credential = Ctap2.getAssertion(key, rpId, sha256(clientData), allowed,
-                    System.currentTimeMillis() + TOUCH_TIMEOUT_MILLIS);
-            Map<String, Object> response = new LinkedHashMap<>();
-            response.put("clientDataJSON", base64url(clientData));
-            response.put("authenticatorData", base64url(credential.authenticatorData));
-            response.put("signature", base64url(credential.signature));
-            if (credential.userHandle != null)
-                response.put("userHandle", base64url(credential.userHandle));
-            return credentialJson(credential.credentialId, response);
-        }
+        Ctap2.Credential credential = key.getAssertion(clientData, rpId, allowed,
+                System.currentTimeMillis() + TOUCH_TIMEOUT_MILLIS);
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("clientDataJSON", base64url(clientData));
+        response.put("authenticatorData", base64url(credential.authenticatorData));
+        response.put("signature", base64url(credential.signature));
+        if (credential.userHandle != null)
+            response.put("userHandle", base64url(credential.userHandle));
+        return credentialJson(credential.credentialId, response);
     }
 
-    private static CtapHid openKey() throws IOException {
-        Optional<CtapHid> key = CtapHid.openFirst();
-        if (! key.isPresent())
-            throw new IOException("No security key found. Plug your key in and try again.");
-        return key.get();
+    /** The desktop host telling us about its window, so a platform prompt - the windows
+     *  one - can be modal to it and come to the front. The java server has no window of
+     *  its own, and the host is a different process.
+     *
+     *  Nothing is trusted to this beyond where a dialog gets parented: the worst a local
+     *  caller can do with a made up handle is send the prompt somewhere unhelpful, which
+     *  is exactly what happens today with no handle at all.
+     */
+    private Map<String, Object> setHostWindow(Map<String, Object> body) {
+        Object handle = body.get("window");
+        if (! (handle instanceof Number) && ! (handle instanceof String))
+            throw new IllegalArgumentException("No window handle");
+        key.setWindowHandle(handle instanceof Number ? ((Number) handle).longValue()
+                : Long.parseLong(handle.toString()));
+        return Map.of("ok", true);
+    }
+
+    private static void reply(HttpExchange exchange, Map<String, Object> result) throws IOException {
+        byte[] reply = JSONParser.toString(result).getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, reply.length);
+        try (OutputStream out = exchange.getResponseBody()) {
+            out.write(reply);
+        }
     }
 
     private static Map<String, Object> credentialJson(byte[] credentialId, Map<String, Object> response) {
@@ -238,13 +258,5 @@ public class WebAuthnHandler implements HttpHandler {
 
     private static String base64url(byte[] data) {
         return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
-    }
-
-    private static byte[] sha256(byte[] data) {
-        try {
-            return MessageDigest.getInstance("SHA-256").digest(data);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/src/peergos/server/tests/WindowsWebauthnLayout.java
+++ b/src/peergos/server/tests/WindowsWebauthnLayout.java
@@ -1,0 +1,111 @@
+package peergos.server.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.foreign.MemoryLayout;
+import java.lang.reflect.Field;
+
+/**
+ *  The one part of the windows security key support that can be checked without windows.
+ *
+ *  A struct laid out wrongly does not fail loudly, it passes garbage to webauthn.dll: a
+ *  DWORD followed by a pointer leaves a 4 byte hole on x64, and missing one shifts every
+ *  field after it. So the offsets are pinned here against webauthn.h, where they are read
+ *  off the declared layouts exactly as the calls read them.
+ *
+ *  Loading the class is itself part of the test: everything that touches the dll lives in
+ *  a holder class, so this must initialise on linux without one.
+ */
+public class WindowsWebauthnLayout {
+
+    private static final Class<?> WINDOWS_KEY = load();
+
+    private static Class<?> load() {
+        try {
+            return Class.forName("peergos.server.webauthn.WindowsSecurityKey");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void inputStructs() {
+        // WEBAUTHN_RP_ENTITY_INFORMATION
+        check("RP_ENTITY", 32, "dwVersion", 0, "pwszId", 8, "pwszName", 16, "pwszIcon", 24);
+        // WEBAUTHN_USER_ENTITY_INFORMATION
+        check("USER_ENTITY", 40, "dwVersion", 0, "cbId", 4, "pbId", 8, "pwszName", 16,
+                "pwszIcon", 24, "pwszDisplayName", 32);
+        // WEBAUTHN_CLIENT_DATA
+        check("CLIENT_DATA", 24, "dwVersion", 0, "cbClientDataJSON", 4, "pbClientDataJSON", 8,
+                "pwszHashAlgId", 16);
+        // WEBAUTHN_COSE_CREDENTIAL_PARAMETER{,S}
+        check("COSE_PARAMETER", 24, "dwVersion", 0, "pwszCredentialType", 8, "lAlg", 16);
+        check("COSE_PARAMETERS", 16, "cCredentialParameters", 0, "pCredentialParameters", 8);
+        // WEBAUTHN_CREDENTIAL{,S}
+        check("CREDENTIAL", 24, "dwVersion", 0, "cbId", 4, "pbId", 8, "pwszCredentialType", 16);
+        check("CREDENTIALS", 16, "cCredentials", 0, "pCredentials", 8);
+        check("EXTENSIONS", 16, "cExtensions", 0, "pExtensions", 8);
+    }
+
+    @Test
+    public void optionStructs() {
+        // WEBAUTHN_AUTHENTICATOR_MAKE_CREDENTIAL_OPTIONS, version 1
+        check("MAKE_CREDENTIAL_OPTIONS", 64, "dwVersion", 0, "dwTimeoutMilliseconds", 4,
+                "CredentialList", 8, "Extensions", 24, "dwAuthenticatorAttachment", 40,
+                "bRequireResidentKey", 44, "dwUserVerificationRequirement", 48,
+                "dwAttestationConveyancePreference", 52, "dwFlags", 56);
+        // WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS, version 1
+        check("GET_ASSERTION_OPTIONS", 56, "dwVersion", 0, "dwTimeoutMilliseconds", 4,
+                "CredentialList", 8, "Extensions", 24, "dwAuthenticatorAttachment", 40,
+                "dwUserVerificationRequirement", 44, "dwFlags", 48);
+        // the allow list is written through the version 1 CredentialList
+        check("GET_ASSERTION_OPTIONS", 56, "CredentialList.cCredentials", 8,
+                "CredentialList.pCredentials", 16);
+    }
+
+    /** These two the dll allocates and we only read, so the offsets have to be right in a
+     *  struct we never see the size of. Reading version 1 fields is safe at any version,
+     *  because later versions only append. */
+    @Test
+    public void returnedStructs() {
+        // WEBAUTHN_CREDENTIAL_ATTESTATION
+        check("CREDENTIAL_ATTESTATION", 96, "dwVersion", 0, "pwszFormatType", 8,
+                "cbAuthenticatorData", 16, "pbAuthenticatorData", 24, "cbAttestation", 32,
+                "pbAttestation", 40, "dwAttestationDecodeType", 48, "pvAttestationDecode", 56,
+                "cbAttestationObject", 64, "pbAttestationObject", 72, "cbCredentialId", 80,
+                "pbCredentialId", 88);
+        // WEBAUTHN_ASSERTION, including the credential the key actually asserted with
+        check("ASSERTION", 72, "dwVersion", 0, "cbAuthenticatorData", 4, "pbAuthenticatorData", 8,
+                "cbSignature", 16, "pbSignature", 24, "Credential", 32, "Credential.cbId", 36,
+                "Credential.pbId", 40, "cbUserId", 56, "pbUserId", 64);
+    }
+
+    private static void check(String struct, long size, Object... fieldsAndOffsets) {
+        MemoryLayout layout = layout(struct);
+        Assert.assertEquals(struct + " size", size, layout.byteSize());
+        for (int i = 0; i < fieldsAndOffsets.length; i += 2) {
+            String field = (String) fieldsAndOffsets[i];
+            long expected = ((Number) fieldsAndOffsets[i + 1]).longValue();
+            Assert.assertEquals(struct + "." + field, expected, offset(layout, field));
+        }
+    }
+
+    private static long offset(MemoryLayout layout, String path) {
+        String[] names = path.split("\\.");
+        MemoryLayout.PathElement[] elements = new MemoryLayout.PathElement[names.length];
+        for (int i = 0; i < names.length; i++)
+            elements[i] = MemoryLayout.PathElement.groupElement(names[i]);
+        return layout.byteOffset(elements);
+    }
+
+    private static MemoryLayout layout(String name) {
+        try {
+            Field field = WINDOWS_KEY.getDeclaredField(name);
+            field.setAccessible(true);
+            return (MemoryLayout) field.get(null);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("No layout " + name + " in WindowsSecurityKey", e);
+        }
+    }
+}

--- a/src/peergos/server/webauthn/Ctap2.java
+++ b/src/peergos/server/webauthn/Ctap2.java
@@ -130,8 +130,13 @@ public class Ctap2 {
         return new Credential(credentialId, authenticatorData, signature, userHandle, null);
     }
 
-    /** The server only accepts a none attestation, so keep authData - which carries
-     *  the public key - and drop whatever the key said about itself. */
+    /** Keep authData - which carries the public key - and drop whatever the key said
+     *  about itself.
+     *
+     *  The server no longer requires this: since Nitrokey support it accepts a self
+     *  attestation too, and never keeps the statement either way. We still send none
+     *  because it is the same shape from every platform, and the smallest thing that
+     *  registers. */
     static byte[] noneAttestation(byte[] authenticatorData) throws IOException {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
         CborEncoder out = new CborEncoder(bout);

--- a/src/peergos/server/webauthn/LinuxSecurityKey.java
+++ b/src/peergos/server/webauthn/LinuxSecurityKey.java
@@ -1,0 +1,54 @@
+package peergos.server.webauthn;
+
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.Optional;
+
+/** CTAP2 over /dev/hidraw, which is a usb security key and nothing else.
+ *
+ *  The key is opened for the length of one ceremony and closed again, so nothing holds
+ *  the device between logins.
+ */
+public class LinuxSecurityKey implements SecurityKey {
+
+    @Override
+    public Ctap2.Credential makeCredential(byte[] clientDataJson,
+                                           String rpId,
+                                           String rpName,
+                                           byte[] userId,
+                                           String userName,
+                                           String displayName,
+                                           List<Long> algorithms,
+                                           long deadline) throws IOException {
+        try (CtapHid key = openKey()) {
+            return Ctap2.makeCredential(key, sha256(clientDataJson), rpId, rpName, userId,
+                    userName, displayName, algorithms, deadline);
+        }
+    }
+
+    @Override
+    public Ctap2.Credential getAssertion(byte[] clientDataJson,
+                                         String rpId,
+                                         List<byte[]> allowedCredentials,
+                                         long deadline) throws IOException {
+        try (CtapHid key = openKey()) {
+            return Ctap2.getAssertion(key, rpId, sha256(clientDataJson), allowedCredentials, deadline);
+        }
+    }
+
+    private static CtapHid openKey() throws IOException {
+        Optional<CtapHid> key = CtapHid.openFirst();
+        if (! key.isPresent())
+            throw new IOException("No security key found. Plug your key in and try again.");
+        return key.get();
+    }
+
+    private static byte[] sha256(byte[] data) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/peergos/server/webauthn/SecurityKey.java
+++ b/src/peergos/server/webauthn/SecurityKey.java
@@ -1,0 +1,55 @@
+package peergos.server.webauthn;
+
+import java.io.IOException;
+import java.util.List;
+
+/** A security key, however this platform reaches one.
+ *
+ *  Everything above this line is shared - the localhost endpoint, the rpId pinning, the
+ *  origin rule and the polyfill in the page - and only the thing that talks to the key
+ *  differs per platform. The clientDataJSON is built above us and passed in whole rather
+ *  than hashed, because CTAP2 wants the hash and webauthn.dll wants the bytes.
+ */
+public interface SecurityKey {
+
+    Ctap2.Credential makeCredential(byte[] clientDataJson,
+                                    String rpId,
+                                    String rpName,
+                                    byte[] userId,
+                                    String userName,
+                                    String displayName,
+                                    List<Long> algorithms,
+                                    long deadline) throws IOException;
+
+    Ctap2.Credential getAssertion(byte[] clientDataJson,
+                                  String rpId,
+                                  List<byte[]> allowedCredentials,
+                                  long deadline) throws IOException;
+
+    /** The desktop host's window, so a platform prompt can be modal to it.
+     *
+     *  Only windows has anything to be modal to: the linux path draws no ui of its own,
+     *  the key itself blinks.
+     */
+    default void setWindowHandle(long handle) {}
+
+    static SecurityKey forThisPlatform() {
+        if (System.getProperty("os.name", "").toLowerCase().contains("win"))
+            return windowsKey();
+        return new LinuxSecurityKey();
+    }
+
+    /** Reflectively, because this jar is also dexed into the android app, where
+     *  java.lang.foreign does not exist. Naming the class here would put it on the
+     *  reachable graph. */
+    private static SecurityKey windowsKey() {
+        try {
+            return (SecurityKey) Class.forName("peergos.server.webauthn.WindowsSecurityKey")
+                    .getDeclaredConstructor()
+                    .newInstance();
+        } catch (ReflectiveOperationException e) {
+            Throwable cause = e instanceof java.lang.reflect.InvocationTargetException ? e.getCause() : e;
+            throw new IllegalStateException("No security key support on this windows build: " + cause, cause);
+        }
+    }
+}

--- a/src/peergos/server/webauthn/WindowsSecurityKey.java
+++ b/src/peergos/server/webauthn/WindowsSecurityKey.java
@@ -1,0 +1,400 @@
+package peergos.server.webauthn;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.function.Consumer;
+
+/** A security key driven by webauthn.dll, the api browsers themselves call.
+ *
+ *  Windows draws the prompt and handles usb, nfc and platform authenticators, and - the
+ *  part that matters here - takes the rpId and the clientDataJSON from the caller, so a
+ *  credential registered in a browser for peergos.net can be used from a window whose page
+ *  came from localhost. That is the same trick the linux path plays over raw CTAP2.
+ *
+ *  Everything is pinned to structure version 1, which carries every field we need. Later
+ *  versions only append, and the dll reads no further than dwVersion says, so there is
+ *  nothing to gate on WebAuthNGetApiVersionNumber beyond the dll being usable at all.
+ *
+ *  This class must not be named from anywhere that android reaches: java.lang.foreign does
+ *  not exist there, and this jar is dexed into the android app. SecurityKey loads it
+ *  reflectively for that reason.
+ */
+public class WindowsSecurityKey implements SecurityKey {
+
+    private static final ValueLayout.OfInt DWORD = ValueLayout.JAVA_INT;
+    private static final ValueLayout.OfInt LONG32 = ValueLayout.JAVA_INT;
+    private static final ValueLayout.OfInt BOOL = ValueLayout.JAVA_INT;
+    private static final MemoryLayout PTR = ValueLayout.ADDRESS;
+    private static final MemoryLayout PAD4 = MemoryLayout.paddingLayout(4);
+
+    // Every struct below is transcribed from webauthn.h. The explicit padding is not
+    // decoration: a DWORD followed by a pointer leaves a 4 byte hole on x64, and getting
+    // that wrong does not fail loudly, it passes garbage to the dll.
+    private static final MemoryLayout RP_ENTITY = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            PAD4,
+            PTR.withName("pwszId"),
+            PTR.withName("pwszName"),
+            PTR.withName("pwszIcon"));
+
+    private static final MemoryLayout USER_ENTITY = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            DWORD.withName("cbId"),
+            PTR.withName("pbId"),
+            PTR.withName("pwszName"),
+            PTR.withName("pwszIcon"),
+            PTR.withName("pwszDisplayName"));
+
+    private static final MemoryLayout CLIENT_DATA = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            DWORD.withName("cbClientDataJSON"),
+            PTR.withName("pbClientDataJSON"),
+            PTR.withName("pwszHashAlgId"));
+
+    private static final MemoryLayout COSE_PARAMETER = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            PAD4,
+            PTR.withName("pwszCredentialType"),
+            LONG32.withName("lAlg"),
+            PAD4);
+
+    private static final MemoryLayout COSE_PARAMETERS = MemoryLayout.structLayout(
+            DWORD.withName("cCredentialParameters"),
+            PAD4,
+            PTR.withName("pCredentialParameters"));
+
+    private static final MemoryLayout CREDENTIAL = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            DWORD.withName("cbId"),
+            PTR.withName("pbId"),
+            PTR.withName("pwszCredentialType"));
+
+    private static final MemoryLayout CREDENTIALS = MemoryLayout.structLayout(
+            DWORD.withName("cCredentials"),
+            PAD4,
+            PTR.withName("pCredentials"));
+
+    private static final MemoryLayout EXTENSIONS = MemoryLayout.structLayout(
+            DWORD.withName("cExtensions"),
+            PAD4,
+            PTR.withName("pExtensions"));
+
+    private static final MemoryLayout MAKE_CREDENTIAL_OPTIONS = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            DWORD.withName("dwTimeoutMilliseconds"),
+            CREDENTIALS.withName("CredentialList"),
+            EXTENSIONS.withName("Extensions"),
+            DWORD.withName("dwAuthenticatorAttachment"),
+            BOOL.withName("bRequireResidentKey"),
+            DWORD.withName("dwUserVerificationRequirement"),
+            DWORD.withName("dwAttestationConveyancePreference"),
+            DWORD.withName("dwFlags"),
+            PAD4);
+
+    private static final MemoryLayout GET_ASSERTION_OPTIONS = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            DWORD.withName("dwTimeoutMilliseconds"),
+            CREDENTIALS.withName("CredentialList"),
+            EXTENSIONS.withName("Extensions"),
+            DWORD.withName("dwAuthenticatorAttachment"),
+            DWORD.withName("dwUserVerificationRequirement"),
+            DWORD.withName("dwFlags"),
+            PAD4);
+
+    // The two the dll allocates and we only read. Reinterpreting to the version 1 size is
+    // safe whatever version it actually returned, because we never read past these fields.
+    private static final MemoryLayout CREDENTIAL_ATTESTATION = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            PAD4,
+            PTR.withName("pwszFormatType"),
+            DWORD.withName("cbAuthenticatorData"),
+            PAD4,
+            PTR.withName("pbAuthenticatorData"),
+            DWORD.withName("cbAttestation"),
+            PAD4,
+            PTR.withName("pbAttestation"),
+            DWORD.withName("dwAttestationDecodeType"),
+            PAD4,
+            PTR.withName("pvAttestationDecode"),
+            DWORD.withName("cbAttestationObject"),
+            PAD4,
+            PTR.withName("pbAttestationObject"),
+            DWORD.withName("cbCredentialId"),
+            PAD4,
+            PTR.withName("pbCredentialId"));
+
+    private static final MemoryLayout ASSERTION = MemoryLayout.structLayout(
+            DWORD.withName("dwVersion"),
+            DWORD.withName("cbAuthenticatorData"),
+            PTR.withName("pbAuthenticatorData"),
+            DWORD.withName("cbSignature"),
+            PAD4,
+            PTR.withName("pbSignature"),
+            CREDENTIAL.withName("Credential"),
+            DWORD.withName("cbUserId"),
+            PAD4,
+            PTR.withName("pbUserId"));
+
+    private static final int VERSION_1 = 1;
+    private static final int S_OK = 0;
+    private static final int ATTACHMENT_ANY = 0;
+    private static final int USER_VERIFICATION_ANY = 0;
+    private static final int ATTESTATION_NONE = 1;
+    private static final String PUBLIC_KEY = "public-key";
+    private static final String SHA_256 = "SHA-256";
+
+    /** Linked on first use rather than at construction, so a machine without a usable
+     *  webauthn.dll fails inside the ceremony, where the message reaches the page, rather
+     *  than while the server is starting up. */
+    private static final class Native {
+        static final SymbolLookup WEBAUTHN = SymbolLookup.libraryLookup("webauthn.dll", Arena.global());
+        static final MethodHandle MAKE_CREDENTIAL = downcall("WebAuthNAuthenticatorMakeCredential",
+                FunctionDescriptor.of(LONG32, PTR, PTR, PTR, PTR, PTR, PTR, PTR));
+        static final MethodHandle GET_ASSERTION = downcall("WebAuthNAuthenticatorGetAssertion",
+                FunctionDescriptor.of(LONG32, PTR, PTR, PTR, PTR, PTR));
+        static final MethodHandle FREE_ATTESTATION = downcall("WebAuthNFreeCredentialAttestation",
+                FunctionDescriptor.ofVoid(PTR));
+        static final MethodHandle FREE_ASSERTION = downcall("WebAuthNFreeAssertion",
+                FunctionDescriptor.ofVoid(PTR));
+        static final MethodHandle ERROR_NAME = downcall("WebAuthNGetErrorName",
+                FunctionDescriptor.of(PTR, LONG32));
+        static final int API_VERSION = apiVersion();
+
+        private static MethodHandle downcall(String name, FunctionDescriptor descriptor) {
+            return Linker.nativeLinker().downcallHandle(WEBAUTHN.findOrThrow(name), descriptor);
+        }
+
+        private static int apiVersion() {
+            try {
+                return (int) downcall("WebAuthNGetApiVersionNumber", FunctionDescriptor.of(DWORD))
+                        .invokeExact();
+            } catch (Throwable t) {
+                throw new IllegalStateException("webauthn.dll is present but unusable", t);
+            }
+        }
+    }
+
+    /** Set by the desktop host, which is a different process and owns the only window we
+     *  have. Volatile because the host posts it on its own thread, and 0 - a null HWND -
+     *  until it does, which windows accepts but may then draw the prompt behind the app. */
+    private volatile long windowHandle = 0;
+
+    @Override
+    public void setWindowHandle(long handle) {
+        this.windowHandle = handle;
+    }
+
+    @Override
+    public Ctap2.Credential makeCredential(byte[] clientDataJson,
+                                           String rpId,
+                                           String rpName,
+                                           byte[] userId,
+                                           String userName,
+                                           String displayName,
+                                           List<Long> algorithms,
+                                           long deadline) throws IOException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment rp = arena.allocate(RP_ENTITY);
+            setInt(rp, RP_ENTITY, "dwVersion", VERSION_1);
+            setPointer(rp, RP_ENTITY, "pwszId", wide(arena, rpId));
+            setPointer(rp, RP_ENTITY, "pwszName", wide(arena, rpName));
+
+            MemorySegment user = arena.allocate(USER_ENTITY);
+            MemorySegment id = arena.allocateFrom(ValueLayout.JAVA_BYTE, userId);
+            setInt(user, USER_ENTITY, "dwVersion", VERSION_1);
+            setInt(user, USER_ENTITY, "cbId", userId.length);
+            setPointer(user, USER_ENTITY, "pbId", id);
+            setPointer(user, USER_ENTITY, "pwszName", wide(arena, userName));
+            setPointer(user, USER_ENTITY, "pwszDisplayName", wide(arena, displayName));
+
+            MemorySegment publicKey = wide(arena, PUBLIC_KEY);
+            MemorySegment parameters = arena.allocate(COSE_PARAMETER, algorithms.size());
+            for (int i = 0; i < algorithms.size(); i++) {
+                MemorySegment parameter = parameters.asSlice(i * COSE_PARAMETER.byteSize(), COSE_PARAMETER.byteSize());
+                setInt(parameter, COSE_PARAMETER, "dwVersion", VERSION_1);
+                setPointer(parameter, COSE_PARAMETER, "pwszCredentialType", publicKey);
+                setInt(parameter, COSE_PARAMETER, "lAlg", algorithms.get(i).intValue());
+            }
+            MemorySegment credentialParameters = arena.allocate(COSE_PARAMETERS);
+            setInt(credentialParameters, COSE_PARAMETERS, "cCredentialParameters", algorithms.size());
+            setPointer(credentialParameters, COSE_PARAMETERS, "pCredentialParameters", parameters);
+
+            MemorySegment options = arena.allocate(MAKE_CREDENTIAL_OPTIONS);
+            setInt(options, MAKE_CREDENTIAL_OPTIONS, "dwVersion", VERSION_1);
+            setInt(options, MAKE_CREDENTIAL_OPTIONS, "dwTimeoutMilliseconds", timeout(deadline));
+            // ANY leaves the choice to the windows chooser, which offers hello alongside a
+            // security key. Narrow this to CROSS_PLATFORM if we decide a peergos second
+            // factor should never be a passkey bound to one machine.
+            setInt(options, MAKE_CREDENTIAL_OPTIONS, "dwAuthenticatorAttachment", ATTACHMENT_ANY);
+            setInt(options, MAKE_CREDENTIAL_OPTIONS, "dwUserVerificationRequirement", USER_VERIFICATION_ANY);
+            // We rebuild a none attestation from the authenticator data below in any case,
+            // so this only saves the user a "share the make and model?" prompt.
+            setInt(options, MAKE_CREDENTIAL_OPTIONS, "dwAttestationConveyancePreference", ATTESTATION_NONE);
+
+            MemorySegment out = arena.allocate(ValueLayout.ADDRESS);
+            int result = call(() -> (int) Native.MAKE_CREDENTIAL.invokeExact(window(), rp, user,
+                    credentialParameters, clientData(arena, clientDataJson), options, out));
+            if (result != S_OK)
+                throw new IOException(errorMessage("Registration", result));
+
+            MemorySegment attestation = owned(out, CREDENTIAL_ATTESTATION, arena, Native.FREE_ATTESTATION);
+            byte[] authenticatorData = bytes(attestation, CREDENTIAL_ATTESTATION, "cbAuthenticatorData", "pbAuthenticatorData");
+            byte[] credentialId = bytes(attestation, CREDENTIAL_ATTESTATION, "cbCredentialId", "pbCredentialId");
+            if (authenticatorData == null)
+                throw new IOException("No authenticator data in the registration response");
+            // The server takes a self attestation now, so pbAttestationObject would do; this
+            // keeps one shape across all three platforms and stores the least.
+            return new Ctap2.Credential(credentialId != null ? credentialId : Ctap2.credentialIdOf(authenticatorData),
+                    authenticatorData, null, null, Ctap2.noneAttestation(authenticatorData));
+        }
+    }
+
+    @Override
+    public Ctap2.Credential getAssertion(byte[] clientDataJson,
+                                         String rpId,
+                                         List<byte[]> allowedCredentials,
+                                         long deadline) throws IOException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment options = arena.allocate(GET_ASSERTION_OPTIONS);
+            setInt(options, GET_ASSERTION_OPTIONS, "dwVersion", VERSION_1);
+            setInt(options, GET_ASSERTION_OPTIONS, "dwTimeoutMilliseconds", timeout(deadline));
+            setInt(options, GET_ASSERTION_OPTIONS, "dwAuthenticatorAttachment", ATTACHMENT_ANY);
+            setInt(options, GET_ASSERTION_OPTIONS, "dwUserVerificationRequirement", USER_VERIFICATION_ANY);
+            if (! allowedCredentials.isEmpty()) {
+                MemorySegment publicKey = wide(arena, PUBLIC_KEY);
+                MemorySegment credentials = arena.allocate(CREDENTIAL, allowedCredentials.size());
+                for (int i = 0; i < allowedCredentials.size(); i++) {
+                    byte[] allowed = allowedCredentials.get(i);
+                    MemorySegment credential = credentials.asSlice(i * CREDENTIAL.byteSize(), CREDENTIAL.byteSize());
+                    setInt(credential, CREDENTIAL, "dwVersion", VERSION_1);
+                    setInt(credential, CREDENTIAL, "cbId", allowed.length);
+                    setPointer(credential, CREDENTIAL, "pbId", arena.allocateFrom(ValueLayout.JAVA_BYTE, allowed));
+                    setPointer(credential, CREDENTIAL, "pwszCredentialType", publicKey);
+                }
+                setInt(options, GET_ASSERTION_OPTIONS, "CredentialList.cCredentials", allowedCredentials.size());
+                setPointer(options, GET_ASSERTION_OPTIONS, "CredentialList.pCredentials", credentials);
+            }
+
+            MemorySegment out = arena.allocate(ValueLayout.ADDRESS);
+            int result = call(() -> (int) Native.GET_ASSERTION.invokeExact(window(), wide(arena, rpId),
+                    clientData(arena, clientDataJson), options, out));
+            if (result != S_OK)
+                throw new IOException(errorMessage("Login", result));
+
+            MemorySegment assertion = owned(out, ASSERTION, arena, Native.FREE_ASSERTION);
+            byte[] authenticatorData = bytes(assertion, ASSERTION, "cbAuthenticatorData", "pbAuthenticatorData");
+            byte[] signature = bytes(assertion, ASSERTION, "cbSignature", "pbSignature");
+            if (authenticatorData == null || signature == null)
+                throw new IOException("Incomplete assertion from the security key");
+            byte[] credentialId = bytes(assertion, ASSERTION, "Credential.cbId", "Credential.pbId");
+            if (credentialId == null && allowedCredentials.size() == 1)
+                credentialId = allowedCredentials.get(0); // as CTAP2 does: it may omit the one we named
+            byte[] userHandle = bytes(assertion, ASSERTION, "cbUserId", "pbUserId");
+            return new Ctap2.Credential(credentialId, authenticatorData, signature, userHandle, null);
+        }
+    }
+
+    private MemorySegment window() {
+        return MemorySegment.ofAddress(windowHandle);
+    }
+
+    private static MemorySegment clientData(Arena arena, byte[] clientDataJson) {
+        MemorySegment json = arena.allocateFrom(ValueLayout.JAVA_BYTE, clientDataJson);
+        MemorySegment clientData = arena.allocate(CLIENT_DATA);
+        setInt(clientData, CLIENT_DATA, "dwVersion", VERSION_1);
+        setInt(clientData, CLIENT_DATA, "cbClientDataJSON", clientDataJson.length);
+        setPointer(clientData, CLIENT_DATA, "pbClientDataJSON", json);
+        // Windows hashes the json itself, which is the whole reason it will sign for an
+        // origin the window does not have.
+        setPointer(clientData, CLIENT_DATA, "pwszHashAlgId", wide(arena, SHA_256));
+        return clientData;
+    }
+
+    private static int timeout(long deadline) {
+        return (int) Math.max(1_000, Math.min(Integer.MAX_VALUE, deadline - System.currentTimeMillis()));
+    }
+
+    /** The dll owns what it returned; freeing is tied to the arena so the error paths
+     *  cannot leak it. */
+    private static MemorySegment owned(MemorySegment out, MemoryLayout layout, Arena arena, MethodHandle free) throws IOException {
+        MemorySegment returned = out.get(ValueLayout.ADDRESS, 0);
+        if (returned.equals(MemorySegment.NULL))
+            throw new IOException("The security key returned nothing");
+        Consumer<MemorySegment> release = segment -> {
+            try {
+                free.invokeExact(segment);
+            } catch (Throwable t) {
+                throw new RuntimeException(t);
+            }
+        };
+        return returned.reinterpret(layout.byteSize(), arena, release);
+    }
+
+    private interface NativeCall {
+        int invoke() throws Throwable;
+    }
+
+    private static int call(NativeCall call) throws IOException {
+        try {
+            return call.invoke();
+        } catch (IOException e) {
+            throw e;
+        } catch (Throwable t) {
+            throw new IOException("Could not reach webauthn.dll: " + t, t);
+        }
+    }
+
+    private static String errorMessage(String what, int hresult) {
+        String name;
+        try {
+            MemorySegment message = (MemorySegment) Native.ERROR_NAME.invokeExact(hresult);
+            name = message.equals(MemorySegment.NULL) ? "" :
+                    message.reinterpret(1024).getString(0, StandardCharsets.UTF_16LE);
+        } catch (Throwable t) {
+            name = "";
+        }
+        // NotAllowedError is what a cancel, a timeout and a wrong key all come back as, and
+        // is the one the page already knows how to phrase.
+        return what + " failed: " + (name.isEmpty() ? "0x" + Integer.toHexString(hresult) : name)
+                + " (api version " + Native.API_VERSION + ")";
+    }
+
+    private static MemorySegment wide(Arena arena, String text) {
+        return arena.allocateFrom(text == null ? "" : text, StandardCharsets.UTF_16LE);
+    }
+
+    /** Field paths, so this reads like webauthn.h rather than like a list of magic numbers.
+     *  "Credential.pbId" walks into a nested struct. */
+    private static long offset(MemoryLayout layout, String path) {
+        String[] names = path.split("\\.");
+        MemoryLayout.PathElement[] elements = new MemoryLayout.PathElement[names.length];
+        for (int i = 0; i < names.length; i++)
+            elements[i] = MemoryLayout.PathElement.groupElement(names[i]);
+        return layout.byteOffset(elements);
+    }
+
+    private static void setInt(MemorySegment struct, MemoryLayout layout, String path, int value) {
+        struct.set(ValueLayout.JAVA_INT, offset(layout, path), value);
+    }
+
+    private static void setPointer(MemorySegment struct, MemoryLayout layout, String path, MemorySegment value) {
+        struct.set(ValueLayout.ADDRESS, offset(layout, path), value);
+    }
+
+    private static byte[] bytes(MemorySegment struct, MemoryLayout layout, String countPath, String pointerPath) {
+        int length = struct.get(ValueLayout.JAVA_INT, offset(layout, countPath));
+        MemorySegment pointer = struct.get(ValueLayout.ADDRESS, offset(layout, pointerPath));
+        if (length <= 0 || pointer.equals(MemorySegment.NULL))
+            return null;
+        return pointer.reinterpret(length).toArray(ValueLayout.JAVA_BYTE);
+    }
+}


### PR DESCRIPTION
* add a SecurityKey seam, picked on os.name, with the existing CTAP2 over hidraw path behind LinuxSecurityKey
* add WindowsSecurityKey, an FFM binding to webauthn.dll pinned to struct version 1, so that a key registered in a browser for peergos.net can be used from a page served from localhost
* take the desktop host's window handle over /webauthn/host, so the windows prompt can be modal to the only window there is
* pass the clientDataJSON down whole rather than hashed: CTAP2 wants the sha256, webauthn.dll wants the bytes and hashes them itself
* pin every struct offset against webauthn.h in a test, since a wrong layout passes garbage to the dll rather than failing
* note on noneAttestation that the server takes a self attestation now, so sending none is uniformity rather than necessity

None of the windows path has been run - it needs a windows machine. The android rules still need -dontwarn java.lang.foreign.**, since the class is in the dexed jar even though nothing there names it.