### PR TITLE
Fix per-folder sync status being dropped, and report a paused sync as paused

### DIFF
--- a/src/peergos/server/sync/PairStatus.java
+++ b/src/peergos/server/sync/PairStatus.java
@@ -45,7 +45,8 @@ public class PairStatus {
             Object m = json.get("msg");
             status = m == null ? null : m.toString();
             Object t = json.get("time");
-            updateTime = t == null ? null : LocalDateTime.parse(t.toString(), TS);
+            // a record stamped between passes carries a state but no time yet
+            updateTime = t == null || t.toString().isEmpty() ? null : LocalDateTime.parse(t.toString(), TS);
             Object e = json.get("error");
             error = e == null || e.toString().isEmpty() ? Optional.empty() : Optional.of(e.toString());
             // status files written by older versions have no state

--- a/src/peergos/server/sync/SyncStatus.java
+++ b/src/peergos/server/sync/SyncStatus.java
@@ -35,12 +35,12 @@ public enum SyncStatus {
     public static SyncStatus aggregate(List<SyncStatus> pairStates, boolean globalError, boolean paused) {
         if (pairStates.isEmpty())
             return NONE;
-        // an error outlives a pause: it is something the user has to act on, and hiding it
-        // behind the pause they already know about would lose it
-        if (globalError || pairStates.contains(ERROR))
-            return ERROR;
+        // nothing runs while it is paused, so that is what every client reports first;
+        // a failure underneath it is still shown on the folder it belongs to
         if (paused)
             return PAUSED;
+        if (globalError || pairStates.contains(ERROR))
+            return ERROR;
         if (pairStates.contains(SYNCING))
             return SYNCING;
         return SYNCED;

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -962,9 +962,9 @@ public class SyncTests {
         // a pause is what the tray shows, whatever the last pass left the pairs on
         Assert.assertEquals(SyncStatus.PAUSED, SyncStatus.aggregate(List.of(SyncStatus.SYNCED), false, true));
         Assert.assertEquals(SyncStatus.PAUSED, SyncStatus.aggregate(List.of(SyncStatus.SYNCING), false, true));
-        // except an error, which the user still has to act on
-        Assert.assertEquals(SyncStatus.ERROR, SyncStatus.aggregate(List.of(SyncStatus.ERROR), false, true));
-        Assert.assertEquals(SyncStatus.ERROR, SyncStatus.aggregate(List.of(SyncStatus.SYNCED), true, true));
+        // including one that failed, which the folder itself still reports
+        Assert.assertEquals(SyncStatus.PAUSED, SyncStatus.aggregate(List.of(SyncStatus.ERROR), false, true));
+        Assert.assertEquals(SyncStatus.PAUSED, SyncStatus.aggregate(List.of(SyncStatus.SYNCED), true, true));
     }
 
     @Test


### PR DESCRIPTION
Two small fixes to how sync status is reported.

### A status file stamped without a time is unreadable

`PairStatus.persist()` writes `"time": ""` whenever the record has no timestamp, and only `setStatus(String)` sets one — `setError(...)` and `setStatus(SyncStatus)` do not. On loading such a file, `LocalDateTime.parse("")` throws, and because the time is parsed before `error` and `state`, the catch discards the whole record and the folder is served with its defaults: `SYNCED`, no error.

That happens whenever the first write for a folder is a stamp rather than a message:

- Android stamps a folder held back on mobile data with `ERROR` and the reason before any pass reaches it. It reads back as up to date with no reason, and since no pass runs while it is blocked, nothing ever writes a time — the record cannot recover.
- `stampPairs(…, null, SYNCING)` at the start of each pass is discarded the same way for an already-timeless record.
- In `DirectorySync`, a pair that throws before its first `perPairLog` message this pass — opening its sync DB, for instance — is stamped `ERROR` on a fresh record, so a real failure reports as fine.

It also logs `Failed to load sync status …` on every poll, once a second while a client is on screen. On 1.31.2 the same record makes `getStatusAndTime()` throw an NPE, so the whole status reply fails; the null guard now on master turned that crash into a silent wrong answer.

The fix treats an empty time as absent, leaving the surrounding code as it was:

```java
updateTime = t == null || t.toString().isEmpty() ? null : LocalDateTime.parse(t.toString(), TS);
```

### A paused sync should report as paused

`aggregate` put `ERROR` ahead of `PAUSED`, so pausing with a failed folder left the tray showing the error icon while the view said Paused. Pause now wins; the failure is still reported on the folder that owns it, and its two assertions are updated to match.

Verified against the built jar: `aggregate` over 9 cases (including the 4 already covered), and `PairStatus` reading a stamped-without-time record, a full timestamp, and a whole-minute timestamp.

Pairs with peergos/web-ui#PR2 — the pause change needs both halves to keep the tray and the view in agreement.