### PR TITLE
Stop scanning when a sync is paused

### DIFF
--- a/src/peergos/server/sync/DirectorySync.java
+++ b/src/peergos/server/sync/DirectorySync.java
@@ -417,10 +417,12 @@ public class DirectorySync {
                 SyncState initialRemote = new JdbcTreeState(initialRemotePath);
                 long r0 = System.currentTimeMillis();
                 LOG.accept("Checking files in Drive");
-                buildDirState(remoteFS, initialRemote, syncedVersions);
+                buildDirState(remoteFS, initialRemote, syncedVersions, isCancelled);
                 LOG.accept("Found " + initialRemote.filesCount() + " remote files in " + (System.currentTimeMillis() - r0)/1_000 + "s");
 
                 localFS.applyToSubtree(file -> {
+                    if (isCancelled.get())
+                        throw new RuntimeException("Sync cancelled during initial scan");
                     FileState synced = syncedVersions.byPath(file.relPath);
                     if (synced != null)
                         return;
@@ -458,6 +460,8 @@ public class DirectorySync {
                         }
                     }
                 }, dir -> {
+                    if (isCancelled.get())
+                        throw new RuntimeException("Sync cancelled during initial scan");
                     // and the same for dirs: an unrecorded dir that is deleted locally looks like
                     // a remote addition, so it would be recreated locally rather than deleted
                     if (initialRemote.hasDir(dir.relPath))
@@ -476,7 +480,7 @@ public class DirectorySync {
             syncedVersions.copyTo(localStatePath);
             SyncState localState = new JdbcTreeState(localStatePath);
             long t1 = System.currentTimeMillis();
-            buildDirState(localFS, localState, syncedVersions);
+            buildDirState(localFS, localState, syncedVersions, isCancelled);
             long t2 = System.currentTimeMillis();
             LOG.accept("Found " + localState.filesCount() + " local files in " + (t2-t1)/1_000 + "s");
 
@@ -496,7 +500,7 @@ public class DirectorySync {
                 // this rehashes anything it cannot match from cache, which for a file of
                 // several GiB is minutes with nothing else to report
                 LOG.accept("Checking files in Drive");
-                remoteVersion = buildDirState(remoteFS, remoteState, syncedVersions);
+                remoteVersion = buildDirState(remoteFS, remoteState, syncedVersions, isCancelled);
             }
             long t4 = System.currentTimeMillis();
             LOG.accept("Found " + remoteState.filesCount() + " remote files in " + (t4-t3)/1_000 + "s");
@@ -1220,7 +1224,8 @@ public class DirectorySync {
         }
     }
 
-    public static Snapshot buildDirState(SyncFilesystem fs, SyncState res, SyncState synced) throws IOException {
+    public static Snapshot buildDirState(SyncFilesystem fs, SyncState res, SyncState synced,
+                                         Supplier<Boolean> isCancelled) throws IOException {
         SnapshotTracker version = new SnapshotTracker(new Snapshot(new HashMap<>()));
         List<Triple<String, FileWrapper, HashTree>> toUpdate = new ArrayList<>();
         AtomicLong downloadedSize = new AtomicLong(0);
@@ -1228,6 +1233,10 @@ public class DirectorySync {
         Set<String> presentDirs = ConcurrentHashMap.newKeySet();
 
         Optional<PublicKeyHash> baseDirWriter = fs.applyToSubtree(props -> {
+            // a pause stops the walk, not just the transfers: scanning a large tree is
+            // minutes of hashing and listing that the user has asked us to stop
+            if (isCancelled.get())
+                throw new RuntimeException("Sync cancelled while scanning " + props.relPath);
             String relPath = props.relPath;
             presentFiles.add(relPath);
             FileState atSync = synced.byPath(relPath);
@@ -1266,6 +1275,8 @@ public class DirectorySync {
                     res.add(fstat);
             }
         }, p -> {
+            if (isCancelled.get())
+                throw new RuntimeException("Sync cancelled while scanning " + p.relPath);
             String relPath = p.relPath;
             presentDirs.add(relPath);
             p.meta.ifPresent(d -> version.update(d.version));

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -611,6 +611,31 @@ public class SyncTests {
     }
 
     @Test
+    public void aStoppedSyncStopsScanning() throws Exception {
+        // Pausing used to stop only the transfers: the walk carried on hashing every file and
+        // logging a skip line for each one, which on a large folder is minutes of work after
+        // the user asked for it to stop.
+        Path dir = Files.createTempDirectory("peergos-sync");
+        byte[] data = new byte[1024];
+        new Random(1).nextBytes(data);
+        Files.createDirectory(dir.resolve("sub"));
+        for (int i = 0; i < 25; i++)
+            Files.write(dir.resolve("sub").resolve("f" + i + ".bin"), data, StandardOpenOption.CREATE);
+        LocalFileSystem fs = new LocalFileSystem(dir, crypto.hasher);
+        SyncState scanned = new JdbcTreeState(":memory:");
+        SyncState synced = new JdbcTreeState(":memory:");
+
+        boolean threw = false;
+        try {
+            DirectorySync.buildDirState(fs, scanned, synced, () -> true);
+        } catch (RuntimeException e) {
+            threw = true;
+        }
+        Assert.assertTrue("A stopped sync must abort the scan", threw);
+        Assert.assertEquals("and must not keep scanning files after it is stopped", 0, scanned.filesCount());
+    }
+
+    @Test
     public void cancelledCopyStaysResumable() throws Exception {
         // Reproduces the race where a queued parallel download runs after the user cancelled:
         // applyCopyOp sees isCancelled==true at its top guard and never writes. It must abort


### PR DESCRIPTION
Pausing stopped the transfers but not the work: two phases of a pass had no
cancellation check, so after pressing Pause a sync kept hashing files and listing
Drive — minutes of CPU, disk and network on a large folder. Reported from Android,
where it also keeps burning battery.

- The initial sync walk hashed every file and logged `Skipping identical remote
  file in initial sync: …` for each; only the transfer inside it was cancellable.
- `buildDirState` took no cancellation supplier at all, so neither the local walk
  nor the remote listing could be interrupted.

Both walks now check at the top of their file and dir callbacks and abort by
throwing, as `applyCopyOp` already does. `syncDirs` treats a user-initiated stop as
stopped rather than failed, so pausing doesn't mark folders as needing attention.
Dir callbacks are guarded too, since remote listings are the network cost.

Stops at file granularity: work already under way on the current file finishes, so a
multi-GiB hash completes before the pass stops. Making that immediate would mean
threading cancellation through `hashFile` on `SyncFilesystem` and its three
implementations, which seemed worth keeping separate.

`setCompletedSync(true)` is at the end of the try block, not the `finally`, so an
aborted scan can't mark an incomplete initial sync as done; the `finally` still
deletes the temp state databases; and the parallel remote walk joins through
`Futures.combineAllInOrder(...).join()`, so the throw propagates.

Adds `aStoppedSyncStopsScanning`: a cancelled scan of 25 files must throw and record
zero. Without the fix it scans all 25 and never throws.