### PR TITLE
Add single use backup codes as a second auth factor

### DIFF
--- a/src/peergos/server/AggregatedMetrics.java
+++ b/src/peergos/server/AggregatedMetrics.java
@@ -61,6 +61,7 @@ public class AggregatedMetrics {
     public static final Counter LOGIN_GET_MFA  = build("login_get_mfa", "Total get mfa calls.");
     public static final Counter LOGIN_ADD_TOTP  = build("login_add_totp", "Total add totp calls.");
     public static final Counter LOGIN_ENABLE_TOTP  = build("login_enable_totp", "Total enable totp calls.");
+    public static final Counter LOGIN_GEN_BACKUP_CODES  = build("login_gen_backup_codes", "Total generate backup codes calls.");
     public static final Counter LOGIN_WEBAUTHN_START  = build("login_webauthn_start", "Total webauthn start calls.");
     public static final Counter LOGIN_WEBAUTHN_COMPLETE  = build("login_webauthn_complete", "Total webauthn complete calls.");
     public static final Counter LOGIN_DELETE_MFA  = build("login_delete_mfa", "Total delete mfa calls.");

--- a/src/peergos/server/Main.java
+++ b/src/peergos/server/Main.java
@@ -1238,13 +1238,17 @@ public class Main extends Builder {
 
     public static CompletableFuture<MultiFactorAuthResponse> getMfaResponseCLI(MultiFactorAuthRequest req) {
         Optional<MultiFactorAuthMethod> anyTotp = req.methods.stream().filter(m -> m.type == MultiFactorAuthMethod.Type.TOTP).findFirst();
-        if (anyTotp.isEmpty())
+        Optional<MultiFactorAuthMethod> anyBackup = req.methods.stream().filter(m -> m.type == MultiFactorAuthMethod.Type.BACKUP_CODES).findFirst();
+        if (anyTotp.isEmpty() && anyBackup.isEmpty())
             throw new IllegalStateException("No supported 2 factor auth method! " + req.methods);
-        MultiFactorAuthMethod totp = anyTotp.get();
-        System.out.println("Enter TOTP code for login");
+        MultiFactorAuthMethod method = anyTotp.orElseGet(anyBackup::get);
+        if (anyTotp.isPresent())
+            System.out.println("Enter TOTP code for login");
+        else
+            System.out.println("Enter a backup code for login");
         Console console = System.console();
         String code = console.readLine().trim();
-        return Futures.of(new MultiFactorAuthResponse(totp.credentialId, Either.a(code)));
+        return Futures.of(new MultiFactorAuthResponse(method.credentialId, Either.a(code)));
     }
 
     public static IpfsWrapper startIpfs(Args a) {

--- a/src/peergos/server/login/AccountWithStorage.java
+++ b/src/peergos/server/login/AccountWithStorage.java
@@ -126,4 +126,9 @@ public class AccountWithStorage implements Account {
     public CompletableFuture<TotpKey> addTotpFactor(String username, byte[] auth) {
         return target.addTotpFactor(username);
     }
+
+    @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        return target.generateBackupCodes(username);
+    }
 }

--- a/src/peergos/server/login/JdbcAccount.java
+++ b/src/peergos/server/login/JdbcAccount.java
@@ -15,6 +15,7 @@ import peergos.shared.user.*;
 import peergos.shared.util.*;
 
 import javax.crypto.spec.*;
+import java.nio.charset.*;
 import java.security.*;
 import java.sql.*;
 import java.time.*;
@@ -40,6 +41,7 @@ public class JdbcAccount implements LoginCache {
     private static final String REMOVE_PENDING = "DELETE FROM pendinglogin WHERE username=?;";
     private static final String CREATE_MFA = "INSERT INTO mfa (username, name, credid, type, enabled, created, value) VALUES(?, ?, ?, ?, ?, ?, ?);";
     private static final String UPDATE_MFA = "UPDATE mfa SET value=? WHERE username = ? AND credid = ?;";
+    private static final String BURN_BACKUP_CODE = "UPDATE mfa SET value=?, name=? WHERE username = ? AND credid = ? AND value = ?;";
     private static final String GET_TYPE = "SELECT type FROM mfa WHERE username = ? AND credid = ?;";
     private static final String GET_AUTH = "SELECT value FROM mfa WHERE username = ? AND credid = ?;";
     private static final String CREATE_CHALLENGE = "INSERT INTO mfa_challenge (challenge, username) VALUES(?, ?);";
@@ -48,6 +50,7 @@ public class JdbcAccount implements LoginCache {
     private static final String ENABLE_AUTH = "UPDATE mfa SET enabled=? WHERE username = ? AND credid = ?;";
     private static final String DELETE_AUTH = "DELETE FROM mfa WHERE username = ? AND credid = ?";
     private static final String GET_AUTH_METHODS = "SELECT name, credid, created, type, enabled FROM mfa WHERE username = ?;";
+    private static final String GET_IDS_OF_TYPE = "SELECT credid FROM mfa WHERE username = ? AND type = ?;";
 
     public static final int MAX_MFA = 10;
     /** A staged login is only left behind by a password change that was interrupted between staging and
@@ -311,7 +314,8 @@ public class JdbcAccount implements LoginCache {
                                                                                           Optional<MultiFactorAuthResponse> mfa) {
         List<MultiFactorAuthMethod> mfas = getSecondAuthMethods(username).join();
         List<MultiFactorAuthMethod> enabled = mfas.stream().filter(m -> m.enabled).collect(Collectors.toList());
-        if (enabled.isEmpty())
+        // backup codes are never a second factor on their own, only a way of satisfying an existing one
+        if (enabled.stream().allMatch(m -> m.type == MultiFactorAuthMethod.Type.BACKUP_CODES))
             return getEntryData(username, authorisedReader).thenApply(Either::a);
         if (mfa.isEmpty()) {
             byte[] challenge = createChallenge(username);
@@ -334,7 +338,13 @@ public class JdbcAccount implements LoginCache {
             verifier.setCounter(newSignCount);
             updateMFA(username, credentialId, verifier.serialize());
         } else {
-            validateTotpCode(username, credentialId, mfaAuth.response.a());
+            MultiFactorAuthMethod.Type type = getType(username, credentialId);
+            if (type == MultiFactorAuthMethod.Type.BACKUP_CODES)
+                validateBackupCode(username, credentialId, mfaAuth.response.a());
+            else if (type == MultiFactorAuthMethod.Type.TOTP)
+                validateTotpCode(username, credentialId, mfaAuth.response.a());
+            else
+                throw new IllegalStateException("Not a code based credential!");
         }
         return getEntryData(username, authorisedReader).thenApply(Either::a);
     }
@@ -407,8 +417,11 @@ public class JdbcAccount implements LoginCache {
                 MultiFactorAuthMethod.Type type = MultiFactorAuthMethod.Type.byValue(rs.getInt("type"));
                 if (type == MultiFactorAuthMethod.Type.TOTP && !enabled)
                     continue; // Don't return disabled totp
+                String name = rs.getString("name");
+                if (type == MultiFactorAuthMethod.Type.BACKUP_CODES && name.equals("0"))
+                    continue; // an exhausted set is no longer a login option
                 res.add(new MultiFactorAuthMethod(
-                        rs.getString("name"),
+                        name,
                         rs.getBytes("credid"),
                         LocalDate.ofEpochDay(rs.getInt("created")),
                         type,
@@ -451,6 +464,123 @@ public class JdbcAccount implements LoginCache {
             stmt.setBytes(7, rawKey);
             stmt.executeUpdate();
             return Futures.of(new TotpKey(credId, rawKey));
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new IllegalStateException(sqe);
+        }
+    }
+
+    /** Generate a fresh set of single use backup codes, invalidating any existing set.
+     *  These are never created automatically - a user has to ask for them, and they are only
+     *  allowed once there is another second factor for them to be a backup for.
+     */
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username) {
+        List<MultiFactorAuthMethod> existing = getSecondAuthMethods(username).join();
+        boolean hasRealFactor = existing.stream()
+                .anyMatch(m -> m.enabled && m.type != MultiFactorAuthMethod.Type.BACKUP_CODES);
+        if (! hasRealFactor)
+            throw new IllegalStateException("Please set up an authenticator app or security key before generating backup codes.");
+
+        List<String> codes = new ArrayList<>();
+        while (codes.size() < BackupCodes.CODE_COUNT) {
+            byte[] random = new byte[BackupCodes.CODE_BYTES];
+            rnd.nextBytes(random);
+            String code = BackupCodes.generate(random);
+            if (! codes.contains(code))
+                codes.add(code);
+        }
+        byte[] credId = new byte[32];
+        rnd.nextBytes(credId);
+
+        // there is only ever 1 set of backup codes, generating replaces any earlier set
+        List<byte[]> older = getBackupCodeIds(username);
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(CREATE_MFA)) {
+            stmt.setString(1, username);
+            stmt.setString(2, Integer.toString(codes.size())); // backup codes carry their remaining count in the name
+            stmt.setBytes(3, credId);
+            stmt.setInt(4, MultiFactorAuthMethod.Type.BACKUP_CODES.value);
+            stmt.setBoolean(5, true);
+            stmt.setLong(6, LocalDate.now().toEpochDay());
+            stmt.setBytes(7, serializeCodeHashes(codes.stream()
+                    .map(JdbcAccount::hashBackupCode)
+                    .collect(Collectors.toList())));
+            stmt.executeUpdate();
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new IllegalStateException(sqe);
+        }
+        for (byte[] oldId : older) {
+            deleteMfa(username, oldId).join();
+        }
+        return Futures.of(new BackupCodes(credId, codes));
+    }
+
+    /** All backup code sets for a user, including any exhausted ones, which are hidden from
+     *  getSecondAuthMethods.
+     */
+    private List<byte[]> getBackupCodeIds(String username) {
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(GET_IDS_OF_TYPE)) {
+            stmt.setString(1, username);
+            stmt.setInt(2, MultiFactorAuthMethod.Type.BACKUP_CODES.value);
+            ResultSet rs = stmt.executeQuery();
+            List<byte[]> res = new ArrayList<>();
+            while (rs.next()) {
+                res.add(rs.getBytes("credid"));
+            }
+            return res;
+        } catch (SQLException sqe) {
+            LOG.log(Level.WARNING, sqe.getMessage(), sqe);
+            throw new RuntimeException(sqe);
+        }
+    }
+
+    private static byte[] hashBackupCode(String code) {
+        return Hash.sha256(BackupCodes.normalise(code).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static byte[] serializeCodeHashes(List<byte[]> hashes) {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("h", new CborObject.CborList(hashes.stream()
+                .map(CborObject.CborByteArray::new)
+                .collect(Collectors.toList())));
+        return CborObject.CborMap.build(state).serialize();
+    }
+
+    private static List<byte[]> parseCodeHashes(byte[] value) {
+        CborObject.CborMap m = (CborObject.CborMap) CborObject.fromByteArray(value);
+        return m.getList("h", c -> ((CborObject.CborByteArray) c).value);
+    }
+
+    /** Check a backup code and burn it. The remaining codes are written back with a compare and
+     *  set on the old value, so two concurrent logins can't both redeem the same code.
+     */
+    private void validateBackupCode(String username, byte[] credentialId, String code) {
+        byte[] hash = hashBackupCode(code);
+        for (int attempt = 0; attempt < 2; attempt++) {
+            byte[] current = getMfa(username, credentialId);
+            List<byte[]> unused = parseCodeHashes(current);
+            List<byte[]> remaining = unused.stream()
+                    .filter(h -> ! MessageDigest.isEqual(h, hash))
+                    .collect(Collectors.toList());
+            if (remaining.size() == unused.size())
+                throw new IllegalStateException("Invalid backup code for credId " + ArrayOps.bytesToHex(credentialId));
+            if (burnBackupCode(username, credentialId, current, remaining))
+                return;
+        }
+        throw new IllegalStateException("Concurrent modification of backup codes for " + username);
+    }
+
+    private boolean burnBackupCode(String username, byte[] credentialId, byte[] oldValue, List<byte[]> remaining) {
+        try (Connection conn = getConnection();
+             PreparedStatement stmt = conn.prepareStatement(BURN_BACKUP_CODE)) {
+            stmt.setBytes(1, serializeCodeHashes(remaining));
+            stmt.setString(2, Integer.toString(remaining.size()));
+            stmt.setString(3, username);
+            stmt.setBytes(4, credentialId);
+            stmt.setBytes(5, oldValue);
+            return stmt.executeUpdate() == 1;
         } catch (SQLException sqe) {
             LOG.log(Level.WARNING, sqe.getMessage(), sqe);
             throw new IllegalStateException(sqe);
@@ -603,6 +733,13 @@ public class JdbcAccount implements LoginCache {
             update.setBytes(2, credentialId);
             update.executeUpdate();
 
+            // backup codes only exist to back up another factor, so don't outlive the last one
+            List<MultiFactorAuthMethod> remaining = getSecondAuthMethods(username).join();
+            if (remaining.stream().noneMatch(m -> m.enabled && m.type != MultiFactorAuthMethod.Type.BACKUP_CODES)) {
+                for (byte[] backupId : getBackupCodeIds(username)) {
+                    deleteMfa(username, backupId).join();
+                }
+            }
             return Futures.of(true);
         } catch (Exception e) {
             LOG.log(Level.WARNING, e.getMessage(), e);

--- a/src/peergos/server/login/LocalOnlyAccount.java
+++ b/src/peergos/server/login/LocalOnlyAccount.java
@@ -7,6 +7,7 @@ import peergos.shared.crypto.asymmetric.PublicSigningKey;
 import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
+import peergos.shared.login.mfa.BackupCodes;
 import peergos.shared.login.mfa.MultiFactorAuthMethod;
 import peergos.shared.login.mfa.MultiFactorAuthRequest;
 import peergos.shared.login.mfa.MultiFactorAuthResponse;
@@ -94,6 +95,11 @@ public class LocalOnlyAccount implements Account {
     @Override
     public CompletableFuture<TotpKey> addTotpFactor(String username, byte[] auth) {
         return target.addTotpFactor(username, auth);
+    }
+
+    @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        return target.generateBackupCodes(username, auth);
     }
 
     @Override

--- a/src/peergos/server/login/NonWriteThroughAccount.java
+++ b/src/peergos/server/login/NonWriteThroughAccount.java
@@ -67,4 +67,9 @@ public class NonWriteThroughAccount implements Account {
     public CompletableFuture<TotpKey> addTotpFactor(String username, byte[] auth) {
         throw new IllegalStateException("TODO");
     }
+
+    @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        throw new IllegalStateException("TODO");
+    }
 }

--- a/src/peergos/server/login/VerifyingAccount.java
+++ b/src/peergos/server/login/VerifyingAccount.java
@@ -68,6 +68,13 @@ public class VerifyingAccount implements Account {
     }
 
     @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        PublicKeyHash identityHash = core.getPublicKeyHash(username).join().get();
+        TimeLimited.isAllowed(Constants.LOGIN_URL + "genBackupCodes", auth, 24*3600, storage, identityHash);
+        return target.generateBackupCodes(username, auth);
+    }
+
+    @Override
     public CompletableFuture<byte[]> registerSecurityKeyStart(String username, byte[] auth) {
         PublicKeyHash identityHash = core.getPublicKeyHash(username).join().get();
         TimeLimited.isAllowed(Constants.LOGIN_URL + "registerWebauthnStart", auth, 24*3600, storage, identityHash);

--- a/src/peergos/server/net/AccountHandler.java
+++ b/src/peergos/server/net/AccountHandler.java
@@ -29,6 +29,33 @@ public class AccountHandler implements HttpHandler {
         this.isPublicServer = isPublicServer;
     }
 
+    /** A client only sends the second factor types it knows about. Anything else is from before
+     *  those types existed, and would fail to parse a method it doesn't recognise, so only offer
+     *  it the original two.
+     */
+    private static Either<UserStaticData, MultiFactorAuthRequest> filterToSupportedMfaTypes(Either<UserStaticData, MultiFactorAuthRequest> res,
+                                                                                            Map<String, List<String>> params) {
+        if (res.isA())
+            return res;
+        Set<Integer> supported = new HashSet<>();
+        if (params.containsKey("mfaTypes")) {
+            for (String type : params.get("mfaTypes").get(0).split(","))
+                supported.add(Integer.parseInt(type));
+        } else {
+            supported.add(MultiFactorAuthMethod.Type.TOTP.value);
+            supported.add(MultiFactorAuthMethod.Type.WEBAUTHN.value);
+        }
+        MultiFactorAuthRequest req = res.b();
+        List<MultiFactorAuthMethod> filtered = new ArrayList<>();
+        for (MultiFactorAuthMethod method : req.methods) {
+            if (supported.contains(method.type.value))
+                filtered.add(method);
+        }
+        if (filtered.size() == req.methods.size())
+            return res;
+        return Either.b(new MultiFactorAuthRequest(filtered, req.challenge));
+    }
+
     public void handle(HttpExchange exchange) throws IOException {
         long t1 = System.currentTimeMillis();
         DataInputStream din = new DataInputStream(exchange.getRequestBody());
@@ -68,6 +95,7 @@ public class AccountHandler implements HttpHandler {
                                 Optional.empty();
                         boolean forceProxy = params.containsKey("proxy") ? Boolean.parseBoolean(params.get("proxy").get(0)) : false;
                         Either<UserStaticData, MultiFactorAuthRequest> res = account.getLoginData(username, authorisedReader, auth, mfa, false, forceProxy, false).join();
+                        res = filterToSupportedMfaTypes(res, params);
                         AggregatedMetrics.LOGIN_GET.inc();
                         byte[] resBytes = new LoginResponse(res).serialize();
                         dout.write(resBytes);
@@ -109,6 +137,13 @@ public class AccountHandler implements HttpHandler {
                     String code = params.get("code").get(0);
                     boolean res = account.enableTotpFactor(username, credentialId, code, auth).join();
                     dout.write(new CborObject.CborBoolean(res).serialize());
+                    break;
+                }
+                case "genBackupCodes": {
+                    AggregatedMetrics.LOGIN_GEN_BACKUP_CODES.inc();
+                    username = params.get("username").get(0);
+                    BackupCodes res = account.generateBackupCodes(username, auth).join();
+                    dout.write(res.serialize());
                     break;
                 }
                 case "registerWebauthnStart": {

--- a/src/peergos/server/tests/BackupCodesTest.java
+++ b/src/peergos/server/tests/BackupCodesTest.java
@@ -1,0 +1,53 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.shared.cbor.*;
+import peergos.shared.login.mfa.*;
+
+import java.security.*;
+import java.util.*;
+import java.util.stream.*;
+
+public class BackupCodesTest {
+
+    @Test
+    public void codeAlphabet() {
+        SecureRandom rnd = new SecureRandom();
+        Set<String> codes = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            byte[] random = new byte[BackupCodes.CODE_BYTES];
+            rnd.nextBytes(random);
+            String code = BackupCodes.generate(random);
+            Assert.assertEquals(BackupCodes.CODE_CHARS, code.length());
+            Assert.assertTrue(code, code.matches("[a-z2-7]+"));
+            codes.add(code);
+        }
+        Assert.assertEquals(1000, codes.size());
+    }
+
+    @Test
+    public void normalisation() {
+        String code = "a3f5b2xqz7";
+        Assert.assertEquals("a3f5b-2xqz7", BackupCodes.format(code));
+        Assert.assertEquals(code, BackupCodes.normalise(code));
+        Assert.assertEquals(code, BackupCodes.normalise(BackupCodes.format(code)));
+        Assert.assertEquals(code, BackupCodes.normalise("A3F5B-2XQZ7"));
+        Assert.assertEquals(code, BackupCodes.normalise(" a3f5b 2xqz7 "));
+        Assert.assertEquals(code, BackupCodes.normalise("a3f5b_2xqz7"));
+    }
+
+    @Test
+    public void cborRoundtrip() {
+        byte[] credentialId = new byte[32];
+        new Random(42).nextBytes(credentialId);
+        List<String> codes = IntStream.range(0, BackupCodes.CODE_COUNT)
+                .mapToObj(i -> BackupCodes.generate(new byte[]{(byte) i, 1, 2, 3, 4, 5, 6}))
+                .collect(Collectors.toList());
+        BackupCodes original = new BackupCodes(credentialId, codes);
+
+        BackupCodes decoded = BackupCodes.fromCbor(CborObject.fromByteArray(original.serialize()));
+        Assert.assertArrayEquals(credentialId, decoded.credentialId);
+        Assert.assertEquals(codes, decoded.codes);
+        Assert.assertEquals(codes.stream().map(BackupCodes::format).collect(Collectors.toList()), decoded.formatted());
+    }
+}

--- a/src/peergos/server/tests/OfflineAccountStoreTests.java
+++ b/src/peergos/server/tests/OfflineAccountStoreTests.java
@@ -11,6 +11,7 @@ import peergos.shared.crypto.asymmetric.PublicSigningKey;
 import peergos.shared.crypto.symmetric.SymmetricKey;
 import peergos.shared.login.LoginCache;
 import peergos.shared.login.OfflineAccountStore;
+import peergos.shared.login.mfa.BackupCodes;
 import peergos.shared.login.mfa.MultiFactorAuthMethod;
 import peergos.shared.login.mfa.MultiFactorAuthRequest;
 import peergos.shared.login.mfa.MultiFactorAuthResponse;
@@ -225,6 +226,11 @@ public class OfflineAccountStoreTests {
 
         @Override
         public CompletableFuture<TotpKey> addTotpFactor(String username, byte[] auth) {
+            throw new IllegalStateException("Not used by these tests");
+        }
+
+        @Override
+        public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
             throw new IllegalStateException("Not used by these tests");
         }
 

--- a/src/peergos/server/tests/RamUserTests.java
+++ b/src/peergos/server/tests/RamUserTests.java
@@ -155,6 +155,137 @@ public class RamUserTests extends UserTests {
         Assert.assertTrue(context.network.account.getSecondAuthMethods(username, context.signer).join().size() == 1);
     }
 
+    @Test
+    public void backupCodes() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+
+        // backup codes are only allowed once there is another factor for them to back up
+        try {
+            context.network.account.generateBackupCodes(username, context.signer).join();
+            Assert.fail("Backup codes shouldn't be allowed without another second factor");
+        } catch (Exception e) {}
+
+        TimeBasedOneTimePasswordGenerator totp = new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30L), 6, TotpKey.ALGORITHM);
+        TotpKey totpKey = addTotpKey(context, totp);
+        // enrolling a totp key must not generate backup codes by itself
+        Assert.assertEquals(1, context.network.account.getSecondAuthMethods(username, context.signer).join().size());
+
+        BackupCodes codes = context.network.account.generateBackupCodes(username, context.signer).join();
+        Assert.assertEquals(BackupCodes.CODE_COUNT, codes.codes.size());
+        Assert.assertEquals(Integer.toString(BackupCodes.CODE_COUNT), remainingBackupCodes(context));
+
+        // a code logs us in, in any of the forms a user might type it
+        testLoginWithBackupCode(username, password, network, codes.credentialId, codes.codes.get(0).toUpperCase());
+        Assert.assertEquals(Integer.toString(BackupCodes.CODE_COUNT - 1), remainingBackupCodes(context));
+        testLoginWithBackupCode(username, password, network, codes.credentialId, BackupCodes.format(codes.codes.get(1)));
+        Assert.assertEquals(Integer.toString(BackupCodes.CODE_COUNT - 2), remainingBackupCodes(context));
+
+        // but only once
+        assertBackupCodeRejected(username, password, network, codes.credentialId, codes.codes.get(0));
+        // and an unknown code never works
+        assertBackupCodeRejected(username, password, network, codes.credentialId, "aaaaaaaaaa");
+        Assert.assertEquals(Integer.toString(BackupCodes.CODE_COUNT - 2), remainingBackupCodes(context));
+
+        // totp still works alongside the codes
+        testLoginRequiresTotp(username, password, network, totp, totpKey);
+
+        // regenerating invalidates the earlier set
+        BackupCodes newCodes = context.network.account.generateBackupCodes(username, context.signer).join();
+        Assert.assertEquals(Integer.toString(BackupCodes.CODE_COUNT), remainingBackupCodes(context));
+        assertBackupCodeRejected(username, password, network, newCodes.credentialId, codes.codes.get(2));
+        testLoginWithBackupCode(username, password, network, newCodes.credentialId, newCodes.codes.get(0));
+
+        // exhausting the set removes it as a login option
+        for (int i = 1; i < BackupCodes.CODE_COUNT; i++)
+            testLoginWithBackupCode(username, password, network, newCodes.credentialId, newCodes.codes.get(i));
+        List<MultiFactorAuthMethod> afterExhaustion = context.network.account.getSecondAuthMethods(username, context.signer).join();
+        Assert.assertEquals(1, afterExhaustion.size());
+        Assert.assertEquals(MultiFactorAuthMethod.Type.TOTP, afterExhaustion.get(0).type);
+
+        // deleting the last real factor deletes the backup codes with it
+        BackupCodes finalCodes = context.network.account.generateBackupCodes(username, context.signer).join();
+        Assert.assertEquals(2, context.network.account.getSecondAuthMethods(username, context.signer).join().size());
+        context.network.account.deleteSecondFactor(username, totpKey.credentialId, context.signer).join();
+        Assert.assertTrue(context.network.account.getSecondAuthMethods(username, context.signer).join().isEmpty());
+        // and login now needs no second factor at all
+        UserContext noMfa = UserContext.signIn(username, password, req -> {
+            throw new IllegalStateException("Shouldn't be asked for a second factor!");
+        }, network, crypto).join();
+        Assert.assertEquals(username, noMfa.username);
+    }
+
+    /** Only one of two logins racing to redeem the same backup code may succeed.
+     */
+    @Test
+    public void concurrentBackupCodeUse() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+
+        TimeBasedOneTimePasswordGenerator totp = new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30L), 6, TotpKey.ALGORITHM);
+        addTotpKey(context, totp);
+        BackupCodes codes = context.network.account.generateBackupCodes(username, context.signer).join();
+        String code = codes.codes.get(0);
+
+        List<CompletableFuture<Boolean>> logins = IntStream.range(0, 2)
+                .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        testLoginWithBackupCode(username, password, network, codes.credentialId, code);
+                        return true;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                }))
+                .collect(Collectors.toList());
+        long succeeded = logins.stream().filter(CompletableFuture::join).count();
+        Assert.assertEquals(1, succeeded);
+        Assert.assertEquals(Integer.toString(BackupCodes.CODE_COUNT - 1), remainingBackupCodes(context));
+    }
+
+    private static String remainingBackupCodes(UserContext context) {
+        return context.network.account.getSecondAuthMethods(context.username, context.signer).join()
+                .stream()
+                .filter(m -> m.type == MultiFactorAuthMethod.Type.BACKUP_CODES)
+                .map(m -> m.name)
+                .findFirst()
+                .orElse("none");
+    }
+
+    private static void testLoginWithBackupCode(String username,
+                                                String password,
+                                                NetworkAccess network,
+                                                byte[] credentialId,
+                                                String code) {
+        AtomicBoolean usedMfa = new AtomicBoolean(false);
+        UserContext freshLogin = UserContext.signIn(username, password, req -> {
+            List<MultiFactorAuthMethod> backups = req.methods.stream()
+                    .filter(m -> m.type == MultiFactorAuthMethod.Type.BACKUP_CODES)
+                    .collect(Collectors.toList());
+            if (backups.isEmpty())
+                throw new IllegalStateException("No backup codes offered! " + req.methods);
+            usedMfa.set(true);
+            return Futures.of(new MultiFactorAuthResponse(credentialId, Either.a(code)));
+        }, network, crypto).join();
+        Assert.assertTrue(usedMfa.get());
+        Assert.assertEquals(username, freshLogin.username);
+    }
+
+    private static void assertBackupCodeRejected(String username,
+                                                 String password,
+                                                 NetworkAccess network,
+                                                 byte[] credentialId,
+                                                 String code) {
+        boolean rejected = false;
+        try {
+            testLoginWithBackupCode(username, password, network, credentialId, code);
+        } catch (Exception e) {
+            rejected = true;
+        }
+        Assert.assertTrue("Backup code should have been rejected", rejected);
+    }
+
     /**
      * Mount login uses the dedicated TOTP credential stored in MountConfig instead of
      * prompting a human. Verifies the round trip: a freshly-issued TOTP key, hex-encoded

--- a/src/peergos/shared/corenode/OpLog.java
+++ b/src/peergos/shared/corenode/OpLog.java
@@ -118,6 +118,11 @@ public class OpLog implements Cborable, Account, MutablePointers, ContentAddress
     }
 
     @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        throw new IllegalStateException("Unsupported operation!");
+    }
+
+    @Override
     public Optional<Bat> getBat(BatId id) {
         throw new IllegalStateException("Unsupported operation!");
     }

--- a/src/peergos/shared/login/OfflineAccountStore.java
+++ b/src/peergos/shared/login/OfflineAccountStore.java
@@ -97,4 +97,9 @@ public class OfflineAccountStore implements Account {
     public CompletableFuture<TotpKey> addTotpFactor(String username, byte[] auth) {
         return target.addTotpFactor(username, auth);
     }
+
+    @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        return target.generateBackupCodes(username, auth);
+    }
 }

--- a/src/peergos/shared/login/mfa/BackupCodes.java
+++ b/src/peergos/shared/login/mfa/BackupCodes.java
@@ -1,0 +1,84 @@
+package peergos.shared.login.mfa;
+
+import jsinterop.annotations.JsType;
+import peergos.shared.cbor.*;
+import peergos.shared.io.ipfs.bases.Base32;
+
+import java.util.*;
+import java.util.stream.*;
+
+/** A set of single use codes which can be used as a second auth factor if a user loses their
+ *  authenticator app or security key. The plaintext codes are only ever available at generation
+ *  time - the server stores only their hashes.
+ */
+@JsType
+public class BackupCodes implements Cborable {
+
+    public static final int CODE_COUNT = 10;
+    public static final int CODE_CHARS = 10;
+    /** enough random bytes to base32 encode to at least CODE_CHARS characters */
+    public static final int CODE_BYTES = 7;
+    private static final int GROUP = 5;
+
+    public final byte[] credentialId;
+    public final List<String> codes;
+
+    public BackupCodes(byte[] credentialId, List<String> codes) {
+        this.credentialId = credentialId;
+        this.codes = codes;
+    }
+
+    /** Display form of a code, e.g. "a3f5b-2xqz7"
+     */
+    public static String format(String code) {
+        StringBuilder res = new StringBuilder();
+        for (int i = 0; i < code.length(); i += GROUP) {
+            if (i > 0)
+                res.append("-");
+            res.append(code, i, Math.min(i + GROUP, code.length()));
+        }
+        return res.toString();
+    }
+
+    public List<String> formatted() {
+        return codes.stream().map(BackupCodes::format).collect(Collectors.toList());
+    }
+
+    /** Users retype or paste codes with the grouping separator, spaces, or in upper case, so
+     *  reduce to the canonical form before hashing or comparing.
+     */
+    public static String normalise(String code) {
+        StringBuilder res = new StringBuilder();
+        String lower = code.toLowerCase();
+        for (int i = 0; i < lower.length(); i++) {
+            char c = lower.charAt(i);
+            if ((c >= 'a' && c <= 'z') || (c >= '2' && c <= '7'))
+                res.append(c);
+        }
+        return res.toString();
+    }
+
+    public static String generate(byte[] random) {
+        if (random.length < CODE_BYTES)
+            throw new IllegalStateException("Insufficient randomness for a backup code!");
+        String base32 = new Base32().encodeToString(random).replaceAll("=", "").toLowerCase();
+        return base32.substring(0, CODE_CHARS);
+    }
+
+    @Override
+    public CborObject toCbor() {
+        SortedMap<String, Cborable> state = new TreeMap<>();
+        state.put("i", new CborObject.CborByteArray(credentialId));
+        state.put("c", new CborObject.CborList(codes.stream()
+                .map(CborObject.CborString::new)
+                .collect(Collectors.toList())));
+        return CborObject.CborMap.build(state);
+    }
+
+    public static BackupCodes fromCbor(Cborable cbor) {
+        if (!(cbor instanceof CborObject.CborMap))
+            throw new IllegalStateException("Invalid cbor for BackupCodes! " + cbor);
+        CborObject.CborMap m = (CborObject.CborMap) cbor;
+        return new BackupCodes(m.getByteArray("i"), m.getList("c", c -> ((CborObject.CborString) c).value));
+    }
+}

--- a/src/peergos/shared/login/mfa/MultiFactorAuthMethod.java
+++ b/src/peergos/shared/login/mfa/MultiFactorAuthMethod.java
@@ -14,7 +14,8 @@ public class MultiFactorAuthMethod implements Cborable {
     @JsType
     public enum Type {
         TOTP(0x1, false),
-        WEBAUTHN(0x2, true);
+        WEBAUTHN(0x2, true),
+        BACKUP_CODES(0x3, false);
 
         public final int value;
         public final boolean hasChallenge;

--- a/src/peergos/shared/user/Account.java
+++ b/src/peergos/shared/user/Account.java
@@ -80,6 +80,16 @@ public interface Account {
                 .thenCompose(auth -> addTotpFactor(username, auth));
     }
 
+    CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth);
+
+    @JsMethod
+    default CompletableFuture<BackupCodes> generateBackupCodes(String username, SigningPrivateKeyAndPublicHash identity) {
+        TimeLimitedClient.SignedRequest req =
+                new TimeLimitedClient.SignedRequest(Constants.LOGIN_URL + "genBackupCodes", System.currentTimeMillis());
+        return req.sign(identity.secret)
+                .thenCompose(auth -> generateBackupCodes(username, auth));
+    }
+
     CompletableFuture<byte[]> registerSecurityKeyStart(String username, byte[] auth);
 
     @JsMethod

--- a/src/peergos/shared/user/AccountProxy.java
+++ b/src/peergos/shared/user/AccountProxy.java
@@ -25,6 +25,8 @@ public interface AccountProxy extends Account {
 
     CompletableFuture<TotpKey> addTotpFactor(Multihash targetServerId, String username, byte[] auth);
 
+    CompletableFuture<BackupCodes> generateBackupCodes(Multihash targetServerId, String username, byte[] auth);
+
     CompletableFuture<Boolean> enableTotpFactor(Multihash targetServerId,
                                                 String username,
                                                 byte[] credentialId,

--- a/src/peergos/shared/user/HttpAccount.java
+++ b/src/peergos/shared/user/HttpAccount.java
@@ -81,6 +81,19 @@ public class HttpAccount implements AccountProxy {
         return getLoginData(getProxyUrlPrefix(targetServerId), p2p, username, authorisedReader, auth, mfa, true);
     }
 
+    /** Tell the server which second factor types we know how to present, so that a newer server
+     *  doesn't offer an older client a method it would fail to parse.
+     */
+    private static String supportedMfaTypes() {
+        StringBuilder res = new StringBuilder();
+        for (MultiFactorAuthMethod.Type type : MultiFactorAuthMethod.Type.values()) {
+            if (res.length() > 0)
+                res.append(",");
+            res.append(type.value);
+        }
+        return res.toString();
+    }
+
     private CompletableFuture<Either<UserStaticData, MultiFactorAuthRequest>> getLoginData(String urlPrefix,
                                                                                            HttpPoster poster,
                                                                                            String username,
@@ -92,6 +105,7 @@ public class HttpAccount implements AccountProxy {
                         + "&author=" + ArrayOps.bytesToHex(authorisedReader.serialize())
                         + "&auth=" + ArrayOps.bytesToHex(auth)
                         + "&proxy=" + forceProxy
+                        + "&mfaTypes=" + supportedMfaTypes()
                         + mfa.map(mfaCode -> "&mfa=" + ArrayOps.bytesToHex(mfaCode.serialize())).orElse(""))
                 .thenApply(res -> LoginResponse.fromCbor(CborObject.fromByteArray(res)).resp);
     }
@@ -129,6 +143,22 @@ public class HttpAccount implements AccountProxy {
         return poster.get(urlPrefix + Constants.LOGIN_URL + "addTotp?username=" + username
                         + "&auth=" + ArrayOps.bytesToHex(auth))
                 .thenApply(res -> TotpKey.fromString(new String(res)));
+    }
+
+    @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        return generateBackupCodes(directUrlPrefix, direct, username, auth);
+    }
+
+    @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(Multihash targetServerId, String username, byte[] auth) {
+        return generateBackupCodes(getProxyUrlPrefix(targetServerId), p2p, username, auth);
+    }
+
+    private CompletableFuture<BackupCodes> generateBackupCodes(String urlPrefix, HttpPoster poster, String username, byte[] auth) {
+        return poster.get(urlPrefix + Constants.LOGIN_URL + "genBackupCodes?username=" + username
+                        + "&auth=" + ArrayOps.bytesToHex(auth))
+                .thenApply(res -> BackupCodes.fromCbor(CborObject.fromByteArray(res)));
     }
 
     @Override

--- a/src/peergos/shared/user/ProxyingAccount.java
+++ b/src/peergos/shared/user/ProxyingAccount.java
@@ -59,6 +59,15 @@ public class ProxyingAccount implements Account {
     }
 
     @Override
+    public CompletableFuture<BackupCodes> generateBackupCodes(String username, byte[] auth) {
+        return core.getPublicKeyHash(username).thenCompose(idOpt -> Proxy.redirectCall(core,
+                serverIds,
+                idOpt.get(),
+                () -> local.generateBackupCodes(username, auth),
+                target -> p2p.generateBackupCodes(target, username, auth)));
+    }
+
+    @Override
     public CompletableFuture<byte[]> registerSecurityKeyStart(String username, byte[] auth) {
         return core.getPublicKeyHash(username).thenCompose(idOpt -> Proxy.redirectCall(core,
                 serverIds,


### PR DESCRIPTION
 - new BACKUP_CODES mfa type, stored as one mfa row with sha256 of each unused code
 - only generated on request, and only once another second factor exists
 - each code works once, burnt with a compare and set so concurrent logins can't reuse one
 - remaining count lives in the name column, exhausted sets stop being offered
 - deleted along with the last factor they were backing up
 - clients send the mfa types they understand, so older ones aren't offered backup codes