### PR TITLE
Separate read queue from write queue

### DIFF
--- a/src/peergos/server/Builder.java
+++ b/src/peergos/server/Builder.java
@@ -202,8 +202,8 @@ public class Builder {
             if (usePostgres) {
                 return new CachingBlockMetadataStore(new JdbcBlockMetadataStore(getPostgresConnector(a, "metadb."), new PostgresCommands()), 200_000);
             } else {
-                File metaFile = a.fromPeergosDir("block-metadata-sql-file", "blockmetadata-v3.sql").toFile();
-                Connection instance = new Sqlite.UncloseableConnection(Sqlite.build(metaFile.getPath()));
+                String metaPath = Sqlite.getDbPath(a, "block-metadata-sql-file", "blockmetadata-v3.sql");
+                Connection instance = new Sqlite.UncloseableConnection(Sqlite.build(metaPath));
                 return new JdbcBlockMetadataStore(() -> instance, new SqliteCommands());
             }
         } catch (SQLException e) {

--- a/src/peergos/server/corenode/MirrorCoreNode.java
+++ b/src/peergos/server/corenode/MirrorCoreNode.java
@@ -28,6 +28,7 @@ import java.time.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.*;
+import java.util.concurrent.locks.*;
 import java.util.function.*;
 import java.util.logging.*;
 import java.util.stream.*;
@@ -64,7 +65,7 @@ public class MirrorCoreNode implements CoreNode {
     private volatile CorenodeState state;
     private final Path statePath;
     private volatile boolean running = true, initialized = false;
-    private final AtomicBoolean updating = new AtomicBoolean(false);
+    private final ReentrantLock updating = new ReentrantLock();
 
     public MirrorCoreNode(CoreNode writeTarget,
                           JdbcAccount rawAccount,
@@ -367,13 +368,34 @@ public class MirrorCoreNode implements CoreNode {
         return new Pair<>(new CorenodeRoots(pkiOwnerIdentity, pkiKey, newPeergosRoot, currentPkiRoot), newPointer);
     }
 
-    /**
+    /** Update our mirror of the pki, unless another update is already in flight
      *
      * @return whether there was a change
      */
     public boolean update() {
-        if (!updating.compareAndSet(false, true))
+        if (! updating.tryLock())
             return false;
+        try {
+            return updateMirror();
+        } finally {
+            updating.unlock();
+        }
+    }
+
+    /** Update our mirror of the pki, waiting for any in flight update to complete first
+     *
+     * @return whether there was a change
+     */
+    public boolean forceUpdate() {
+        updating.lock();
+        try {
+            return updateMirror();
+        } finally {
+            updating.unlock();
+        }
+    }
+
+    private boolean updateMirror() {
         try {
             Pair<CorenodeRoots, byte[]> remoteState = getPkiState();
             CorenodeRoots remote = remoteState.left;
@@ -449,8 +471,6 @@ public class MirrorCoreNode implements CoreNode {
             return true;
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage(), e);
-        } finally {
-            updating.set(false);
         }
     }
 

--- a/src/peergos/server/tests/AsyncLockTests.java
+++ b/src/peergos/server/tests/AsyncLockTests.java
@@ -1,0 +1,157 @@
+package peergos.server.tests;
+
+import org.junit.*;
+import peergos.shared.util.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+
+public class AsyncLockTests {
+
+    private static <T> CompletableFuture<T> read(AsyncLock<T> lock, java.util.function.Function<T, CompletionStage<T>> processor) {
+        return lock.runWithReadLock(processor, () -> Futures.errored(new IllegalStateException("Unexpected updater call")));
+    }
+
+    @Test
+    public void readsDontWaitForAnInflightWrite() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        CompletableFuture<Integer> slowWrite = new CompletableFuture<>();
+        CompletableFuture<Integer> write = lock.runWithLock(x -> slowWrite);
+
+        CompletableFuture<Integer> result = read(lock, x -> Futures.of(42));
+
+        assertTrue("read completed whilst a write is in flight", result.isDone());
+        assertEquals(42, (int) result.join());
+        assertFalse(write.isDone());
+
+        slowWrite.complete(1);
+        assertEquals(1, (int) write.join());
+    }
+
+    @Test
+    public void readsAreSerialisedWithEachOther() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        CompletableFuture<Integer> slowRead = new CompletableFuture<>();
+        List<Integer> order = new ArrayList<>();
+
+        CompletableFuture<Integer> first = read(lock, x -> slowRead.thenApply(v -> {
+            order.add(1);
+            return v;
+        }));
+        CompletableFuture<Integer> second = read(lock, x -> {
+            order.add(2);
+            return Futures.of(2);
+        });
+
+        assertTrue("second read hasn't started", order.isEmpty());
+        assertFalse(second.isDone());
+
+        slowRead.complete(1);
+        assertEquals(Arrays.asList(1, 2), order);
+        assertEquals(1, (int) first.join());
+        assertEquals(2, (int) second.join());
+    }
+
+    @Test
+    public void aFailedReadDoesntPoisonTheReadQueue() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(7));
+
+        CompletableFuture<Integer> failed = read(lock, x -> Futures.errored(new RuntimeException("boom")));
+        assertTrue(failed.isCompletedExceptionally());
+
+        List<Integer> startedFrom = new ArrayList<>();
+        CompletableFuture<Integer> next = read(lock, x -> {
+            startedFrom.add(x);
+            return Futures.of(x + 1);
+        });
+        assertEquals("previous value retained", Arrays.asList(7), startedFrom);
+        assertEquals(8, (int) next.join());
+    }
+
+    @Test
+    public void aFailedInitialValueIsRecoveredForReads() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.errored(new RuntimeException("boom")));
+
+        CompletableFuture<Integer> failed = lock.runWithReadLock(x -> Futures.of(x), () -> Futures.of(5));
+        assertTrue(failed.isCompletedExceptionally());
+
+        List<Integer> startedFrom = new ArrayList<>();
+        CompletableFuture<Integer> next = read(lock, x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        });
+        assertEquals(Arrays.asList(5), startedFrom);
+        assertEquals(5, (int) next.join());
+    }
+
+    @Test
+    public void aReadDoesntOverwriteAnInflightWritesResult() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        CompletableFuture<Integer> slowRead = new CompletableFuture<>();
+        CompletableFuture<Integer> reading = read(lock, x -> slowRead);
+
+        // a write starts and completes whilst the read is in flight
+        assertEquals(5, (int) lock.runWithLock(x -> Futures.of(5)).join());
+
+        // the read returns a value retrieved before the write
+        slowRead.complete(1);
+        assertEquals(1, (int) reading.join());
+
+        List<Integer> startedFrom = new ArrayList<>();
+        lock.runWithLock(x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        }).join();
+        assertEquals("write starts from the written value", Arrays.asList(5), startedFrom);
+    }
+
+    @Test
+    public void aWriteIsVisibleToTheNextRead() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        lock.runWithLock(x -> Futures.of(9)).join();
+
+        List<Integer> startedFrom = new ArrayList<>();
+        read(lock, x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        }).join();
+        assertEquals(Arrays.asList(9), startedFrom);
+    }
+
+    @Test
+    public void aReadRefreshesAnIdleWriteQueue() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        read(lock, x -> Futures.of(3)).join();
+
+        List<Integer> startedFrom = new ArrayList<>();
+        lock.runWithLock(x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        }).join();
+        assertEquals(Arrays.asList(3), startedFrom);
+    }
+
+    @Test
+    public void writesAreStillSerialised() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        CompletableFuture<Integer> slowWrite = new CompletableFuture<>();
+        List<Integer> order = new ArrayList<>();
+
+        CompletableFuture<Integer> first = lock.runWithLock(x -> slowWrite.thenApply(v -> {
+            order.add(1);
+            return v;
+        }));
+        CompletableFuture<Integer> second = lock.runWithLock(x -> {
+            order.add(2);
+            return Futures.of(x + 1);
+        });
+
+        assertTrue(order.isEmpty());
+        slowWrite.complete(10);
+        assertEquals(Arrays.asList(1, 2), order);
+        assertEquals(10, (int) first.join());
+        assertEquals(11, (int) second.join());
+    }
+}

--- a/src/peergos/server/tests/AsyncLockTests.java
+++ b/src/peergos/server/tests/AsyncLockTests.java
@@ -86,6 +86,9 @@ public class AsyncLockTests {
         assertEquals(5, (int) next.join());
     }
 
+    /** With async IO a read's retrieval and its completion can straddle a write, so a read that
+     *  started before a write must not resurrect pre-write state afterwards.
+     */
     @Test
     public void aReadDoesntOverwriteAnInflightWritesResult() {
         AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
@@ -120,9 +123,13 @@ public class AsyncLockTests {
         assertEquals(Arrays.asList(9), startedFrom);
     }
 
+    /** A read retrieves committed state, which can be older than what an in-flight write is building,
+     *  so it must never become the value a later write starts from.
+     */
     @Test
-    public void aReadRefreshesAnIdleWriteQueue() {
+    public void aReadNeverChangesTheWriteQueuesValue() {
         AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        lock.runWithLock(x -> Futures.of(7)).join();
         read(lock, x -> Futures.of(3)).join();
 
         List<Integer> startedFrom = new ArrayList<>();
@@ -130,7 +137,40 @@ public class AsyncLockTests {
             startedFrom.add(x);
             return Futures.of(x);
         }).join();
-        assertEquals(Arrays.asList(3), startedFrom);
+        assertEquals("write starts from the last written value", Arrays.asList(7), startedFrom);
+    }
+
+    @Test
+    public void updateIfIdleAdvancesTheValueTheNextWriteStartsFrom() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(4));
+        lock.updateIfIdle(existing -> Math.max(existing, 9));
+        lock.updateIfIdle(existing -> Math.max(existing, 6));
+
+        List<Integer> startedFrom = new ArrayList<>();
+        lock.runWithLock(x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        }).join();
+        assertEquals("only ever advances", Arrays.asList(9), startedFrom);
+    }
+
+    @Test
+    public void updateIfIdleIsIgnoredWhilstAWriteIsInFlight() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
+        CompletableFuture<Integer> slowWrite = new CompletableFuture<>();
+        CompletableFuture<Integer> write = lock.runWithLock(x -> slowWrite);
+
+        lock.updateIfIdle(existing -> 99);
+
+        slowWrite.complete(5);
+        assertEquals(5, (int) write.join());
+
+        List<Integer> startedFrom = new ArrayList<>();
+        lock.runWithLock(x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        }).join();
+        assertEquals("in-flight write's result is not clobbered", Arrays.asList(5), startedFrom);
     }
 
     @Test

--- a/src/peergos/server/tests/AsyncLockTests.java
+++ b/src/peergos/server/tests/AsyncLockTests.java
@@ -140,38 +140,7 @@ public class AsyncLockTests {
         assertEquals("write starts from the last written value", Arrays.asList(7), startedFrom);
     }
 
-    @Test
-    public void updateIfIdleAdvancesTheValueTheNextWriteStartsFrom() {
-        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(4));
-        lock.updateIfIdle(existing -> Math.max(existing, 9));
-        lock.updateIfIdle(existing -> Math.max(existing, 6));
 
-        List<Integer> startedFrom = new ArrayList<>();
-        lock.runWithLock(x -> {
-            startedFrom.add(x);
-            return Futures.of(x);
-        }).join();
-        assertEquals("only ever advances", Arrays.asList(9), startedFrom);
-    }
-
-    @Test
-    public void updateIfIdleIsIgnoredWhilstAWriteIsInFlight() {
-        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(0));
-        CompletableFuture<Integer> slowWrite = new CompletableFuture<>();
-        CompletableFuture<Integer> write = lock.runWithLock(x -> slowWrite);
-
-        lock.updateIfIdle(existing -> 99);
-
-        slowWrite.complete(5);
-        assertEquals(5, (int) write.join());
-
-        List<Integer> startedFrom = new ArrayList<>();
-        lock.runWithLock(x -> {
-            startedFrom.add(x);
-            return Futures.of(x);
-        }).join();
-        assertEquals("in-flight write's result is not clobbered", Arrays.asList(5), startedFrom);
-    }
 
     @Test
     public void writesAreStillSerialised() {

--- a/src/peergos/server/tests/GCTests.java
+++ b/src/peergos/server/tests/GCTests.java
@@ -32,18 +32,15 @@ import java.util.stream.*;
 public class GCTests {
     private static final Crypto crypto = JavaCrypto.init();
 
-    private Supplier<Connection> getDb(Path file) throws Exception {
-        File storeFile = file.toFile();
-        String sqlFilePath = storeFile.getPath();
-        Connection db = Sqlite.build(sqlFilePath);
+    private Supplier<Connection> getDb() throws Exception {
+        Connection db = Sqlite.build(":memory:");
         Connection instance = new Sqlite.UncloseableConnection(db);
         return () -> instance;
     }
 
     @Test
     public void linksInDb() throws Exception {
-        Path dir = Files.createTempDirectory("peergos-gc-test");
-        SqliteBlockReachability rdb = SqliteBlockReachability.createReachabilityDb(dir.resolve("reachability.sqlite"));
+        SqliteBlockReachability rdb = new SqliteBlockReachability(getDb(), new SqliteCommands());
         Cid block = new Cid(1, Cid.Codec.DagCbor, Multihash.Type.sha2_256, crypto.random.randomBytes(32));
         List<Cid> links = new ArrayList<>();
         for (int i=0; i<10; i++)
@@ -60,11 +57,11 @@ public class GCTests {
     public void versionedGC() throws Exception {
         Path dir = Files.createTempDirectory("peergos-gc-test");
         SqliteCommands cmds = new SqliteCommands();
-        RequestCountingBlockMetadataStore metadb = new RequestCountingBlockMetadataStore(new JdbcBlockMetadataStore(getDb(dir.resolve("metadata.sqlite")), cmds));
+        RequestCountingBlockMetadataStore metadb = new RequestCountingBlockMetadataStore(new JdbcBlockMetadataStore(getDb(), cmds));
 
         VersionedWriteOnlyStorage storage = new VersionedWriteOnlyStorage(metadb);
-        JdbcIpnsAndSocial pointers = new JdbcIpnsAndSocial(getDb(dir.resolve("mutable.sqlite")), cmds);
-        JdbcUsageStore usage = new JdbcUsageStore(getDb(dir.resolve("usage.sqlite")), cmds);
+        JdbcIpnsAndSocial pointers = new JdbcIpnsAndSocial(getDb(), cmds);
+        JdbcUsageStore usage = new JdbcUsageStore(getDb(), cmds);
 
         GarbageCollector gc = new GarbageCollector(storage, pointers, usage, new RamPki(), dir, (x, y, z) -> Futures.of(true), u -> Futures.of(true), true);
         gc.collect(s -> Futures.of(true));
@@ -156,11 +153,11 @@ public class GCTests {
     public void fullGC() throws Exception {
         Path dir = Files.createTempDirectory("peergos-gc-test");
         SqliteCommands cmds = new SqliteCommands();
-        RequestCountingBlockMetadataStore metadb = new RequestCountingBlockMetadataStore(new JdbcBlockMetadataStore(getDb(dir.resolve("metadata.sqlite")), cmds));
+        RequestCountingBlockMetadataStore metadb = new RequestCountingBlockMetadataStore(new JdbcBlockMetadataStore(getDb(), cmds));
 
         WriteOnlyStorage storage = new WriteOnlyStorage(metadb);
-        JdbcIpnsAndSocial pointers = new JdbcIpnsAndSocial(getDb(dir.resolve("mutable.sqlite")), cmds);
-        JdbcUsageStore usage = new JdbcUsageStore(getDb(dir.resolve("usage.sqlite")), cmds);
+        JdbcIpnsAndSocial pointers = new JdbcIpnsAndSocial(getDb(), cmds);
+        JdbcUsageStore usage = new JdbcUsageStore(getDb(), cmds);
 
         GarbageCollector gc = new GarbageCollector(storage, pointers, usage, new RamPki(), dir, (x, y, z) -> Futures.of(true), u -> Futures.of(true), true);
         gc.collect(s -> Futures.of(true));
@@ -280,17 +277,10 @@ public class GCTests {
     }
 
     @Test
-    public void correctMarkPhase() throws IOException, SQLException {
-        Path dir = Files.createTempDirectory("peergos-block-metadata");
-        File storeFile = dir.resolve("metadata.sql" + System.currentTimeMillis()).toFile();
-        String sqlFilePath = storeFile.getPath();
-        Connection db = Sqlite.build(sqlFilePath);
-        Connection instance = new Sqlite.UncloseableConnection(db);
-        BlockMetadataStore metadb = new JdbcBlockMetadataStore(() -> instance, new SqliteCommands());
+    public void correctMarkPhase() throws Exception {
+        BlockMetadataStore metadb = new JdbcBlockMetadataStore(getDb(), new SqliteCommands());
 
-        String filename = "temp.sql";
-        Path file = Path.of(filename);
-        SqliteBlockReachability reachability = SqliteBlockReachability.createReachabilityDb(file);
+        SqliteBlockReachability reachability = new SqliteBlockReachability(getDb(), new SqliteCommands());
         PublicKeyHash owner = new PublicKeyHash(randomCbor(new Random(42)));
 
         int nUsers = 1;

--- a/src/peergos/server/tests/MultiNodeNetworkTests.java
+++ b/src/peergos/server/tests/MultiNodeNetworkTests.java
@@ -221,7 +221,7 @@ public class MultiNodeNetworkTests {
             CoreNode core = service.localApi.coreNode;
             CoreNode target = ((SignUpFilter) ((CorenodeEventPropagator) core).target).target;
             if (target instanceof MirrorCoreNode)
-                ((MirrorCoreNode)target).update();
+                ((MirrorCoreNode)target).forceUpdate();
         }
     }
 

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -32,7 +32,7 @@ import static peergos.server.tests.PeergosNetworkUtils.getUserContextsForNode;
 
 public class MultiUserTests {
 
-    private static Args args = UserTests.buildArgs()
+    private static Args args = UserTests.useMemoryDbs(UserTests.buildArgs())
             .with("enable-gc", "false")
             .with("log-to-console", "true");
     private static UserService service;

--- a/src/peergos/server/tests/MultiUserTests.java
+++ b/src/peergos/server/tests/MultiUserTests.java
@@ -744,7 +744,7 @@ public class MultiUserTests {
 
         Path filePath = PathUtil.get(u1.username, subdirName, filename);
 
-        shareFunction.apply(u1, userContexts, filePath);
+        shareFunction.apply(u1, userContexts, filePath).join();
 
         FileWrapper theFile = u1.getByPath(filePath).get().get();
         Set<String> sharedWriteAccessWithBefore = u1.sharedWith(filePath).join().get(sharedWithAccess);
@@ -802,7 +802,7 @@ public class MultiUserTests {
 
         Path dirPath = PathUtil.get(u1.username, subdirName);
 
-        shareFunction.apply(u1, userContexts, dirPath);
+        shareFunction.apply(u1, userContexts, dirPath).join();
 
         FileWrapper theDir = u1.getByPath(dirPath).get().get();
         Set<String> sharedWriteAccessWithBefore = u1.sharedWith(dirPath).join().get(sharedWithAccess);
@@ -836,7 +836,7 @@ public class MultiUserTests {
         //read access
         TriFunction<UserContext, List<UserContext>, Path, Object> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
-                        u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
+                        u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet())).join();
 
         moveToFileSharedWith(readAccessSharingFunction, s -> ! s.readAccess.isEmpty());
         //write access
@@ -910,7 +910,7 @@ public class MultiUserTests {
         //read access
         TriFunction<UserContext, List<UserContext>, Path, Object> readAccessSharingFunction =
                 (u1, u2List, filePath) ->
-                        u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet()));
+                        u1.shareReadAccessWith(filePath, u2List.stream().map(u -> u.username).collect(Collectors.toSet())).join();
 
         moveFileToDifferentWriter(readAccessSharingFunction, s -> ! s.readAccess.isEmpty());
         //write access

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -400,6 +400,247 @@ public abstract class UserTests {
         Assert.assertTrue(updatedFile.getFileProperties().modified.isAfter(emptyFile.getFileProperties().modified));
     }
 
+    /** An in-flight upload holds the write lock for the whole file, so reads must not queue behind it.
+     */
+    @Test
+    public void navigateDuringUpload() {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        byte[] existingData = randomData(1024);
+        context.getUserRoot().join().uploadOrReplaceFile("existing.bin", AsyncReader.build(existingData),
+                existingData.length, context.network, context.crypto, () -> false, l -> {}).join();
+
+        byte[] data = randomData(2 * Chunk.MAX_SIZE);
+        BlockingReader blocking = new BlockingReader(AsyncReader.build(data), Chunk.MAX_SIZE);
+        CompletableFuture<FileWrapper> upload = context.getUserRoot().join()
+                .uploadOrReplaceFile("uploading.bin", blocking, data.length, context.network, context.crypto,
+                        () -> false, l -> {});
+        blocking.awaitBlocked();
+        Assert.assertFalse("upload is still in flight", upload.isDone());
+
+        // all of these queue behind the upload without a separate read queue
+        FileWrapper existing = context.getByPath(PathUtil.get(username, "existing.bin")).join().get();
+        Assert.assertEquals(existingData.length, existing.getSize());
+
+        Set<String> childNames = context.getUserRoot().join().getChildren(crypto.hasher, network).join()
+                .stream().map(FileWrapper::getName).collect(Collectors.toSet());
+        Assert.assertTrue(childNames.contains("existing.bin"));
+
+        byte[] retrieved = Serialize.readFully(existing.getInputStream(network, crypto, x -> {}).join(),
+                existingData.length).join();
+        Assert.assertArrayEquals(existingData, retrieved);
+
+        blocking.unblock();
+        upload.join();
+
+        FileWrapper uploaded = context.getByPath(PathUtil.get(username, "uploading.bin")).join().get();
+        Assert.assertEquals(data.length, uploaded.getSize());
+        Assert.assertArrayEquals(data, Serialize.readFully(uploaded.getInputStream(network, crypto, x -> {}).join(),
+                data.length).join());
+    }
+
+    /** Browsing and then queueing a second upload whilst a first is in flight must not stall the first.
+     */
+    @Test
+    public void secondUploadDuringFirst() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        TransactionService txns = context.getTransactionService();
+        context.getUserRoot().join().mkdir("subdir", network, false, context.mirrorBatId(), crypto).join();
+        byte[] existingData = randomData(1024);
+        context.getByPath(PathUtil.get(username, "subdir")).join().get()
+                .uploadOrReplaceFile("existing.bin", AsyncReader.build(existingData), existingData.length,
+                        context.network, context.crypto, () -> false, l -> {}).join();
+
+        byte[] data = randomData(2 * Chunk.MAX_SIZE);
+        BlockingReader blocking = new BlockingReader(AsyncReader.build(data), Chunk.MAX_SIZE);
+        CompletableFuture<FileWrapper> first = context.getUserRoot().join()
+                .uploadFileJS("big.bin", blocking, 0, data.length, false, context.mirrorBatId(),
+                        network, crypto, l -> {}, txns, f -> Futures.of(true));
+        blocking.awaitBlocked();
+        Assert.assertFalse("first upload is still in flight", first.isDone());
+
+        // browse to a sub dir and view a file in it
+        FileWrapper subdir = context.getByPath(PathUtil.get(username, "subdir")).join().get();
+        FileWrapper existing = context.getByPath(PathUtil.get(username, "subdir", "existing.bin")).join().get();
+        Assert.assertArrayEquals(existingData, Serialize.readFully(existing.getInputStream(network, crypto, x -> {})
+                .join(), existingData.length).join());
+
+        // then start a second upload, which must queue behind the first
+        byte[] secondData = randomData(1024);
+        CompletableFuture<FileWrapper> second = subdir.uploadFileJS("second.bin",
+                AsyncReader.build(secondData), 0, secondData.length, false, context.mirrorBatId(),
+                network, crypto, l -> {}, txns, f -> Futures.of(true));
+        Assert.assertFalse("second upload is queued", second.isDone());
+
+        blocking.unblock();
+        first.get(180, TimeUnit.SECONDS);
+        second.get(180, TimeUnit.SECONDS);
+
+        Assert.assertEquals(data.length, context.getByPath(PathUtil.get(username, "big.bin")).join().get().getSize());
+        Assert.assertEquals(secondData.length, context.getByPath(PathUtil.get(username, "subdir", "second.bin"))
+                .join().get().getSize());
+    }
+
+    /** Reads interleaved with an actively progressing upload, as happens in the browser.
+     */
+    @Test
+    public void readsInterleavedWithUpload() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        TransactionService txns = context.getTransactionService();
+        context.getUserRoot().join().mkdir("subdir", network, false, context.mirrorBatId(), crypto).join();
+        byte[] existingData = randomData(1024);
+        context.getByPath(PathUtil.get(username, "subdir")).join().get()
+                .uploadOrReplaceFile("existing.bin", AsyncReader.build(existingData), existingData.length,
+                        context.network, context.crypto, () -> false, l -> {}).join();
+
+        byte[] data = randomData(4 * Chunk.MAX_SIZE);
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        CompletableFuture<Boolean> firstDone = new CompletableFuture<>();
+        pool.submit(() -> {
+            try {
+                context.getUserRoot().join().uploadFileJS("big.bin", AsyncReader.build(data), 0, data.length,
+                        false, context.mirrorBatId(), network, crypto, l -> {}, txns, f -> Futures.of(true)).join();
+                firstDone.complete(true);
+            } catch (Throwable t) {
+                firstDone.completeExceptionally(t);
+            }
+        });
+
+        int reads = 0;
+        boolean startedSecond = false;
+        CompletableFuture<Boolean> secondDone = new CompletableFuture<>();
+        long deadline = System.currentTimeMillis() + 240_000;
+        while (! firstDone.isDone() && System.currentTimeMillis() < deadline) {
+            FileWrapper home = context.getByPath(PathUtil.get(username)).join().get();
+            home.getChildren(crypto.hasher, network).join();
+            home.getLatest(network).join();
+            FileWrapper subdir = context.getByPath(PathUtil.get(username, "subdir")).join().get();
+            subdir.getChildren(crypto.hasher, network).join();
+            FileWrapper existing = context.getByPath(PathUtil.get(username, "subdir", "existing.bin")).join().get();
+            Serialize.readFully(existing.getInputStream(network, crypto, x -> {}).join(), existingData.length).join();
+            reads++;
+            if (reads == 3 && ! startedSecond) {
+                startedSecond = true;
+                byte[] secondData = randomData(1024);
+                pool.submit(() -> {
+                    try {
+                        subdir.uploadFileJS("second.bin", AsyncReader.build(secondData), 0, secondData.length,
+                                false, context.mirrorBatId(), network, crypto, l -> {}, txns, f -> Futures.of(true)).join();
+                        secondDone.complete(true);
+                    } catch (Throwable t) {
+                        secondDone.completeExceptionally(t);
+                    }
+                });
+            }
+        }
+        pool.shutdown();
+        Assert.assertTrue("did some reads during the upload", reads > 2);
+        firstDone.get(120, TimeUnit.SECONDS);
+        secondDone.get(120, TimeUnit.SECONDS);
+        Assert.assertEquals(data.length, context.getByPath(PathUtil.get(username, "big.bin")).join().get().getSize());
+    }
+
+    /** An upload waits for the replace/resume callbacks whilst holding the writer's lock, so a prompt
+     *  the user never answers parks the upload with no network activity and no error.
+     */
+    @Test
+    public void uploadParkedOnReplacePrompt() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        TransactionService txns = context.getTransactionService();
+        FileWrapper home = context.getUserRoot().join();
+        byte[] original = randomData(1024);
+        home.uploadOrReplaceFile("collides.bin", AsyncReader.build(original), original.length,
+                context.network, context.crypto, () -> false, l -> {}).join();
+
+        // a prompt the user never answers
+        CompletableFuture<Boolean> neverAnswered = new CompletableFuture<>();
+        CompletableFuture<Boolean> prompted = new CompletableFuture<>();
+        byte[] replacement = randomData(2048);
+        FileWrapper.FileUploadProperties file = new FileWrapper.FileUploadProperties("collides.bin",
+                () -> AsyncReader.build(replacement), 0, replacement.length, Optional.empty(), Optional.empty(),
+                false, false, l -> {});
+        CompletableFuture<FileWrapper> upload = context.getUserRoot().join()
+                .uploadSubtree(Stream.of(new FileWrapper.FolderUploadProperties(Collections.emptyList(),
+                                Collections.singletonList(file))), context.mirrorBatId(), network, crypto, txns,
+                        f -> Futures.of(false),
+                        name -> {
+                            prompted.complete(true);
+                            return neverAnswered;
+                        }, () -> true);
+        prompted.get(60, TimeUnit.SECONDS);
+
+        // reads still work, exactly as reported from the UI
+        Assert.assertEquals(original.length, context.getByPath(PathUtil.get(username, "collides.bin"))
+                .join().get().getSize());
+        context.getUserRoot().join().getChildren(crypto.hasher, network).join();
+
+        // but any write for that writer is stuck behind the unanswered prompt
+        CompletableFuture<FileWrapper> queuedWrite = context.getUserRoot().join()
+                .mkdir("newdir", network, false, context.mirrorBatId(), crypto);
+        Thread.sleep(2000);
+        Assert.assertFalse("upload is parked on the prompt", upload.isDone());
+        Assert.assertFalse("later writes are stuck behind it", queuedWrite.isDone());
+
+        neverAnswered.complete(true);
+        upload.get(120, TimeUnit.SECONDS);
+        queuedWrite.get(120, TimeUnit.SECONDS);
+    }
+
+    /** Pauses a read once a threshold of bytes has been read, so an upload can be held mid flight.
+     */
+    private static class BlockingReader implements AsyncReader {
+        private final AsyncReader source;
+        private final long blockAfter;
+        private final CompletableFuture<Boolean> blocked = new CompletableFuture<>();
+        private final CompletableFuture<Boolean> unblocked = new CompletableFuture<>();
+        private long totalRead = 0;
+
+        public BlockingReader(AsyncReader source, long blockAfter) {
+            this.source = source;
+            this.blockAfter = blockAfter;
+        }
+
+        public void awaitBlocked() {
+            blocked.join();
+        }
+
+        public void unblock() {
+            unblocked.complete(true);
+        }
+
+        @Override
+        public CompletableFuture<Integer> readIntoArray(byte[] res, int offset, int length) {
+            totalRead += length;
+            if (totalRead > blockAfter) {
+                blocked.complete(true);
+                return unblocked.thenCompose(x -> source.readIntoArray(res, offset, length));
+            }
+            return source.readIntoArray(res, offset, length);
+        }
+
+        @Override
+        public CompletableFuture<AsyncReader> seekJS(int high32, int low32) {
+            return source.seekJS(high32, low32).thenApply(x -> this);
+        }
+
+        @Override
+        public CompletableFuture<AsyncReader> reset() {
+            return source.reset().thenApply(x -> this);
+        }
+
+        @Override
+        public void close() {
+            source.close();
+        }
+    }
+
     @Test
     public void changePassword() throws Exception {
         String username = generateUsername();

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -440,6 +440,32 @@ public abstract class UserTests {
                 data.length).join());
     }
 
+    /** Opening an app whose data dir already exists must not wait for an in-flight upload.
+     */
+    @Test
+    public void openAppDuringUpload() throws Exception {
+        String username = generateUsername();
+        String password = "password";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+        App.init(context, "calendar").join();
+
+        byte[] data = randomData(2 * Chunk.MAX_SIZE);
+        BlockingReader blocking = new BlockingReader(AsyncReader.build(data), Chunk.MAX_SIZE);
+        CompletableFuture<FileWrapper> upload = context.getUserRoot().join()
+                .uploadOrReplaceFile("uploading.bin", blocking, data.length, context.network, context.crypto,
+                        () -> false, l -> {});
+        blocking.awaitBlocked();
+        Assert.assertFalse("upload is still in flight", upload.isDone());
+
+        App calendar = App.init(context, "calendar").get(60, TimeUnit.SECONDS);
+        Assert.assertTrue(calendar.dirInternal(null, null).get(60, TimeUnit.SECONDS).isEmpty());
+
+        blocking.unblock();
+        upload.join();
+
+        Assert.assertEquals(data.length, context.getByPath(PathUtil.get(username, "uploading.bin")).join().get().getSize());
+    }
+
     /** Browsing and then queueing a second upload whilst a first is in flight must not stall the first.
      */
     @Test

--- a/src/peergos/server/tests/UserTests.java
+++ b/src/peergos/server/tests/UserTests.java
@@ -101,6 +101,31 @@ public abstract class UserTests {
         }
     }
 
+    private static final List<String> SERVER_DBS = Arrays.asList(
+            "transactions-sql-file",
+            "bat-store",
+            "mutable-pointers-file",
+            "social-sql-file",
+            "space-requests-sql-file",
+            "account-sql-file",
+            "quotas-sql-file",
+            "space-usage-sql-file",
+            "link-counts-sql-file",
+            "server-messages-sql-file",
+            "serverids-file",
+            "partition-status-file",
+            "block-metadata-sql-file");
+
+    /** Run all the server's databases in RAM. Only safe for tests that never restart a server,
+     *  as nothing survives the process it was written in.
+     */
+    public static Args useMemoryDbs(Args args) {
+        Args res = args;
+        for (String db : SERVER_DBS)
+            res = res.with(db, ":memory:");
+        return res;
+    }
+
     public static void deleteFiles(File f) {
         if (! f.exists())
             return;

--- a/src/peergos/server/util/Sqlite.java
+++ b/src/peergos/server/util/Sqlite.java
@@ -24,6 +24,11 @@ public class Sqlite {
         return sqlFile.equals(":memory:") ? sqlFile : a.fromPeergosDir(type).toString();
     }
 
+    public static String getDbPath(Args a, String type, String defaultName) {
+        String sqlFile = a.getArg(type, defaultName);
+        return sqlFile.equals(":memory:") ? sqlFile : a.fromPeergosDir(type, defaultName).toString();
+    }
+
     public static class UncloseableConnection implements Connection {
 
         private final Connection target;

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -156,7 +156,7 @@ public class NetworkAccess {
                                                                Hasher hasher) {
         BufferedStorage blockBuffer = new BufferedStorage(dht, hasher);
         MutablePointers unbufferedMutable = mutable;
-        BufferedPointers mutableBuffer = new BufferedPointers(unbufferedMutable);
+        BufferedPointers mutableBuffer = new BufferedPointers(unbufferedMutable, false);
         WriteSynchronizer synchronizer = new WriteSynchronizer(mutableBuffer, blockBuffer, hasher);
         MutableTree tree = new MutableTreeImpl(mutableBuffer, blockBuffer, hasher, synchronizer);
 
@@ -560,7 +560,7 @@ public class NetworkAccess {
     }
 
     public CompletableFuture<Optional<FileWrapper>> retrieveEntryPoint(EntryPoint e) {
-        return synchronizer.getValue(e.pointer.owner, e.pointer.writer)
+        return synchronizer.readOnlyValue(e.pointer.owner, e.pointer.writer)
                 .thenCompose(version -> getFile(version, e.pointer, Optional.empty(), e.ownerName))
                 .exceptionally(t -> {
                     LOG.log(Level.SEVERE, t.getMessage(), t);
@@ -601,7 +601,7 @@ public class NetworkAccess {
 
     @JsMethod
     public CompletableFuture<Optional<FileWrapper>> getFile(AbsoluteCapability cap, String owner) {
-        return synchronizer.getValue(cap.owner, cap.writer)
+        return synchronizer.readOnlyValue(cap.owner, cap.writer)
                 .thenCompose(version -> getFile(version, cap, Optional.empty(), owner))
                 .exceptionally(t -> {
                     LOG.log(Level.SEVERE, t.getMessage(), t);

--- a/src/peergos/shared/mutable/BufferedPointers.java
+++ b/src/peergos/shared/mutable/BufferedPointers.java
@@ -57,11 +57,6 @@ public class BufferedPointers implements MutablePointers {
         return commitsToTarget ? target : this;
     }
 
-    @Override
-    public boolean hasUncommittedWrites() {
-        return commitsToTarget && ! isEmpty();
-    }
-
     public boolean isBufferedWrite(PublicKeyHash writer, MaybeMultihash target) {
         WriterUpdate latestWrite = latest.get(writer);
         if (latestWrite == null)

--- a/src/peergos/shared/mutable/BufferedPointers.java
+++ b/src/peergos/shared/mutable/BufferedPointers.java
@@ -33,6 +33,8 @@ public class BufferedPointers implements MutablePointers {
     }
 
     private final MutablePointers target;
+    // during signup nothing is ever committed to the target, so the buffer is the only source of truth
+    private final boolean commitsToTarget;
     private final Map<PublicKeyHash, SigningPrivateKeyAndPublicHash> writers = new HashMap<>();
     private final Map<PublicKeyHash, WriterUpdate> latest = new HashMap<>();
     private final Map<PublicKeyHash, WriterUpdate> lastCommits = new LRUCache<>(20);
@@ -40,9 +42,24 @@ public class BufferedPointers implements MutablePointers {
     private final Set<MaybeMultihash> mergedTargets = new HashSet();
 
     public BufferedPointers(MutablePointers target) {
+        this(target, true);
+    }
+
+    public BufferedPointers(MutablePointers target, boolean commitsToTarget) {
         if (target instanceof BufferedPointers)
             throw new IllegalStateException("Nested BufferedPointers!");
         this.target = target;
+        this.commitsToTarget = commitsToTarget;
+    }
+
+    @Override
+    public MutablePointers committed() {
+        return commitsToTarget ? target : this;
+    }
+
+    @Override
+    public boolean hasUncommittedWrites() {
+        return commitsToTarget && ! isEmpty();
     }
 
     public boolean isBufferedWrite(PublicKeyHash writer, MaybeMultihash target) {
@@ -181,7 +198,7 @@ public class BufferedPointers implements MutablePointers {
 
     @Override
     public MutablePointers clearCache() {
-        return new BufferedPointers(target.clearCache());
+        return new BufferedPointers(target.clearCache(), commitsToTarget);
     }
 
     public void recordCommitted(List<WriterUpdate> updates) {

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -62,12 +62,6 @@ public interface MutablePointers {
         return this;
     }
 
-    /** Are there local writes which haven't been committed to the target yet?
-     */
-    default boolean hasUncommittedWrites() {
-        return false;
-    }
-
     MutablePointers clearCache();
 
     static CompletableFuture<PointerUpdate> parsePointerTarget(byte[] pointerCas,

--- a/src/peergos/shared/mutable/MutablePointers.java
+++ b/src/peergos/shared/mutable/MutablePointers.java
@@ -55,6 +55,19 @@ public interface MutablePointers {
                         Futures.of(PointerUpdate.empty()));
     }
 
+    /** The source of committed state, bypassing any local write buffer. Retrievals which must not
+     *  observe in-flight local writes use this.
+     */
+    default MutablePointers committed() {
+        return this;
+    }
+
+    /** Are there local writes which haven't been committed to the target yet?
+     */
+    default boolean hasUncommittedWrites() {
+        return false;
+    }
+
     MutablePointers clearCache();
 
     static CompletableFuture<PointerUpdate> parsePointerTarget(byte[] pointerCas,

--- a/src/peergos/shared/user/Snapshot.java
+++ b/src/peergos/shared/user/Snapshot.java
@@ -18,15 +18,36 @@ import java.util.stream.Stream;
 public class Snapshot implements Cborable {
 
     public final Map<PublicKeyHash, CommittedWriterData> versions;
+    /** True if this was retrieved without waiting for in-flight writes, in which case any further
+     *  writer retrievals from it are also read only.
+     */
+    public final boolean readOnly;
 
     public Snapshot(Map<PublicKeyHash, CommittedWriterData> versions) {
+        this(versions, false);
+    }
+
+    public Snapshot(Map<PublicKeyHash, CommittedWriterData> versions, boolean readOnly) {
         this.versions = Collections.unmodifiableMap(versions);
+        this.readOnly = readOnly;
     }
 
     public Snapshot(PublicKeyHash writer, CommittedWriterData base) {
         HashMap<PublicKeyHash, CommittedWriterData> state = new HashMap<>();
         state.put(writer, base);
         this.versions = Collections.unmodifiableMap(state);
+        this.readOnly = false;
+    }
+
+    public Snapshot asReadOnly() {
+        return readOnly ? this : new Snapshot(versions, true);
+    }
+
+    /** The value stored in a write queue must never route subsequent retrievals to the read only path,
+     *  even if a mutation returned a version it retrieved read only.
+     */
+    public Snapshot asWritable() {
+        return readOnly ? new Snapshot(versions, false) : this;
     }
 
     public Snapshot merge(Snapshot other) {
@@ -36,7 +57,7 @@ public class Snapshot implements Cborable {
                 throw new IllegalStateException("Conflicting merge of Snapshots!");
             merge.put(entry.getKey(), entry.getValue());
         }
-        return new Snapshot(merge);
+        return new Snapshot(merge, readOnly && other.readOnly);
     }
 
     public Snapshot mergeAndOverwriteWith(Snapshot other) {
@@ -44,11 +65,13 @@ public class Snapshot implements Cborable {
         for (Map.Entry<PublicKeyHash, CommittedWriterData> entry : other.versions.entrySet()) {
             merge.put(entry.getKey(), entry.getValue());
         }
-        return new Snapshot(merge);
+        return new Snapshot(merge, readOnly && other.readOnly);
     }
 
     public Snapshot retainOnly(PublicKeyHash writer) {
-        return new Snapshot(writer, versions.get(writer));
+        HashMap<PublicKeyHash, CommittedWriterData> retained = new HashMap<>();
+        retained.put(writer, versions.get(writer));
+        return new Snapshot(retained, readOnly);
     }
 
     public boolean contains(PublicKeyHash writer) {
@@ -70,19 +93,22 @@ public class Snapshot implements Cborable {
     public Snapshot remove(PublicKeyHash w) {
         HashMap<PublicKeyHash, CommittedWriterData> removed = new HashMap<>(versions);
         removed.remove(w);
-        return new Snapshot(removed);
+        return new Snapshot(removed, readOnly);
     }
 
     public Snapshot withVersion(PublicKeyHash writer, CommittedWriterData version) {
         HashMap<PublicKeyHash, CommittedWriterData> result = new HashMap<>(versions);
         result.put(writer, version);
-        return new Snapshot(result);
+        return new Snapshot(result, readOnly);
     }
 
     public CompletableFuture<Snapshot> withWriter(PublicKeyHash owner, PublicKeyHash writer, NetworkAccess network) {
         if (versions.containsKey(writer))
             return CompletableFuture.completedFuture(this);
-        return network.synchronizer.getValue(owner, writer).thenApply(s -> s.merge(this));
+        return (readOnly ?
+                network.synchronizer.readOnlyValue(owner, writer) :
+                network.synchronizer.getValue(owner, writer))
+                .thenApply(s -> s.merge(this));
     }
 
     public CompletableFuture<Snapshot> withWriters(PublicKeyHash owner, Set<PublicKeyHash> writers, NetworkAccess network) {

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -63,12 +63,34 @@ public class WriteSynchronizer {
     }
 
     public CompletableFuture<Snapshot> getWriterData(PublicKeyHash owner, PublicKeyHash writer) {
-        return mutable.getPointerTarget(owner, writer, dht)
+        return getWriterData(mutable, owner, writer);
+    }
+
+    private CompletableFuture<Snapshot> getWriterData(MutablePointers source, PublicKeyHash owner, PublicKeyHash writer) {
+        return source.getPointerTarget(owner, writer, dht)
                 .thenCompose(x -> x.updated.isPresent() ?
                         WriterData.getWriterData(owner, (Cid)x.updated.get(), x.sequence, dht)
                                 .thenApply(cwd -> new Snapshot(writer, cwd)) :
                         Futures.of(new Snapshot(Collections.emptyMap()))
                 );
+    }
+
+    /** The current version committed by writer, without waiting for any in-flight local write.
+     *
+     *  Whilst a local write is buffered the buffer is unstable - committing it gcs superseded blocks
+     *  which were never uploaded - so the committed state is retrieved in that case. At rest the
+     *  buffer is empty, so this is the same as getValue without the queueing.
+     *
+     * @param owner
+     * @param writer
+     * @return The last committed version of writer, marked read only
+     */
+    public CompletableFuture<Snapshot> readOnlyValue(PublicKeyHash owner, PublicKeyHash writer) {
+        Supplier<CompletableFuture<Snapshot>> retrieve = () ->
+                getWriterData(mutable.hasUncommittedWrites() ? mutable.committed() : mutable, owner, writer);
+        return pending.computeIfAbsent(new Pair<>(owner, writer), p -> new AsyncLock<>(getWriterData(owner, p.right)))
+                .runWithReadLock(x -> retrieve.get(), retrieve)
+                .thenApply(Snapshot::asReadOnly);
     }
 
     /**
@@ -115,6 +137,7 @@ public class WriteSynchronizer {
                                                 wd.get().commit(aOwner, signer, existing.hash, existing.sequence, mutable, dht, hasher, tid) :
                                                 WriterData.commitDeletion(aOwner, signer, existing.hash, existing.sequence, mutable))
                                                 .thenCompose(s -> updateWriterState(owner, signer.publicKeyHash, s).thenApply(x -> s)), owner, commitWatcher))
+                                .thenApply(Snapshot::asWritable)
                                 .thenCompose(v -> flusher.commit(owner, v, commitWatcher)),
                         () -> getWriterData(owner, writer.publicKeyHash));
     }
@@ -160,7 +183,7 @@ public class WriteSynchronizer {
                                                         .thenCompose(s -> updateWriterState(owner, signer.publicKeyHash, s)
                                                                 .thenApply(x -> s)),
                                         owner, () -> true))
-                                .thenCompose(p -> flusher.commit(owner, p.left, () -> true).thenApply(x -> p))
+                                .thenCompose(p -> flusher.commit(owner, p.left.asWritable(), () -> true).thenApply(x -> p))
                                 .thenApply(p -> {
                                     res.complete(p);
                                     return p.left;

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -106,26 +106,8 @@ public class WriteSynchronizer {
                         return lock.runWithLock(x -> getWriterData(owner, writer),
                                         () -> getWriterData(owner, writer))
                                 .thenApply(Snapshot::asReadOnly);
-                    // keep the write path up to date, but only ever forwards: with async IO a retrieval
-                    // can start before a write and complete after it, and it reads committed state, so
-                    // it can be older than the value the write left behind
-                    lock.updateIfIdle(existing -> mostRecent(existing, fresh, writer));
                     return Futures.of(fresh.asReadOnly());
                 });
-    }
-
-    private static Snapshot mostRecent(Snapshot existing, Snapshot candidate, PublicKeyHash writer) {
-        if (! candidate.contains(writer))
-            return existing;
-        if (! existing.contains(writer))
-            return existing.withVersion(writer, candidate.get(writer));
-        Optional<Long> existingSeq = existing.get(writer).sequence;
-        Optional<Long> candidateSeq = candidate.get(writer).sequence;
-        if (existingSeq.isEmpty() && candidateSeq.isPresent())
-            return existing.withVersion(writer, candidate.get(writer));
-        if (existingSeq.isPresent() && candidateSeq.isPresent() && candidateSeq.get() > existingSeq.get())
-            return existing.withVersion(writer, candidate.get(writer));
-        return existing;
     }
 
     /**

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -86,11 +86,46 @@ public class WriteSynchronizer {
      * @return The last committed version of writer, marked read only
      */
     public CompletableFuture<Snapshot> readOnlyValue(PublicKeyHash owner, PublicKeyHash writer) {
-        Supplier<CompletableFuture<Snapshot>> retrieve = () ->
-                getWriterData(mutable.hasUncommittedWrites() ? mutable.committed() : mutable, owner, writer);
-        return pending.computeIfAbsent(new Pair<>(owner, writer), p -> new AsyncLock<>(getWriterData(owner, p.right)))
-                .runWithReadLock(x -> retrieve.get(), retrieve)
-                .thenApply(Snapshot::asReadOnly);
+        AsyncLock<Snapshot> lock = pending.computeIfAbsent(new Pair<>(owner, writer),
+                p -> new AsyncLock<>(getWriterData(owner, p.right)));
+        if (lock.isDone())
+            // No write in flight, so ordering with writes costs nothing, and anything only the write
+            // path knows about - buffered state that hasn't been committed - stays visible
+            return lock.runWithLock(x -> getWriterData(owner, writer), () -> getWriterData(owner, writer))
+                    .thenApply(Snapshot::asReadOnly);
+
+        // A write is in flight. Its buffer is unstable, a flush gcs superseded blocks which were never
+        // uploaded, so retrieve the committed state instead of waiting for the write to finish.
+        Supplier<CompletableFuture<Snapshot>> retrieve = () -> getWriterData(mutable.committed(), owner, writer);
+        return lock.runWithReadLock(x -> retrieve.get(), retrieve)
+                .thenCompose(fresh -> {
+                    if (! fresh.contains(writer))
+                        // The in-flight write is creating this writer, so there is nothing to read yet.
+                        // Wait for it - every caller of this used to wait for all writes, so none of
+                        // them can be inside this writer's lock.
+                        return lock.runWithLock(x -> getWriterData(owner, writer),
+                                        () -> getWriterData(owner, writer))
+                                .thenApply(Snapshot::asReadOnly);
+                    // keep the write path up to date, but only ever forwards: with async IO a retrieval
+                    // can start before a write and complete after it, and it reads committed state, so
+                    // it can be older than the value the write left behind
+                    lock.updateIfIdle(existing -> mostRecent(existing, fresh, writer));
+                    return Futures.of(fresh.asReadOnly());
+                });
+    }
+
+    private static Snapshot mostRecent(Snapshot existing, Snapshot candidate, PublicKeyHash writer) {
+        if (! candidate.contains(writer))
+            return existing;
+        if (! existing.contains(writer))
+            return existing.withVersion(writer, candidate.get(writer));
+        Optional<Long> existingSeq = existing.get(writer).sequence;
+        Optional<Long> candidateSeq = candidate.get(writer).sequence;
+        if (existingSeq.isEmpty() && candidateSeq.isPresent())
+            return existing.withVersion(writer, candidate.get(writer));
+        if (existingSeq.isPresent() && candidateSeq.isPresent() && candidateSeq.get() > existingSeq.get())
+            return existing.withVersion(writer, candidate.get(writer));
+        return existing;
     }
 
     /**

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -2053,9 +2053,15 @@ public class FileWrapper {
             return getChild(elements.get(0), crypto.hasher, network)
                     .thenCompose(kid -> kid.get().getOrMkdirs(PathUtil.get(elements.subList(1, elements.size())
                             .stream().collect(Collectors.joining("/"))), network, isSystemFolder, mirrorBat, crypto));
-        return network.synchronizer.applyComplexComputation(owner(), signingPair(),
-                (state, committer) -> getOrMkdirs(elements, isSystemFolder, mirrorBat, network, crypto, state, committer))
-                .thenApply(p -> p.right);
+        // Only take the write lock if something is actually missing, otherwise opening an app whilst
+        // an upload is in flight would wait for the upload
+        return getLatest(network)
+                .thenCompose(latest -> latest.getDescendentByPath(finalPath, crypto.hasher, network))
+                .thenCompose(existing -> existing.isPresent() ?
+                        Futures.of(existing.get()) :
+                        network.synchronizer.applyComplexComputation(owner(), signingPair(),
+                                        (state, committer) -> getOrMkdirs(elements, isSystemFolder, mirrorBat, network, crypto, state, committer))
+                                .thenApply(p -> p.right));
     }
 
     public CompletableFuture<Pair<Snapshot, FileWrapper>> getOrMkdirs(List<String> subPath,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -116,7 +116,7 @@ public class FileWrapper {
     public CompletableFuture<FileWrapper> getLatest(NetworkAccess network) {
         if (isRoot())
             return Futures.of(this);
-        return network.synchronizer.getValue(owner(), writer())
+        return network.synchronizer.readOnlyValue(owner(), writer())
                 .thenCompose(latest -> getUpdated(latest, network));
 
     }
@@ -2954,7 +2954,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
     public CompletableFuture<? extends AsyncReader> getInputStream(NetworkAccess network,
                                                                    Crypto crypto,
                                                                    ProgressConsumer<Long> monitor) {
-        return network.synchronizer.getValue(owner(), writer())
+        return network.synchronizer.readOnlyValue(owner(), writer())
                 .thenCompose(state -> getInputStream(state.get(writer()), network, crypto, getFileProperties().size, 1, monitor));
     }
 
@@ -2985,7 +2985,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                                    int fileSizeHi,
                                                                    int fileSizeLow,
                                                                    ProgressConsumer<Long> monitor) {
-        return network.synchronizer.getValue(owner(), writer())
+        return network.synchronizer.readOnlyValue(owner(), writer())
                 .thenCompose(state -> getInputStream(state.get(writer()), network, crypto, fileSize(fileSizeHi, fileSizeLow), 1, monitor));
     }
 
@@ -3001,7 +3001,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                                    long fileSize,
                                                                    int nBufferedChunks,
                                                                    ProgressConsumer<Long> monitor) {
-        return network.synchronizer.getValue(owner(), writer())
+        return network.synchronizer.readOnlyValue(owner(), writer())
                 .thenCompose(state -> getInputStream(state.get(writer()), network, crypto, fileSize, nBufferedChunks, monitor));
     }
 

--- a/src/peergos/shared/util/AsyncLock.java
+++ b/src/peergos/shared/util/AsyncLock.java
@@ -1,6 +1,5 @@
 package peergos.shared.util;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
 
@@ -17,18 +16,9 @@ public class AsyncLock<T> {
 
     private CompletableFuture<T> queueHead;
     private CompletableFuture<T> readHead;
-    // the most recent value the write side settled on, which can hold local state that has not been
-    // committed anywhere else yet
-    private Optional<T> lastValue = Optional.empty();
-
     public AsyncLock(CompletableFuture<T> initialValue) {
         this.queueHead = initialValue;
         this.readHead = initialValue;
-        initialValue.thenAccept(this::record);
-    }
-
-    private synchronized void record(T value) {
-        lastValue = Optional.of(value);
     }
 
     public synchronized boolean isDone() {
@@ -54,7 +44,6 @@ public class AsyncLock<T> {
         CompletableFuture<T> result = new CompletableFuture<>();
         existing.thenCompose(current -> processor.apply(current)
                 .thenApply(res -> {
-                    record(res);
                     publishToReaders(res);
                     newHead.complete(res);
                     return result.complete(res);
@@ -62,7 +51,6 @@ public class AsyncLock<T> {
                 .exceptionally(t -> {
                     updater.get()
                             .thenApply(res -> {
-                                record(res);
                                 newHead.complete(res);
                                 return result.completeExceptionally(t);
                             })
@@ -120,18 +108,6 @@ public class AsyncLock<T> {
                 });
 
         return result;
-    }
-
-    /** Update the value the next write starts from, if no write is in flight. The merge function is
-     *  given the current value and returns the value to keep, so a retrieval that completed after a
-     *  write can't move the value backwards.
-     */
-    public synchronized void updateIfIdle(Function<T, T> merge) {
-        if (queueHead.isDone() && ! queueHead.isCompletedExceptionally() && lastValue.isPresent()) {
-            T merged = merge.apply(lastValue.get());
-            queueHead = CompletableFuture.completedFuture(merged);
-            record(merged);
-        }
     }
 
     /** Make the result of a write visible to subsequent reads, unless a read is already in flight,

--- a/src/peergos/shared/util/AsyncLock.java
+++ b/src/peergos/shared/util/AsyncLock.java
@@ -6,14 +6,20 @@ import java.util.function.*;
 /** This class implements a lock that can be held across multiple dependent asynchronous tasks which return a new value
  * for the guarded object or to get the value after any pending updaters have completed
  *
+ * There are two independent queues: writes, which are serialised with each other, and read only
+ * retrievals, which are serialised with each other, but never wait for a write. This means a long
+ * running write, like an upload, doesn't block navigating or listing.
+ *
  * @param <T>
  */
 public class AsyncLock<T> {
 
     private CompletableFuture<T> queueHead;
+    private CompletableFuture<T> readHead;
 
     public AsyncLock(CompletableFuture<T> initialValue) {
         this.queueHead = initialValue;
+        this.readHead = initialValue;
     }
 
     public synchronized boolean isDone() {
@@ -37,11 +43,21 @@ public class AsyncLock<T> {
 
         CompletableFuture<T> result = new CompletableFuture<>();
         existing.thenCompose(current -> processor.apply(current)
-                .thenApply(res -> newHead.complete(res) && result.complete(res))
+                .thenApply(res -> {
+                    publishToReaders(res);
+                    newHead.complete(res);
+                    return result.complete(res);
+                })
                 .exceptionally(t -> {
                     updater.get()
-                            .thenApply(res -> newHead.complete(res) && result.completeExceptionally(t))
-                            .exceptionally(e -> newHead.complete(current) && result.completeExceptionally(e));
+                            .thenApply(res -> {
+                                newHead.complete(res);
+                                return result.completeExceptionally(t);
+                            })
+                            .exceptionally(e -> {
+                                newHead.complete(current);
+                                return result.completeExceptionally(e);
+                            });
                     t.printStackTrace();
                     return true;
                 }))
@@ -56,6 +72,60 @@ public class AsyncLock<T> {
                 });
 
         return result;
+    }
+
+    /** Run a read only task which never waits for an in-flight write. Read only tasks are still
+     *  serialised with each other, which bounds the concurrent retrievals of the same value.
+     *
+     * @param processor
+     * @param updater a method to get a fresh value which is called if the previous read left no usable value
+     * @return A future completed with the result from a computation, or exceptionally completed on error
+     */
+    public synchronized CompletableFuture<T> runWithReadLock(Function<T, CompletionStage<T>> processor,
+                                                             Supplier<CompletableFuture<T>> updater) {
+        CompletableFuture<T> existing = readHead;
+        CompletableFuture<T> newHead = new CompletableFuture<>();
+        this.readHead = newHead;
+        CompletableFuture<T> writeHeadAtStart = queueHead;
+
+        CompletableFuture<T> result = new CompletableFuture<>();
+        existing.thenCompose(current -> processor.apply(current)
+                .thenApply(res -> {
+                    publishToWriters(writeHeadAtStart, res);
+                    newHead.complete(res);
+                    return result.complete(res);
+                })
+                .exceptionally(t -> {
+                    // a failed read must not poison the queue, retain the previous value
+                    result.completeExceptionally(t);
+                    return newHead.complete(current);
+                }))
+                .exceptionally(t -> {
+                    // The previous readHead failed - use updater to recover
+                    result.completeExceptionally(t);
+                    updater.get()
+                            .thenApply(newHead::complete)
+                            .exceptionally(e -> newHead.completeExceptionally(e));
+                    return true;
+                });
+
+        return result;
+    }
+
+    /** Make the result of a write visible to subsequent reads, unless a read is already in flight,
+     *  which will retrieve a current value itself.
+     */
+    private synchronized void publishToReaders(T value) {
+        if (readHead.isDone())
+            readHead = CompletableFuture.completedFuture(value);
+    }
+
+    /** Make the result of a read available to the next write, unless a write has been queued since
+     *  the read began, which would mean replacing a newer value with an older one.
+     */
+    private synchronized void publishToWriters(CompletableFuture<T> headAtStart, T value) {
+        if (queueHead == headAtStart && queueHead.isDone())
+            queueHead = CompletableFuture.completedFuture(value);
     }
 
     public synchronized CompletableFuture<T> getValue() {

--- a/src/peergos/shared/util/AsyncLock.java
+++ b/src/peergos/shared/util/AsyncLock.java
@@ -1,5 +1,6 @@
 package peergos.shared.util;
 
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.*;
 
@@ -16,10 +17,18 @@ public class AsyncLock<T> {
 
     private CompletableFuture<T> queueHead;
     private CompletableFuture<T> readHead;
+    // the most recent value the write side settled on, which can hold local state that has not been
+    // committed anywhere else yet
+    private Optional<T> lastValue = Optional.empty();
 
     public AsyncLock(CompletableFuture<T> initialValue) {
         this.queueHead = initialValue;
         this.readHead = initialValue;
+        initialValue.thenAccept(this::record);
+    }
+
+    private synchronized void record(T value) {
+        lastValue = Optional.of(value);
     }
 
     public synchronized boolean isDone() {
@@ -36,7 +45,8 @@ public class AsyncLock<T> {
      * @param updater a method to get a fresh value which is called if updater completes exceptionally
      * @return A future completed with the result from a computation, or exceptionally completed on error
      */
-    public synchronized CompletableFuture<T> runWithLock(Function<T, CompletionStage<T>> processor, Supplier<CompletableFuture<T>> updater) {
+    public synchronized CompletableFuture<T> runWithLock(Function<T, CompletionStage<T>> processor,
+                                                         Supplier<CompletableFuture<T>> updater) {
         CompletableFuture<T> existing = queueHead;
         CompletableFuture<T> newHead = new CompletableFuture<>();
         this.queueHead = newHead;
@@ -44,6 +54,7 @@ public class AsyncLock<T> {
         CompletableFuture<T> result = new CompletableFuture<>();
         existing.thenCompose(current -> processor.apply(current)
                 .thenApply(res -> {
+                    record(res);
                     publishToReaders(res);
                     newHead.complete(res);
                     return result.complete(res);
@@ -51,6 +62,7 @@ public class AsyncLock<T> {
                 .exceptionally(t -> {
                     updater.get()
                             .thenApply(res -> {
+                                record(res);
                                 newHead.complete(res);
                                 return result.completeExceptionally(t);
                             })
@@ -86,12 +98,10 @@ public class AsyncLock<T> {
         CompletableFuture<T> existing = readHead;
         CompletableFuture<T> newHead = new CompletableFuture<>();
         this.readHead = newHead;
-        CompletableFuture<T> writeHeadAtStart = queueHead;
 
         CompletableFuture<T> result = new CompletableFuture<>();
         existing.thenCompose(current -> processor.apply(current)
                 .thenApply(res -> {
-                    publishToWriters(writeHeadAtStart, res);
                     newHead.complete(res);
                     return result.complete(res);
                 })
@@ -112,20 +122,24 @@ public class AsyncLock<T> {
         return result;
     }
 
+    /** Update the value the next write starts from, if no write is in flight. The merge function is
+     *  given the current value and returns the value to keep, so a retrieval that completed after a
+     *  write can't move the value backwards.
+     */
+    public synchronized void updateIfIdle(Function<T, T> merge) {
+        if (queueHead.isDone() && ! queueHead.isCompletedExceptionally() && lastValue.isPresent()) {
+            T merged = merge.apply(lastValue.get());
+            queueHead = CompletableFuture.completedFuture(merged);
+            record(merged);
+        }
+    }
+
     /** Make the result of a write visible to subsequent reads, unless a read is already in flight,
      *  which will retrieve a current value itself.
      */
     private synchronized void publishToReaders(T value) {
         if (readHead.isDone())
             readHead = CompletableFuture.completedFuture(value);
-    }
-
-    /** Make the result of a read available to the next write, unless a write has been queued since
-     *  the read began, which would mean replacing a newer value with an older one.
-     */
-    private synchronized void publishToWriters(CompletableFuture<T> headAtStart, T value) {
-        if (queueHead == headAtStart && queueHead.isDone())
-            queueHead = CompletableFuture.completedFuture(value);
     }
 
     public synchronized CompletableFuture<T> getValue() {


### PR DESCRIPTION
Give AsyncLock a separate read queue so navigating doesn't wait for an in-flight upload.

This means that you can navigate, view and download files in the ui concurrently with an upload. 