### PR TITLE
Fix 32-bit overflow in chunk offsets breaking resumed uploads over 2 GiB

### DIFF
--- a/src/peergos/shared/user/fs/AsyncReader.java
+++ b/src/peergos/shared/user/fs/AsyncReader.java
@@ -13,7 +13,8 @@ import java.util.function.*;
 public interface AsyncReader extends AutoCloseable {
 
     default CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
-        return seek(low32 | (((long)high32)) << 32);
+        // mask low32 rather than sign extending it, else offsets in 2-4 GiB, 6-8 GiB, ... go negative
+        return seek((low32 & 0xFFFFFFFFL) | (((long) high32) << 32));
     }
 
     @JsIgnore

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -143,7 +143,7 @@ public class FileUploader implements AutoCloseable {
                                                   SafeRandom random,
                                                   Hasher hasher) {
         if (startChunkIndex > 0) hashBuilder = null;
-        return reader.seek(startChunkIndex * Chunk.MAX_SIZE).thenCompose(seeked -> {
+        return reader.seek((long) startChunkIndex * Chunk.MAX_SIZE).thenCompose(seeked -> {
             long t1 = System.currentTimeMillis();
 
             AsyncUploadQueue queue = new AsyncUploadQueue();


### PR DESCRIPTION
## Problem

Chunk offsets are computed with `int` arithmetic in two places, which overflows
once the offset passes `Integer.MAX_VALUE`. Chunks are 5 MiB, so the first bad
index is 410 (410 × 5 MiB = 2,149,580,800, wrapping to −2,145,386,496).

The visible symptom is in `FileUploader.uploadFrom`:

    return reader.seek(startChunkIndex * Chunk.MAX_SIZE)

`startChunkIndex` is non-zero only when an upload is resumed — `FileWrapper`
derives it from `findFirstAbsentChunkIndex`, and the convenience overload passes
0 — so a fresh upload is unaffected. But an upload interrupted past ~2 GiB
computes a negative seek offset on resume and fails with:

    java.io.IOException: Negative seek offset

Every retry recomputes the same offset, so the file can never finish uploading.

## Changes

- `FileUploader.uploadFrom` — cast before multiplying, so the seek offset is
  computed in 64 bits.
- `AsyncReader.seekJS` — `low32` was sign-extended rather than masked when
  combined with `high32`, so any offset whose low word has the top bit set
  (2–4 GiB, 6–8 GiB, …) became negative.

Two lines of behaviour change, no format or API changes.

## Verification

A/B against the same 3.71 GiB file and the same interrupted transaction, driven
through the sync client:

| build | resumed from chunk ~572 | result |
| --- | --- | --- |
| master (`03872eaff`) | 572 × 5 MiB wraps to −1,296,039,936 | `IOException: Negative seek offset` |
| this branch | 2,998,927,360 | completes, 3804/3804 MiB, sync reports `SYNCED` |

An uninterrupted upload of the same file succeeds on both builds, consistent
with `startChunkIndex` being 0 on that path — which is likely why this has gone
unnoticed.

The `seekJS` change is the same class of defect, found by inspection alongside
the upload one; it is not exercised by the A/B above.