### PR TITLE
Rebuild the hash tree when resuming an upload over 5 GiB

### DIFF
--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -729,22 +729,28 @@ public class FileWrapper {
                                                                                              Crypto crypto) {
         RelativeCapability fromParent = writableFilePointer().relativise(txn.writeCap());
         FileProperties props = txn.props;
-        // only valid for files < 5 GiB
-        Optional<HashTree> txnHash = props.treeHash.map(b -> new HashTree(b.rootHash,
-                b.level1.stream().collect(Collectors.toList()),
-                b.level2.stream().collect(Collectors.toList()),
-                b.level3.stream().collect(Collectors.toList())));
+        // a stored branch only covers its own group of 1024 chunks, so above 5 GiB rebuild the whole tree
+        // from the source data; uploadFrom seeks before reading, so consuming the reader here is safe
+        Optional<HashBranch> branch = props.treeHash;
+        CompletableFuture<Optional<HashTree>> txnHash = branch.isEmpty() || txn.size() < 1024L * Chunk.MAX_SIZE ?
+                Futures.of(branch.map(b -> new HashTree(b.rootHash,
+                        b.level1.stream().collect(Collectors.toList()),
+                        b.level2.stream().collect(Collectors.toList()),
+                        b.level3.stream().collect(Collectors.toList())))) :
+                HashTree.buildParallel(p -> data, (int) (txn.size() >>> 32), (int) txn.size(), crypto.hasher, 1)
+                        .thenApply(Optional::of);
         // first find how many chunks were already uploaded, then seek reader to that offset and continue
         long totalChunks = (txn.size() + Chunk.MAX_SIZE - 1) / Chunk.MAX_SIZE;
-        return findFirstAbsentChunkIndex(txn.streamSecret(), txn.getFirstLocation(), txn.firstBat, totalChunks, s, network, crypto)
-                .thenCompose(startChunkIndex -> {
-                    monitor.accept(startChunkIndex * Chunk.MAX_SIZE);
-                    FileUploader uploader = new FileUploader(txn.targetFilename(), data, startChunkIndex*Chunk.MAX_SIZE,
-                            txn.size(), txn.baseKey, txn.dataKey, getLocation(), getPointer().capability.bat, getParentKey(),
-                            monitor, props, txnHash, txn.getFirstLocation().getMapKey(), txn.firstBat, isCancelled);
-                    return uploader.uploadFrom(s, c, network, startChunkIndex.intValue(), txn.getFirstLocation().owner,
-                            signingPair(), mirrorBatId(), crypto.random, crypto.hasher);
-                }).thenApply(v -> new Pair<>(v, Optional.of(new NamedRelativeCapability(txn.targetFilename(), fromParent,
+        return txnHash
+                .thenCompose(hash -> findFirstAbsentChunkIndex(txn.streamSecret(), txn.getFirstLocation(), txn.firstBat, totalChunks, s, network, crypto)
+                        .thenCompose(startChunkIndex -> {
+                            monitor.accept(startChunkIndex * Chunk.MAX_SIZE);
+                            FileUploader uploader = new FileUploader(txn.targetFilename(), data, startChunkIndex*Chunk.MAX_SIZE,
+                                    txn.size(), txn.baseKey, txn.dataKey, getLocation(), getPointer().capability.bat, getParentKey(),
+                                    monitor, props, hash, txn.getFirstLocation().getMapKey(), txn.firstBat, isCancelled);
+                            return uploader.uploadFrom(s, c, network, startChunkIndex.intValue(), txn.getFirstLocation().owner,
+                                    signingPair(), mirrorBatId(), crypto.random, crypto.hasher);
+                        })).thenApply(v -> new Pair<>(v, Optional.of(new NamedRelativeCapability(txn.targetFilename(), fromParent,
                         Optional.of(props.isDirectory), Optional.of(props.mimeType), Optional.of(props.created)))));
     }
 


### PR DESCRIPTION
## Problem

Resuming an upload of a file 5 GiB or larger always fails with:

    java.lang.IllegalArgumentException: Invalid chunk hash tree state!
        at peergos.shared.user.fs.HashBranch.<init>(HashBranch.java:20)
        at peergos.shared.user.fs.HashTree.branch(HashTree.java:56)
        at peergos.shared.user.fs.FileUploader.lambda$encryptChunk$4(FileUploader.java:220)

`FileWrapper.resumeUpload` rebuilds the file's `HashTree` from
`props.treeHash`, which is a single `HashBranch`:

    // only valid for files < 5 GiB
    Optional<HashTree> txnHash = props.treeHash.map(b -> new HashTree(b.rootHash,
            b.level1.stream().collect(Collectors.toList()), ...

`HashBranch.level1` is an `Optional`, so the reconstructed `level1` list holds
at most one entry — it describes that branch's own group of 1024 chunks and
nothing beyond it. `FileUploader` writes a branch at every 1024th chunk:

    chunkIndex % 1024 == 0 ? props.withHash(hash.map(t -> t.branch(chunkIndex))) : props

At chunk 1024, `HashTree.branch` does `level1.stream().skip(chunkIndex / 1024)`,
which skips past the only entry and yields empty, while `level2` is still
present. `HashBranch`'s constructor rejects that combination. Chunk 1024 is
exactly 5120 MiB, so every resumed upload at or above 5 GiB dies at that point,
and each retry dies in the same place.

The existing comment documents the limit; this makes the code meet it.

## Change

Below 5 GiB, keep reconstructing from the stored branch as before. At or above
it, rebuild the full tree from the source data with `HashTree.buildParallel`.
`uploadFrom` seeks before reading, so consuming the reader is safe.

`PeergosSyncFS.hashFile` already guards this same boundary the same way
(`props.size < 1024L * Chunk.MAX_SIZE`, else recompute); `resumeUpload` was the
one reconstruction without the guard.

## Verification

A 7395 MiB file, uploaded through the sync client, interrupted at ~4560 MiB so
that the resume crosses the chunk-1024 boundary. Only this commit differs
between the two runs:

| build | at the boundary | result |
| --- | --- | --- |
| master | 5100 MiB | `Invalid chunk hash tree state!` |
| this branch | crossed 5120 MiB | completed, 7395/7395 MiB, no hash tree errors |

## Note

For files at or above 5 GiB the rebuild reads the source once more before
uploading resumes. That is bounded by disk read plus sha256, and only happens
on resume, where the alternative is a permanent failure.