### PR TITLE
Fix a crash loading a saved mount config on Android, and harden the write path

### DIFF
--- a/src/peergos/server/net/MountConfigHandler.java
+++ b/src/peergos/server/net/MountConfigHandler.java
@@ -407,6 +407,11 @@ public class MountConfigHandler implements HttpHandler {
                         new String(Serialize.readFully(exchange.getRequestBody())));
                 String peergosUsername = (String) body.get("peergosUsername");
                 String peergosPassword = (String) body.get("peergosPassword");
+                // saveConfig only keeps a password it was given, so enabling without one
+                // persists a mount that claims to be on and can never log in again
+                if (peergosUsername == null || peergosUsername.isEmpty()
+                        || peergosPassword == null || peergosPassword.isEmpty())
+                    throw new IllegalStateException("Mounting needs your username and password");
                 boolean autoMount = body.get("autoMount") instanceof Boolean ? (Boolean) body.get("autoMount") : true;
                 String authType = "digest";
                 String webdavUsername = generateToken();

--- a/src/peergos/server/net/MountConfigHandler.java
+++ b/src/peergos/server/net/MountConfigHandler.java
@@ -139,7 +139,9 @@ public class MountConfigHandler implements HttpHandler {
         if (!configFile.toFile().exists())
             return MountConfig.disabled();
         try {
-            String json = Files.readString(configFile);
+            // readAllBytes, not readString: android's java.nio.file.Files has no
+            // readString, and this runs there when the app bootstraps a saved mount
+            String json = new String(Files.readAllBytes(configFile), StandardCharsets.UTF_8);
             MountConfig config = MountConfig.fromJson((Map<String, Object>) JSONParser.parse(json));
             if (secretStore.embedsInConfigFile() || config.peergosUsername.isEmpty())
                 return config;

--- a/src/peergos/server/net/MountConfigHandler.java
+++ b/src/peergos/server/net/MountConfigHandler.java
@@ -35,6 +35,8 @@ import java.util.function.Function;
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.nio.file.*;
 import java.security.SecureRandom;
 import java.util.*;
@@ -154,6 +156,15 @@ public class MountConfigHandler implements HttpHandler {
         }
     }
 
+    /** The config always holds the webdav password, and the peergos password too where no
+     *  keyring is available, so it is created unreadable to anyone else from the start. */
+    private static FileAttribute<?>[] ownerOnly(Path dir) {
+        return dir.getFileSystem().supportedFileAttributeViews().contains("posix") ?
+                new FileAttribute<?>[]{PosixFilePermissions.asFileAttribute(
+                        PosixFilePermissions.fromString("rw-------"))} :
+                new FileAttribute<?>[0];
+    }
+
     private synchronized void saveConfig(MountConfig config) {
         try {
             if (!secretStore.embedsInConfigFile()) {
@@ -166,8 +177,12 @@ public class MountConfigHandler implements HttpHandler {
                     secretStore.delete(SECRET_SERVICE, config.peergosUsername + ":totp");
             }
             MountConfig toWrite = secretStore.embedsInConfigFile() ? config : config.withoutSecrets();
-            Files.write(peergosDir.resolve(MountConfig.FILENAME),
-                    JSONParser.toString(toWrite.toJson()).getBytes(StandardCharsets.UTF_8));
+            // written beside the config and swapped in: a half written file reads as a mount
+            // that cannot log in, and readConfig holds a different lock from this method
+            Path partial = Files.createTempFile(peergosDir, MountConfig.FILENAME, ".tmp", ownerOnly(peergosDir));
+            Files.write(partial, JSONParser.toString(toWrite.toJson()).getBytes(StandardCharsets.UTF_8));
+            Files.move(partial, peergosDir.resolve(MountConfig.FILENAME),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/peergos/server/tests/SecretStoreTests.java
+++ b/src/peergos/server/tests/SecretStoreTests.java
@@ -1,9 +1,16 @@
 package peergos.server.tests;
 
 import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import peergos.server.net.MountConfigHandler;
 import peergos.server.util.secrets.*;
+import peergos.server.webdav.MountConfig;
+import peergos.shared.io.ipfs.api.JSONParser;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -11,6 +18,9 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 public class SecretStoreTests {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
 
     /* ------------------------------------------------------------------ */
     /* MemorySecretStore — exercises the interface contract that all      */
@@ -159,5 +169,46 @@ public class SecretStoreTests {
         } finally {
             store.delete(service, account);
         }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* MountConfigHandler.readConfig — where a saved mount is loaded, on  */
+    /* every desktop start and every android process start.               */
+    /* ------------------------------------------------------------------ */
+
+    private Path writeConfig(MountConfig config) throws IOException {
+        Path dir = tmp.newFolder().toPath();
+        Files.write(dir.resolve(MountConfig.FILENAME),
+                JSONParser.toString(config.toJson()).getBytes(StandardCharsets.UTF_8));
+        return dir;
+    }
+
+    @Test
+    public void readConfig_missingFileIsDisabled() throws IOException {
+        assertFalse(MountConfigHandler.readConfig(tmp.newFolder().toPath(), new MemorySecretStore()).enabled);
+    }
+
+    @Test
+    public void readConfig_readsASavedConfig() throws IOException {
+        MountConfig saved = new MountConfig(true, "alice", "pw", "dav-user", "dav-pass",
+                8090, "digest", "", "");
+        MountConfig read = MountConfigHandler.readConfig(writeConfig(saved), new JsonFileSecretStore());
+        assertTrue(read.enabled);
+        assertEquals("alice", read.peergosUsername);
+        assertEquals(8090, read.webdavPort);
+        assertEquals("digest", read.authType);
+    }
+
+    /** A keyring-backed store redacts the secrets from the file, so a restore that
+     *  cannot splice them back in logs in with nothing and is rejected. */
+    @Test
+    public void readConfig_splicesKeyringSecretsBackIn() throws IOException {
+        SecretStore store = new MemorySecretStore();
+        store.put("peergos-mount", "alice:password", "the-password");
+        MountConfig onDisk = new MountConfig(true, "alice", "pw", "dav-user", "dav-pass",
+                8090, "digest", "", "").withoutSecrets();
+        assertEquals("", onDisk.peergosPassword);
+        MountConfig read = MountConfigHandler.readConfig(writeConfig(onDisk), store);
+        assertEquals("the-password", read.peergosPassword);
     }
 }


### PR DESCRIPTION
`MountConfigHandler.readConfig` used `Files.readString`, which Android's
`java.nio.file.Files` does not implement. Once a mount config existed on disk,
every Android process start threw `NoSuchMethodError` out of
`Application.onCreate` — including the one WorkManager starts, so background
sync went down with the app. Reads now use `Files.readAllBytes` with an
explicit UTF-8 decode.

The other `Files.readString` call, in `SyncRunner.ThreadBased`, is desktop-only
(Android implements `SyncRunner` directly) and is left as it is.

Two further issues in the same file:

- **The config was not written atomically.** `saveConfig` used a plain
  `Files.write`, and it holds the instance lock while
  `readConfig(Path, SecretStore)` is `static synchronized` — a different
  monitor — so a reader could observe a partially written file, and a crash
  mid-write left one behind. It is now written to a temp file in the same
  directory and moved into place with `ATOMIC_MOVE`.

- **The config was created world-readable.** It always contains
  `webdavPassword`, and the account password too when no keyring is available
  (`JsonFileSecretStore` embeds secrets, which is what a plain Linux desktop
  gets from `SecretStore.detect()`). The temp file is now created `rw-------`
  where the filesystem supports POSIX permissions, so there is no window in
  which the secrets are readable by other local users.

- **`enable` accepted an empty password.** `saveConfig` stores a password only
  when it is given one, so enabling with an empty field persisted a config
  claiming `enabled: true` with no recoverable credential; every subsequent
  restore then failed with "Incorrect username or password" and the mount could
  never come back. It is now rejected before anything is generated or written.

### Tests

Three tests around `readConfig` in `SecretStoreTests`: a missing file yields a
disabled config, a saved config round-trips, and a keyring-backed store has its
redacted secrets spliced back in. `ant compile` is clean and the suite passes
(16 tests).

Verified on both platforms by planting a saved config and starting the app:
Android now boots with no `NoSuchMethodError`, both platforms report the failed
restore through `get-config` instead of appearing mounted, and `enable` with an
empty password returns 400 with "Mounting needs your username and password".

### Notes

The atomic write and the permission change run only inside `saveConfig`, which
needs a real login, so they are covered by review and by the read-side tests
rather than by an end-to-end run. If the process is killed between creating the
temp file and renaming it, a `mount-config.json*.tmp` is left in the data
directory; it is inert and the next save is unaffected.