### PR TITLE
Keep sync pause active across pass reset

### DIFF
--- a/src/peergos/server/sync/SyncRunner.java
+++ b/src/peergos/server/sync/SyncRunner.java
@@ -47,7 +47,8 @@ public interface SyncRunner {
         }
 
         public synchronized void resume() {
-            cancelled.set(false);
+            if (! paused.get())
+                cancelled.set(false);
         }
 
         public synchronized boolean isCancelled() {

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -901,6 +901,25 @@ public class SyncTests {
     }
 
     @Test
+    public void pauseBetweenRunnerCheckAndPassIsNotLost() {
+        SyncRunner.StatusHolder status = new SyncRunner.StatusHolder();
+
+        // ThreadBased has already passed its top-of-loop pause check.
+        Assert.assertFalse(status.isPaused());
+        status.pause();
+
+        // DirectorySync resets cancellation when starting a pass.
+        status.resume();
+
+        Assert.assertTrue(status.isPaused());
+        Assert.assertTrue(status.isCancelled());
+
+        status.unpause();
+        Assert.assertFalse(status.isPaused());
+        Assert.assertFalse(status.isCancelled());
+    }
+
+    @Test
     public void syncStatusAggregation() {
         // no pairs configured => nothing to report, rather than "all good"
         Assert.assertEquals(SyncStatus.NONE, SyncStatus.aggregate(Collections.emptyList(), false));


### PR DESCRIPTION
## Summary
- keep cancellation set while sync is paused
- add a deterministic regression test for the race between the runner pause check and pass startup

## Why
`ThreadBased` can pass its `isPaused()` check just before `pause()` sets both flags. `DirectorySync.syncDirs()` then calls `resume()`, which previously cleared `cancelled` and allowed that pass to continue.

`unpause()` still clears `paused` before calling `resume()`, so one-shot cancellation behavior is unchanged.

## Testing
- `ant dist` with Homebrew OpenJDK 26
- targeted pause-race regression: PASS

Follow-up to #1399.