### PR TITLE
Fix operator precedence in ResetableFileInputStream seek

### DIFF
--- a/src/peergos/server/storage/ResetableFileInputStream.java
+++ b/src/peergos/server/storage/ResetableFileInputStream.java
@@ -20,7 +20,7 @@ public class ResetableFileInputStream implements AsyncReader {
     @Override
     public CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
         try {
-            raf.seek((low32 & 0xFFFFFFFFL) + (high32 & 0xFFFFFFFFL) << 32);
+            raf.seek((low32 & 0xFFFFFFFFL) | (((long) high32) << 32));
             return CompletableFuture.completedFuture(this);
         } catch (IOException e) {
             CompletableFuture<AsyncReader> err = new CompletableFuture<>();


### PR DESCRIPTION
## Problem

`ResetableFileInputStream.seekJS` recombines the two halves of the offset as:

    raf.seek((low32 & 0xFFFFFFFFL) + (high32 & 0xFFFFFFFFL) << 32);

`+` binds tighter than `<<`, so this evaluates as `((low32 + high32) << 32)`
instead of `low32 | (high32 << 32)`. Only offset 0 comes out correct.

Below 2 GiB the result is a large positive number, and since
`RandomAccessFile.seek` accepts positions past the end of the file, the failure
is silent — the seek succeeds and the next read returns -1. At 2 GiB and above
the value goes negative and the seek throws.

The class is only constructed from tests (`PeergosNetworkUtils`,
`MultiUserTests`), which read sequentially from the start, so nothing depends on
the broken behaviour today; it would surface for any test that seeks or resumes
an upload through this reader.

## Change

Combine the halves the way `AsyncReader.seekJS` does:

    raf.seek((low32 & 0xFFFFFFFFL) | (((long) high32) << 32));

## Verification

Seeking into a sparse file with a distinct 4 byte marker written at each
offset, through `ResetableFileInputStream` itself:

| offset | master | this branch |
| --- | --- | --- |
| 0 | `read "M000"` | `read "M000"` |
| 1,000 | EOF (read -1) | `read "M000"` |
| 5,242,880 | EOF (read -1) | `read "M880"` |
| 3,221,225,472 | `IOException: Negative seek offset` | `read "M472"` |

The markers differ per offset, so the reads confirm the stream lands at the
requested position rather than merely succeeding.