### PR TITLE
Add pause to sync, and fix pair add/remove handling

### DIFF
--- a/src/peergos/server/net/SyncConfigHandler.java
+++ b/src/peergos/server/net/SyncConfigHandler.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class SyncConfigHandler implements HttpHandler {
@@ -94,18 +93,51 @@ public class SyncConfigHandler implements HttpHandler {
         }
     }
 
-    public void updateRemotePaths(SyncConfig updated) {
-        List<String> links = updated.links;
-        List<String> remotePaths = links.stream()
-                .map(this::getRemotePath)
-                .collect(Collectors.toList());
-        saveConfigToFile(new SyncConfig(updated.localDirs, remotePaths, links, updated.syncLocalDeletes, updated.syncRemoteDeletes,
-                updated.allowOnMobile, updated.maxDownloadParallelism, updated.minFreeSpacePercent));
+    public void updateRemotePaths(SyncConfig snapshot) {
+        // resolving the links hits the network, so do it before taking the lock
+        Map<String, String> resolved = new LinkedHashMap<>();
+        for (String link : snapshot.links)
+            resolved.put(link, getRemotePath(link));
+        synchronized (this) {
+            // pairs can be added or removed while the paths are being resolved, so merge
+            // into the config as it is now: writing the old one back would bring a
+            // removed pair straight back
+            SyncConfig current = getUpdatedArgs();
+            List<String> remotePaths = new ArrayList<>();
+            boolean changed = false;
+            for (int i = 0; i < current.links.size(); i++) {
+                String path = resolved.getOrDefault(current.links.get(i), current.remotePaths.get(i));
+                changed |= ! path.equals(current.remotePaths.get(i));
+                remotePaths.add(path);
+            }
+            if (changed)
+                saveConfigToFile(new SyncConfig(current.localDirs, remotePaths, current.links,
+                        current.syncLocalDeletes, current.syncRemoteDeletes, current.allowOnMobile,
+                        current.maxDownloadParallelism, current.minFreeSpacePercent));
+        }
     }
 
     public void start() {
         if (! getUpdatedArgs().links.isEmpty())
             syncer.start();
+    }
+
+    /** Windows and macOS treat local paths as case insensitive, so comparing them
+     *  literally would let an overlapping pair through. Drive paths always match exactly. */
+    private static String localCompare(String path) {
+        return isWindows() || isMac() ? path.toLowerCase() : path;
+    }
+
+    /** True when either path is the other, or lies inside it. */
+    private static boolean nested(String a, String b) {
+        // local paths use the platform separator, remote ones always "/"
+        String x = a.replace('\\', '/');
+        String y = b.replace('\\', '/');
+        if (! x.endsWith("/"))
+            x = x + "/";
+        if (! y.endsWith("/"))
+            y = y + "/";
+        return x.startsWith(y) || y.startsWith(x);
     }
 
     private String getRemotePath(String link) {
@@ -128,6 +160,18 @@ public class SyncConfigHandler implements HttpHandler {
             String host = exchange.getRequestHeaders().get("Host").get(0);
             if (! host.startsWith("localhost:")) {
                 exchange.sendResponseHeaders(404, 0);
+                exchange.close();
+                return;
+            }
+            // A page in the user's browser can POST here cross site without a preflight,
+            // so anything that admits to another origin is refused: otherwise any site
+            // the user visits could pause their sync or remove a folder. No
+            // Access-Control-Allow-Origin is ever sent, so such a caller cannot read a
+            // reply either.
+            List<String> origins = exchange.getRequestHeaders().get("Origin");
+            if (origins != null && ! origins.isEmpty() && ! origins.get(0).equals("http://" + host)) {
+                LOG.info("Refusing sync request from origin " + origins.get(0));
+                exchange.sendResponseHeaders(403, 0);
                 exchange.close();
                 return;
             }
@@ -156,9 +200,29 @@ public class SyncConfigHandler implements HttpHandler {
                     exchange.sendResponseHeaders(200, 0);
                     exchange.close();
                 } else {
+                    // one pair's folder must not sit inside another's, on either side:
+                    // the outer pair would mirror the inner one's files and propagate
+                    // its deletions, copying data back and forth and losing it
+                    String newRemote = getRemotePath(link);
+                    for (int i = 0; i < links.size(); i++) {
+                        if (nested(newRemote, remotePaths.get(i)))
+                            throw new IllegalStateException("That Drive folder overlaps the one already synced with "
+                                    + localDirs.get(i));
+                        if (nested(localCompare(localDir), localCompare(localDirs.get(i))))
+                            throw new IllegalStateException("That folder overlaps the one already synced with "
+                                    + remotePaths.get(i));
+                    }
+                    // a folder added back after being removed must not report the old status
+                    String pairHash = PairLogger.hash(newRemote, localDir);
+                    try {
+                        PairLogger.deleteFor(peergosDir, pairHash);
+                        PairStatus.deleteFor(peergosDir, pairHash);
+                    } catch (IOException e) {
+                        LOG.info("Error clearing sync log/status for " + pairHash + ": " + e.getMessage());
+                    }
                     links.add(link);
                     localDirs.add(localDir);
-                    remotePaths.add(getRemotePath(link));
+                    remotePaths.add(newRemote);
                     syncLocalDeletes.add(newSyncLocalDeletes);
                     syncRemoteDeletes.add(newSyncRemoteDeletes);
                     // New pairs default to Wi-Fi only; flip via set-allow-mobile.
@@ -210,7 +274,10 @@ public class SyncConfigHandler implements HttpHandler {
                 }
                 SyncRunner.StatusHolder status = syncer.getStatusHolder();
                 status.setStatus("Removed sync of " + removedLocal);
+                // cancelling stops the whole pass, so ask for another one straight away:
+                // the folders it had not reached should not wait for the next schedule
                 status.cancel();
+                syncer.runNow();
                 // clear sync state db again if it was recreated by an in progress sync
                 if (Files.exists(syncDb)) {
                     Files.delete(syncDb);
@@ -361,5 +428,9 @@ public class SyncConfigHandler implements HttpHandler {
 
     private static boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().startsWith("windows");
+    }
+
+    private static boolean isMac() {
+        return System.getProperty("os.name").toLowerCase().startsWith("mac");
     }
 }

--- a/src/peergos/server/net/SyncConfigHandler.java
+++ b/src/peergos/server/net/SyncConfigHandler.java
@@ -113,13 +113,24 @@ public class SyncConfigHandler implements HttpHandler {
             if (changed)
                 saveConfigToFile(new SyncConfig(current.localDirs, remotePaths, current.links,
                         current.syncLocalDeletes, current.syncRemoteDeletes, current.allowOnMobile,
-                        current.maxDownloadParallelism, current.minFreeSpacePercent));
+                        current.maxDownloadParallelism, current.minFreeSpacePercent, current.paused));
         }
     }
 
     public void start() {
-        if (! getUpdatedArgs().links.isEmpty())
+        SyncConfig config = getUpdatedArgs();
+        if (config.paused)
+            syncer.getStatusHolder().pause();
+        if (! config.links.isEmpty())
             syncer.start();
+    }
+
+    // under the same lock as the other whole config rewrites, so a pause cannot be
+    // lost against the path refresh that every get-pairs schedules
+    private synchronized void setPaused(boolean paused) {
+        SyncConfig c = getUpdatedArgs();
+        saveConfigToFile(new SyncConfig(c.localDirs, c.remotePaths, c.links, c.syncLocalDeletes,
+                c.syncRemoteDeletes, c.allowOnMobile, c.maxDownloadParallelism, c.minFreeSpacePercent, paused));
     }
 
     /** Windows and macOS treat local paths as case insensitive, so comparing them
@@ -228,7 +239,7 @@ public class SyncConfigHandler implements HttpHandler {
                     // New pairs default to Wi-Fi only; flip via set-allow-mobile.
                     allowOnMobile.add(false);
                     saveConfigToFile(new SyncConfig(localDirs, remotePaths, links, syncLocalDeletes, syncRemoteDeletes,
-                            allowOnMobile, updated.maxDownloadParallelism, updated.minFreeSpacePercent));
+                            allowOnMobile, updated.maxDownloadParallelism, updated.minFreeSpacePercent, updated.paused));
                     // run sync client now
                     syncer.start();
                     System.out.println("Syncing " + localDir + " syncLocalDeletes: " + newSyncLocalDeletes + ", syncRemoteDeletes: " + newSyncRemoteDeletes);
@@ -260,7 +271,7 @@ public class SyncConfigHandler implements HttpHandler {
                 allowOnMobile.remove(toRemove);
 
                 saveConfigToFile(new SyncConfig(localDirs, remotePaths, links, syncLocalDeletes, syncRemoteDeletes,
-                        allowOnMobile, updated.maxDownloadParallelism, updated.minFreeSpacePercent));
+                        allowOnMobile, updated.maxDownloadParallelism, updated.minFreeSpacePercent, updated.paused));
                 // clear sync state db as well
                 String linkPath = UserContext.fromSecretLinksV2(Arrays.asList(link), Arrays.asList(() -> Futures.of("")), network, crypto).join().getEntryPath().join();
                 Path syncDb = DirectorySync.getSyncStateDbPath(peergosDir, linkPath, removedLocal);
@@ -354,7 +365,21 @@ public class SyncConfigHandler implements HttpHandler {
                 resp.write(res);
                 exchange.close();
             } else if (action.equals("sync-now")) {
+                // also clears the cancellation, else the triggered run aborts immediately
+                syncer.getStatusHolder().unpause();
+                setPaused(false);
                 syncer.runNow();
+                byte[] res = JSONParser.toString(new LinkedHashMap<>()).getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, res.length);
+                OutputStream resp = exchange.getResponseBody();
+                resp.write(res);
+                exchange.close();
+            } else if (action.equals("pause")) {
+                SyncRunner.StatusHolder holder = syncer.getStatusHolder();
+                holder.pause();
+                setPaused(true);
+                // no further pass is coming, so settle the state rather than leave it SYNCING
+                holder.setStatus(SyncStatus.SYNCED);
                 byte[] res = JSONParser.toString(new LinkedHashMap<>()).getBytes(StandardCharsets.UTF_8);
                 exchange.sendResponseHeaders(200, res.length);
                 OutputStream resp = exchange.getResponseBody();
@@ -383,6 +408,7 @@ public class SyncConfigHandler implements HttpHandler {
                 reply.put("msg", global.getStatusAndTime());
                 boolean globalError = error.isPresent() || global.getStatus() == SyncStatus.ERROR;
                 reply.put("state", SyncStatus.aggregate(pairStates, globalError).name());
+                reply.put("paused", global.isPaused());
                 error.ifPresent(err -> reply.put("error", err));
                 reply.put("pairs", pairs);
                 byte[] res = JSONParser.toString(reply).getBytes(StandardCharsets.UTF_8);

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -227,6 +227,9 @@ public class DirectorySync {
         while (true) {
             LOG.accept("Syncing " + links.size() + " pairs of directories: " + IntStream.range(0, links.size()).mapToObj(i -> Arrays.asList(localDirs.get(i), linkPaths.get(i))).collect(Collectors.toList()));
             boolean errored = false;
+            // a cancel that stopped the previous pass must not abort this one before it
+            // syncs anything; a pause is held by its own flag, so this cannot resume one
+            status.resume();
             status.setStatus(SyncStatus.SYNCING);
             for (int i=0; i < links.size(); i++) {
                 SyncState syncedState = null;
@@ -247,6 +250,8 @@ public class DirectorySync {
                     Path remoteDir = PathUtil.get(linkPaths.get(i));
                     syncedState = syncedStates.get(i).get();
                     perPairLog.accept("Syncing " + localDir + " to+from " + remoteDir);
+                    // else a stale failure is shown for the whole of a long transfer
+                    pairStatus.setError(null);
                     pairStatus.setStatus(SyncStatus.SYNCING);
                     long t0 = System.currentTimeMillis();
                     String username = remoteDir.getName(0).toString();
@@ -400,6 +405,7 @@ public class DirectorySync {
             try {
                 SyncState initialRemote = new JdbcTreeState(initialRemotePath);
                 long r0 = System.currentTimeMillis();
+                LOG.accept("Checking files in Drive");
                 buildDirState(remoteFS, initialRemote, syncedVersions);
                 LOG.accept("Found " + initialRemote.filesCount() + " remote files in " + (System.currentTimeMillis() - r0)/1_000 + "s");
 
@@ -474,8 +480,12 @@ public class DirectorySync {
             remoteStatePath = File.createTempFile("peergos-sync", ".sqlite", peergosDir.toFile()).toString();
             SyncState remoteState = remoteChange ? new JdbcTreeState(remoteStatePath) : syncedVersions;
             long t3 = System.currentTimeMillis();
-            if (remoteChange)
+            if (remoteChange) {
+                // this rehashes anything it cannot match from cache, which for a file of
+                // several GiB is minutes with nothing else to report
+                LOG.accept("Checking files in Drive");
                 remoteVersion = buildDirState(remoteFS, remoteState, syncedVersions);
+            }
             long t4 = System.currentTimeMillis();
             LOG.accept("Found " + remoteState.filesCount() + " remote files in " + (t4-t3)/1_000 + "s");
 

--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -276,6 +276,16 @@ public class DirectorySync {
                         pairStatus.setStatus(SyncStatus.SYNCED);
                     }
                 } catch (Exception e) {
+                    if (status.isPaused() || status.isCancelled()) {
+                        // stopped on request (paused, or the pair was removed), so not a
+                        // failure; the message keeps the progress reached, which is what
+                        // is useful to see while stopped
+                        pairStatus.setError(null);
+                        pairStatus.setStatus(SyncStatus.SYNCED);
+                        if (pairLog != null)
+                            pairLog.log(status.isPaused() ? "Sync paused" : "Sync stopped");
+                        return false;
+                    }
                     errored = true;
                     ERROR.accept(e);
                     if (pairLog != null)

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -171,6 +171,9 @@ public class LocalFileSystem implements SyncFilesystem {
             byte[] buf = new byte[4096];
             long done = 0;
             while (done < size) {
+                // a paused or removed pair must stop here too, not just on upload
+                if (isCancelled.get())
+                    throw new IllegalStateException("Download cancelled!");
                 int read = fin.readIntoArray(buf, 0, (int) Math.min(buf.length, size - done)).join();
                 raf.write(buf, 0, read);
                 done += read;

--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -175,7 +175,7 @@ public class LocalFileSystem implements SyncFilesystem {
                 raf.write(buf, 0, read);
                 done += read;
                 if (done >= 1024*1024)
-                    progress.accept("Downloaded " + (done/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + p.getFileName().toString());
+                    progress.accept("Downloaded " + (done/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + p.toString());
             }
             if (modificationTime.isPresent()) {
                 long time = modificationTime.get().toInstant(ZoneOffset.UTC).toEpochMilli() / 1000 * 1000;

--- a/src/peergos/server/sync/PairStatus.java
+++ b/src/peergos/server/sync/PairStatus.java
@@ -78,7 +78,9 @@ public class PairStatus {
     }
 
     public synchronized String getStatusAndTime() {
-        if (status == null)
+        // a record can hold a state with no message yet, and loadFromDisk leaves the
+        // time unset when it cannot parse one, so both halves have to be checked
+        if (status == null || status.isEmpty() || updateTime == null)
             return "";
         return status + " at " + updateTime.toLocalDate() + " " + updateTime.toLocalTime().withNano(0);
     }

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -209,6 +209,9 @@ public class PeergosSyncFS implements SyncFilesystem {
                                             Consumer<String> progress) throws IOException {
         Optional<FileWrapper> existing = context.getByPath(root.resolve(p)).join();
         String filename = p.getFileName().toString();
+        // progress names the path within the synced folder, not just the leaf: several
+        // subfolders can hold the same filename, and the log has to say which one
+        String relPath = p.toString();
         if (existing.isEmpty() && fileOffset == 0) {
             Optional<FileWrapper> parentOpt = context.getByPath(root.resolve(p).getParent()).join();
             if (parentOpt.isEmpty()) {
@@ -222,7 +225,7 @@ public class PeergosSyncFS implements SyncFilesystem {
                     context.network, context.crypto, isCancelled, x -> {
                         long total = done.addAndGet(x);
                         if (total >= 1024*1024)
-                            progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + filename);
+                            progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + relPath);
                     }).join();
         } else {
             FileWrapper f = existing.get();
@@ -238,7 +241,7 @@ public class PeergosSyncFS implements SyncFilesystem {
             f.overwriteSectionJS(data, (int) (fileOffset >>> 32), (int) fileOffset, (int) (end >>> 32), (int) end, modificationTime, context.network, context.crypto, x -> {
                 long total = done.addAndGet(x);
                 if (total >= 1024*1024)
-                    progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + filename);
+                    progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + relPath);
             }).join();
         }
         return modificationTime;

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -239,6 +239,10 @@ public class PeergosSyncFS implements SyncFilesystem {
             long end = fileOffset + size;
             AtomicLong done = new AtomicLong(0);
             f.overwriteSectionJS(data, (int) (fileOffset >>> 32), (int) fileOffset, (int) (end >>> 32), (int) end, modificationTime, context.network, context.crypto, x -> {
+                // this path carries no cancel check of its own, so a resumed upload would
+                // otherwise run to the end after a pause
+                if (isCancelled.get())
+                    throw new IllegalStateException("Upload cancelled!");
                 long total = done.addAndGet(x);
                 if (total >= 1024*1024)
                     progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + relPath);

--- a/src/peergos/server/sync/SyncConfig.java
+++ b/src/peergos/server/sync/SyncConfig.java
@@ -12,6 +12,7 @@ public class SyncConfig implements Jsonable {
     public final List<String> localDirs, remotePaths, links;
     public final List<Boolean> syncLocalDeletes, syncRemoteDeletes, allowOnMobile;
     public final int maxDownloadParallelism, minFreeSpacePercent;
+    public final boolean paused;
 
     public SyncConfig(List<String> localDirs,
                       List<String> remotePaths,
@@ -20,7 +21,8 @@ public class SyncConfig implements Jsonable {
                       List<Boolean> syncRemoteDeletes,
                       List<Boolean> allowOnMobile,
                       int maxDownloadParallelism,
-                      int minFreeSpacePercent) {
+                      int minFreeSpacePercent,
+                      boolean paused) {
         if (localDirs.size() != remotePaths.size())
             throw new IllegalStateException("Invalid SyncConfig!");
         if (localDirs.size() != links.size())
@@ -39,6 +41,7 @@ public class SyncConfig implements Jsonable {
         this.allowOnMobile = allowOnMobile;
         this.maxDownloadParallelism = maxDownloadParallelism;
         this.minFreeSpacePercent = minFreeSpacePercent;
+        this.paused = paused;
     }
 
     public Map<String, Object> toJsonWithoutCaps() {
@@ -79,6 +82,7 @@ public class SyncConfig implements Jsonable {
         res.put("pairs", pairs);
         res.put("maxParallelism", maxDownloadParallelism);
         res.put("minPercentFreeSpace", minFreeSpacePercent);
+        res.put("paused", paused);
         return res;
     }
 
@@ -100,8 +104,10 @@ public class SyncConfig implements Jsonable {
             Boolean allow = (Boolean) pair.get("allowOnMobile");
             allowOnMobile.add(allow != null && allow);
         }
+        // Older config files predate this flag; treat missing as running.
+        Boolean paused = (Boolean) json.get("paused");
         return new SyncConfig(localDirs, remoteDirs, links, syncLocalDeletes, syncRemoteDeletes, allowOnMobile,
-                (Integer)json.get("maxParallelism"), (Integer)json.get("minPercentFreeSpace"));
+                (Integer)json.get("maxParallelism"), (Integer)json.get("minPercentFreeSpace"), paused != null && paused);
     }
 
     public static List<String> getLinks(Args updated) {
@@ -156,7 +162,8 @@ public class SyncConfig implements Jsonable {
                 getSyncRemoteDeletes(a),
                 getAllowOnMobile(a, localDirs.size()),
                 a.getInt("max-parallelism", 32),
-                a.getInt("min-free-space-percent", 5));
+                a.getInt("min-free-space-percent", 5),
+                false);
     }
 
     private static boolean isWindows() {

--- a/src/peergos/server/sync/SyncRunner.java
+++ b/src/peergos/server/sync/SyncRunner.java
@@ -39,6 +39,8 @@ public interface SyncRunner {
         private Optional<String> error = Optional.empty();
         private SyncStatus state = SyncStatus.SYNCED;
         private final AtomicBoolean cancelled = new AtomicBoolean(false);
+        // a pass clears cancelled as it aborts, so holding a pause needs its own flag
+        private final AtomicBoolean paused = new AtomicBoolean(false);
 
         public synchronized void cancel() {
             cancelled.set(true);
@@ -50,6 +52,21 @@ public interface SyncRunner {
 
         public synchronized boolean isCancelled() {
             return cancelled.get();
+        }
+
+        /** Stops the pass in flight and the scheduled ones until unpause(). */
+        public synchronized void pause() {
+            paused.set(true);
+            cancel();
+        }
+
+        public synchronized void unpause() {
+            paused.set(false);
+            resume();
+        }
+
+        public synchronized boolean isPaused() {
+            return paused.get();
         }
 
         public synchronized void setStatus(String newStatus) {
@@ -101,6 +118,13 @@ public interface SyncRunner {
                     crypto.hasher, Collections.emptyList(), false);
             this.runner = new Thread(() -> {
                 while (true) {
+                    if (status.isPaused()) {
+                        // runNow() interrupts this, so unpausing resumes the schedule at once
+                        try {
+                            Thread.sleep(30_000);
+                        } catch (InterruptedException e) {}
+                        continue;
+                    }
                     inPass.set(true);
                     try {
                         Path peergosDir = args.getPeergosDir();

--- a/src/peergos/server/sync/SyncRunner.java
+++ b/src/peergos/server/sync/SyncRunner.java
@@ -86,6 +86,8 @@ public interface SyncRunner {
         private static final Logger LOG = Logging.LOG();
         private final Thread runner;
         private final AtomicBoolean started = new AtomicBoolean(false);
+        private final AtomicBoolean inPass = new AtomicBoolean(false);
+        private final AtomicBoolean rerun = new AtomicBoolean(false);
         private final StatusHolder status = new StatusHolder();
 
         public ThreadBased(Args args,
@@ -99,6 +101,7 @@ public interface SyncRunner {
                     crypto.hasher, Collections.emptyList(), false);
             this.runner = new Thread(() -> {
                 while (true) {
+                    inPass.set(true);
                     try {
                         Path peergosDir = args.getPeergosDir();
                         Path jsonSyncConfig = peergosDir.resolve(SYNC_CONFIG_FILENAME);
@@ -123,6 +126,7 @@ public interface SyncRunner {
                                     DirectorySync.log(e.getMessage());
                                 }
                             };
+                            status.setError(null);
                             DirectorySync.syncDirs(links, localDirs, syncLocalDeletes, syncRemoteDeletes,
                                     maxDownloadParallelism, minFreeSpacePercent, true,
                                     root -> new LocalFileSystem(Paths.get(root), crypto.hasher),
@@ -146,7 +150,11 @@ public interface SyncRunner {
                         }
                     } catch (Exception e) {
                         LOG.log(Level.WARNING, e.getMessage(), e);
+                    } finally {
+                        inPass.set(false);
                     }
+                    if (rerun.getAndSet(false))
+                        continue;
                     try {
                         Thread.sleep(30_000);
                     } catch (InterruptedException e) {}
@@ -160,12 +168,22 @@ public interface SyncRunner {
                 runner.start();
                 started.set(true);
             } else
+                wake();
+        }
+
+        /** Interrupting only helps while the thread is asleep: during a pass it cannot
+         *  start anything, and tears the transfer in flight. Asking for a rerun instead
+         *  picks up a changed config as soon as the pass unwinds, rather than a sleep later. */
+        private void wake() {
+            if (inPass.get())
+                rerun.set(true);
+            else
                 runner.interrupt();
         }
 
         @Override
         public void runNow() {
-            runner.interrupt();
+            wake();
         }
 
         @Override

--- a/src/peergos/shared/user/fs/FileUploader.java
+++ b/src/peergos/shared/user/fs/FileUploader.java
@@ -155,7 +155,12 @@ public class FileUploader implements AutoCloseable {
                             (a, b) -> b)
                     .exceptionally(res::completeExceptionally);
             Futures.reduceAll(input, current,
-                            (s, i) -> queue.poll().thenCompose(chunk -> uploadChunk(s, c, chunk, writer, network, monitor)),
+                            (s, i) -> {
+                                // else every already encrypted chunk still uploads first
+                                if (isCancelled.get())
+                                    throw new IllegalStateException("Upload cancelled!");
+                                return queue.poll().thenCompose(chunk -> uploadChunk(s, c, chunk, writer, network, monitor));
+                            },
                             (a, b) -> b)
                     .thenApply(x -> {
                         LOG.info("File encryption, upload took: " + (System.currentTimeMillis() - t1) + " mS");


### PR DESCRIPTION
Four independent bug fixes, then pause on top. Each commit stands alone.

## Fixes

**`get-pairs` could resurrect a removed folder.** It snapshots the config, then
asynchronously resolves every link over the network and writes the whole snapshot
back. Remove a folder while that is in flight and the pre-removal snapshot lands on
top of it. `updateRemotePaths` now resolves outside the lock and merges into the
config as it is at write time, and only writes when a path actually changed.
Reproducible by removing a pair while polling `get-pairs`: before, it reappeared
within ~2s every time.

**Overlapping pairs were accepted.** Syncing a folder that contains, or sits inside,
another synced folder makes each pair mirror the other's files and propagate its
deletions. `add-pair` now rejects either direction. Paths are compared with
separators normalised, and case-insensitively on Windows and macOS where the
filesystem treats them as the same folder.

**The sync endpoints accepted cross-site POSTs.** Any page the user visits could
pause syncing or remove a folder with a simple POST to localhost — no preflight, and
the caller cannot read the reply, but the side effect lands. Requests declaring a
different origin are now refused, mirroring the check `WebAuthnHandler` already
applies. Requests with no `Origin` header (native and app clients) are unaffected.

**Removing a folder stranded the others.** `remove-pair` cancels the running pass,
which abandons every folder it had not reached, and the runner then slept its full
interval. It now asks for another pass immediately. Two related fixes: a cancel no
longer leaks into the next pass (which used to consume it and abort before syncing
anything), and `runNow()` no longer interrupts mid-transfer — it records the request
so a changed config is picked up as soon as the pass unwinds.

Smaller ones: a re-added folder no longer reports the old pair's status; a pair's
stale error is cleared when its next attempt starts; progress names the path within
the synced folder instead of the leaf, since several subfolders can hold the same
filename; a status record with no message is no longer reported as one; and the
remote scan says what it is doing, as it rehashes anything it cannot match from
cache — minutes of silence on large files.

## Pause

New `pause` action, `sync-now` resumes, and `status` gains `paused`.

The flag is stored in `sync-config.json`, so a pause survives a restart. That matters
most on Android, where the process is killed routinely and an in-memory flag would
last minutes. Configs written by earlier versions have no key and are treated as
running.

Pausing stops the pass in flight, not just the schedule: fresh uploads, resumed
uploads and downloads all check for cancellation, so a transfer stops in about a
second instead of running to completion. A stop the user asked for is recorded as
stopped rather than as a failure, so a paused folder is not left looking broken.

## Testing

Exercised against a live account with two sync pairs: pause mid-transfer and resume;
remove a folder mid-upload and re-add it; break a folder and repair it; add
overlapping pairs in both directions; cross-origin requests refused while same-origin
and header-less ones pass; pause across a daemon restart; and a config written
without the new key still loads and syncs.