### PR TITLE
Reuse an existing mount when restoring, instead of failing or duplicating

### DIFF
--- a/src/peergos/server/tests/SecretStoreTests.java
+++ b/src/peergos/server/tests/SecretStoreTests.java
@@ -5,6 +5,7 @@ import org.junit.rules.TemporaryFolder;
 import peergos.server.net.MountConfigHandler;
 import peergos.server.util.secrets.*;
 import peergos.server.webdav.MountConfig;
+import peergos.server.webdav.WebdavMount;
 import peergos.shared.io.ipfs.api.JSONParser;
 
 import java.io.IOException;
@@ -210,5 +211,22 @@ public class SecretStoreTests {
         assertEquals("", onDisk.peergosPassword);
         MountConfig read = MountConfigHandler.readConfig(writeConfig(onDisk), store);
         assertEquals("the-password", read.peergosPassword);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* WebdavMount.alreadyMounted — a mount left behind by a killed         */
+    /* app is the mount being asked for, not a failure.                     */
+    /* ------------------------------------------------------------------ */
+
+    @Test
+    public void alreadyMounted_recognisesGiosWording() {
+        assertTrue(WebdavMount.alreadyMounted(
+                "Command failed (exit 2): gio mount dav://x@localhost:1\ngio: dav://x@localhost:1/: Location is already mounted"));
+    }
+
+    @Test
+    public void alreadyMounted_ignoresOtherFailures() {
+        assertFalse(WebdavMount.alreadyMounted("gio: Could not connect: Connection refused"));
+        assertFalse(WebdavMount.alreadyMounted(null));
     }
 }

--- a/src/peergos/server/tests/SecretStoreTests.java
+++ b/src/peergos/server/tests/SecretStoreTests.java
@@ -229,4 +229,37 @@ public class SecretStoreTests {
         assertFalse(WebdavMount.alreadyMounted("gio: Could not connect: Connection refused"));
         assertFalse(WebdavMount.alreadyMounted(null));
     }
+
+    @Test
+    public void mountedAt_readsTheMountTable() {
+        String table = "/dev/disk1s1 on / (apfs, local, journaled)\n"
+                + "map -hosts on /net (autofs, nosuid)\n"
+                + "//user@localhost:8090 on /Volumes/Peergos (webdav, nodev, noexec)";
+        assertTrue(WebdavMount.mountedAt(table, "/Volumes/Peergos", 8090));
+        assertFalse(WebdavMount.mountedAt(table, "/Volumes/Other", 8090));
+        assertFalse(WebdavMount.mountedAt(null, "/Volumes/Peergos", 8090));
+    }
+
+    /** Adopting whatever happens to sit there would hand back someone else's files. */
+    @Test
+    public void mountedAt_ignoresSomethingElseMountedThere() {
+        String table = "//someone@elsewhere:8090 on /Volumes/Peergos (webdav, nodev)";
+        assertFalse(WebdavMount.mountedAt(table, "/Volumes/Peergos", 8090));
+        assertFalse(WebdavMount.mountedAt("/dev/disk2 on /Volumes/Peergos (hfs, local)",
+                "/Volumes/Peergos", 8090));
+    }
+
+    @Test
+    public void mappedLetter_findsTheShareInNetUseOutput() {
+        String out = "New connections will be remembered.\n\n"
+                + "Status       Local     Remote                    Network\n"
+                + "-------------------------------------------------------\n"
+                + "OK           P:        \\\\localhost@8090\\Peergos    Web Client Network\n"
+                + "OK           Z:        \\\\server\\share            Microsoft Windows Network";
+        assertEquals(Optional.of("P:"), WebdavMount.mappedLetter(out, "\\\\localhost@8090\\Peergos"));
+        assertEquals(Optional.empty(), WebdavMount.mappedLetter(out, "\\\\localhost@9999\\Peergos"));
+        assertEquals(Optional.empty(), WebdavMount.mappedLetter(null, "\\\\localhost@8090\\Peergos"));
+        assertEquals(Optional.empty(), WebdavMount.mappedLetter(
+                "OK  1:  \\\\localhost@8090\\Peergos  Web Client Network", "\\\\localhost@8090\\Peergos"));
+    }
 }

--- a/src/peergos/server/webdav/WebdavMount.java
+++ b/src/peergos/server/webdav/WebdavMount.java
@@ -51,8 +51,28 @@ public class WebdavMount implements Closeable {
         return m;
     }
 
+    /** Whether our own webdav server is already mounted at this point. Rows of the mount
+     *  table read "<what> on <where> (<options>)"; the endpoint has to match too, or
+     *  anything else mounted there would be adopted as the drive. */
+    public static boolean mountedAt(String mountTable, String mountPoint, int port) {
+        if (mountTable == null)
+            return false;
+        for (String line : mountTable.split("\n")) {
+            boolean here = line.contains(" on " + mountPoint + " ") || line.endsWith(" on " + mountPoint);
+            if (here && line.contains("localhost:" + port))
+                return true;
+        }
+        return false;
+    }
+
     private static WebdavMount mountMacOS(int port, String user, String pass) throws IOException {
         String mountPoint = "/Volumes/Peergos";
+        // a mount this app left behind, by being killed while mounted, is the mount being
+        // asked for: mounting over it fails, and unmounting it first would drop open files
+        if (mountedAt(captureOrEmpty(host("mount")), mountPoint, port)) {
+            LOG.info("WebDAV was already mounted at " + mountPoint);
+            return new WebdavMount(mountPoint, () -> runSilent(host("umount", mountPoint)));
+        }
         new File(mountPoint).mkdirs();
         String url = "http://" + urlEncode(user) + ":" + urlEncode(pass) + "@localhost:" + port;
         runChecked(host("mount_webdav", "-s", "-v", "Peergos", url, mountPoint));
@@ -96,6 +116,14 @@ public class WebdavMount implements Closeable {
     private static WebdavMount mountWindows(int port, String user, String pass) throws IOException {
         ensureWindowsWebDavReady();
         String unc = "\\\\localhost@" + port + "\\Peergos";
+        // as on the other platforms, a mapping left behind is the one being asked for;
+        // mapping the share again would take a second letter every time the app restarts
+        Optional<String> existing = mappedLetter(captureOrEmpty(host("net", "use")), unc);
+        if (existing.isPresent()) {
+            String mapped = existing.get();
+            LOG.info("WebDAV was already mapped to " + mapped);
+            return new WebdavMount(mapped, () -> runSilent(host("net", "use", mapped, "/delete", "/yes")));
+        }
         Set<String> before = driveLetters();
         String letter = null;
         if (!before.contains("P:")) {
@@ -119,6 +147,30 @@ public class WebdavMount implements Closeable {
         String regKey = "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\MountPoints2\\##localhost@" + port + "#Peergos";
         runSilent(host("reg.exe", "add", regKey, "/v", "_LabelFromReg", "/t", "REG_SZ", "/d", "Peergos", "/f"));
         return new WebdavMount(mountedLetter, () -> runSilent(host("net", "use", mountedLetter, "/delete", "/yes")));
+    }
+
+    /** The drive letter already mapped to this share, from `net use` output whose rows
+     *  read "<status> <letter> <remote> <network>". */
+    public static Optional<String> mappedLetter(String netUseOutput, String unc) {
+        if (netUseOutput == null)
+            return Optional.empty();
+        for (String line : netUseOutput.split("\n")) {
+            if (! line.contains(unc))
+                continue;
+            for (String word : line.trim().split("\\s+"))
+                if (word.length() == 2 && word.charAt(1) == ':' && Character.isLetter(word.charAt(0)))
+                    return Optional.of(word.toUpperCase());
+        }
+        return Optional.empty();
+    }
+
+    /** The command's output, or nothing: asking what is mounted must not stop a mount. */
+    private static String captureOrEmpty(String... cmd) {
+        try {
+            return capture(cmd);
+        } catch (IOException cannotAsk) {
+            return "";
+        }
     }
 
     private static Set<String> driveLetters() {

--- a/src/peergos/server/webdav/WebdavMount.java
+++ b/src/peergos/server/webdav/WebdavMount.java
@@ -131,11 +131,24 @@ public class WebdavMount implements Closeable {
         return letters;
     }
 
+    /** gio's wording when the location it was asked to mount is mounted already. */
+    public static boolean alreadyMounted(String message) {
+        return message != null && message.toLowerCase().contains("already mounted");
+    }
+
     private static WebdavMount mountLinux(int port, String user, String pass) throws IOException {
         // gio mount ignores credentials in the URL and prompts interactively;
         // pipe the password to its stdin instead.
         String url = "dav://" + urlEncode(user) + "@localhost:" + port;
-        runCheckedWithStdin(pass, host("gio", "mount", url));
+        try {
+            runCheckedWithStdin(pass, host("gio", "mount", url));
+        } catch (IOException e) {
+            // a mount this app left behind, by being killed while mounted, is the mount we
+            // are asking for: gio refusing to make a second one is not a failure to be here
+            if (! alreadyMounted(e.getMessage()))
+                throw e;
+            LOG.info("WebDAV was already mounted at " + url);
+        }
         String mountPoint = findGvfsMountPoint(port);
         LOG.info("WebDAV mounted at " + mountPoint);
         return new WebdavMount(mountPoint, () -> runSilent(host("gio", "mount", "--unmount", url)));


### PR DESCRIPTION
Restoring a saved mount assumes nothing is mounted yet. A mount left behind by a
crash or a forced quit breaks that assumption differently on each platform:

- **Linux** — `gio mount` exits non-zero with "Location is already mounted", and
  the restore was reported as failed even though the mount was present and
  usable. The app then offered the password form for a drive that was already
  mounted, with no way out but unmounting by hand.
- **macOS** — `/Volumes/Peergos` is a fixed mount point, so `mount_webdav` fails
  on it once something is there.
- **Windows** — `net use` never failed, but with `P:` already taken it fell
  through to `net use *`, mapping a *second* drive letter to the same share on
  every restart.

Each path now reuses what is already mounted. Linux recognises gio's message;
macOS and Windows ask the system what is mounted (`mount`, `net use`) and match
on that output rather than on error text, since their exact wording is not
verified here. macOS also requires the row to reference our own endpoint, so
that something else mounted at that path is never adopted as the drive. A
failure to ask is ignored, so the check can never block a mount that would
otherwise succeed.

Unit tests cover the three predicates against realistic command output,
including a foreign mount at our mount point and a non-letter drive token.

Tested end to end on Linux only: killed the app while mounted, restarted, and
the restore succeeded over the stale mount. The macOS and Windows changes are
unverified on those platforms.