### PR TITLE
Huge speed up to granting write access

### DIFF
--- a/src/peergos/server/tests/RequestCountTests.java
+++ b/src/peergos/server/tests/RequestCountTests.java
@@ -85,6 +85,45 @@ public class RequestCountTests {
     }
 
     @Test
+    public void nestedWritingSpaceSurvivesParentGrant() {
+        CryptreeNode.setMaxChildLinkPerBlob(500);
+        String password = "notagoodone";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(generateUsername(random), password, network, crypto);
+        Path folder = PathUtil.get(context.username, "folder");
+        Path subdir = folder.resolve("subdir");
+        context.getUserRoot().join().mkdir("folder", network, false, context.mirrorBatId(), crypto).join();
+        context.getByPath(folder).join().get().mkdir("subdir", network, false, context.mirrorBatId(), crypto).join();
+        byte[] data = "nested payload".getBytes();
+        context.getByPath(subdir).join().get()
+                .uploadOrReplaceFile("deep.txt", AsyncReader.build(data), data.length, network, crypto,
+                        () -> false, x -> {}).join();
+
+        context.shareWriteAccessWith(subdir, Collections.emptySet()).join();
+        PublicKeyHash nestedWriter = context.getByPath(subdir).join().get().writer();
+
+        // moving the parent into its own writing space must leave the nested one alone
+        context.shareWriteAccessWith(folder, Collections.emptySet()).join();
+        PublicKeyHash folderWriter = context.getByPath(folder).join().get().writer();
+
+        FileWrapper nested = context.getByPath(subdir).join()
+                .orElseThrow(() -> new AssertionError("nested writing space survives the parent grant"));
+        Assert.assertEquals("nested writer is untouched", nestedWriter, nested.writer());
+        Assert.assertTrue(nested.isWritable());
+        Assert.assertEquals(1, nested.getChildren(crypto.hasher, network).join().size());
+        Assert.assertEquals("/" + subdir, nested.getPath(network).join());
+        Assert.assertTrue("nested writer re-parented onto the new writer",
+                isOwnedBy(context, folderWriter, nestedWriter));
+        Assert.assertFalse("nested writer no longer owned by home",
+                isOwnedBy(context, context.getUserRoot().join().writer(), nestedWriter));
+    }
+
+    private boolean isOwnedBy(UserContext context, PublicKeyHash parent, PublicKeyHash child) {
+        return UserContext.getWriterData(network, context.signer.publicKeyHash, parent).join()
+                .props.get().directOwnedKeys(context.signer.publicKeyHash, network.dhtClient, crypto.hasher)
+                .join().contains(child);
+    }
+
+    @Test
     public void socialFeedRequestCount() {
         CryptreeNode.setMaxChildLinkPerBlob(10);
         String password = "notagoodone";

--- a/src/peergos/server/tests/RequestCountTests.java
+++ b/src/peergos/server/tests/RequestCountTests.java
@@ -5,6 +5,7 @@ import peergos.server.*;
 import peergos.server.storage.*;
 import peergos.server.util.*;
 import peergos.shared.*;
+import peergos.shared.crypto.hash.*;
 import peergos.shared.crypto.symmetric.*;
 import peergos.shared.display.*;
 import peergos.shared.mutable.*;
@@ -49,6 +50,38 @@ public class RequestCountTests {
     @BeforeClass
     public static void init() {
         service = Main.PKI_INIT.main(args).localApi;
+    }
+
+    @Test
+    public void writeGrantRequestCount() {
+        CryptreeNode.setMaxChildLinkPerBlob(500);
+        String password = "notagoodone";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(generateUsername(random), password, network, crypto);
+        int nFiles = 100;
+        Path dir = PathUtil.get(context.username, "shared-dir");
+        context.getUserRoot().join().mkdir("shared-dir", network, false, context.mirrorBatId(), crypto).join();
+        for (int i = 0; i < nFiles; i++) {
+            byte[] data = new byte[1024];
+            random.nextBytes(data);
+            context.getByPath(dir).join().get()
+                    .uploadOrReplaceFile("file-" + i, AsyncReader.build(data), data.length, network, crypto,
+                            () -> false, x -> {}).join();
+        }
+        AbsoluteCapability before = context.getByPath(dir).join().get().getPointer().capability;
+        PublicKeyHash homeWriter = context.getUserRoot().join().writer();
+
+        storageCounter.reset();
+        context.shareWriteAccessWith(dir, Collections.emptySet()).join();
+        int requests = storageCounter.requestTotal();
+        Assert.assertTrue("granting write access to " + nFiles + " files: " + requests, requests <= 160);
+
+        FileWrapper granted = context.getByPath(dir).join().get();
+        Assert.assertNotEquals("moved to its own writing space", homeWriter, granted.writer());
+        // granting access compromises no key, so the subtree is re-homed unchanged rather than rotated
+        AbsoluteCapability after = granted.getPointer().capability;
+        Assert.assertEquals(before.rBaseKey, after.rBaseKey);
+        Assert.assertArrayEquals(before.getMapKey(), after.getMapKey());
+        Assert.assertEquals(nFiles, granted.getChildren(crypto.hasher, network).join().size());
     }
 
     @Test

--- a/src/peergos/shared/NetworkAccess.java
+++ b/src/peergos/shared/NetworkAccess.java
@@ -820,8 +820,9 @@ public class NetworkAccess {
                                                            Snapshot current,
                                                            Committer committer) {
         CommittedWriterData version = current.get(writer);
-        return tree.put(version.props.get(), owner, writer, mapKey, metadata.committedHash(), metadata.committedHash().get(), tid)
-                .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid));
+        return tree.put(version.props.get(), owner, writer, mapKey, MaybeMultihash.empty(), metadata.committedHash().get(), tid)
+                .thenCompose(wd -> committer.commit(owner, writer, wd, version, tid))
+                .thenApply(committed -> current.withVersion(writer.publicKeyHash, committed.get(writer)));
     }
 
     public CompletableFuture<Snapshot> deleteChunk(Snapshot current,

--- a/src/peergos/shared/storage/BufferedStorage.java
+++ b/src/peergos/shared/storage/BufferedStorage.java
@@ -359,32 +359,31 @@ public class BufferedStorage extends DelegatingStorage {
 
     public void gc(List<Cid> roots) {
         synchronized (storage) {
-            List<Cid> all = new ArrayList<>(storage.keySet());
-            List<Boolean> reachable = new ArrayList<>();
-            for (int i = 0; i < all.size(); i++)
-                reachable.add(false);
+            Set<Cid> reachable = new HashSet<>();
             for (Cid root : roots) {
-                markReachable(root, reachable, all, storage);
+                markReachable(root, reachable, storage);
             }
-            for (int i = 0; i < all.size(); i++) {
-                if (!reachable.get(i))
-                    storage.remove(all.get(i));
-            }
+            if (reachable.size() == storage.size())
+                return;
+            List<Cid> unreachable = storage.keySet().stream()
+                    .filter(c -> ! reachable.contains(c))
+                    .collect(Collectors.toList());
+            unreachable.forEach(storage::remove);
         }
     }
 
-    private static void markReachable(Cid current, List<Boolean> reachable, List<Cid> all, Map<Cid, OpLog.BlockWrite> storage) {
+    private static void markReachable(Cid current, Set<Cid> reachable, Map<Cid, OpLog.BlockWrite> storage) {
         OpLog.BlockWrite block = storage.get(current);
         if (block == null)
             return;
-        int index = all.indexOf(current);
-        reachable.set(index, true);
+        if (! reachable.add(current))
+            return;
 
         if (current.isRaw())
             return;
         List<Multihash> links = CborObject.fromByteArray(block.block).links();
         for (Multihash link : links) {
-            markReachable((Cid)link, reachable, all, storage);
+            markReachable((Cid)link, reachable, storage);
         }
     }
 

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -2344,12 +2344,10 @@ public class UserContext {
         //    in which case, just share a write cap
         //
         // b) file needs to be moved to a different signing key (along with its subtree)
-        // To do this atomically,
-        // 1) rotate all the keys as if we were revoking write access
+        // 1) move the subtree to a new signing key, keeping all its keys and blocks
         // 2) update parent pointer
         // 3) delete old subtree
         // 4) then reshare all sub sharees
-        System.out.println("Sharing write: " + parent.writer() + " child " + file.writer());
         ensureAllowedToShare(file, username, true);
         SigningPrivateKeyAndPublicHash currentSigner = file.signingPair();
         boolean changeSigner = currentSigner.publicKeyHash.equals(parent.signingPair().publicKeyHash);
@@ -2361,22 +2359,77 @@ public class UserContext {
         }
 
         return network.synchronizer.applyComplexUpdate(signer.publicKeyHash,
-                file.signingPair(), (s, c) -> rotateAllKeys(file, parent, true, s, c)
-                        .thenCompose(s2 -> getByPath(pathToFile.toString(), s2)
-                                .thenCompose(newFileOpt -> {
-                                    System.out.println("New child writer: " + newFileOpt.get().writer());
-                                    return sharedWithCache
-                                            .addSharedWith(SharedWithCache.Access.WRITE, pathToFile, writersToAdd, s2, c, network);
-                                })
+                file.signingPair(), (s, c) -> moveToNewWritingSpace(file, parent, s, c)
+                        .thenCompose(s2 -> sharedWithCache
+                                .addSharedWith(SharedWithCache.Access.WRITE, pathToFile, writersToAdd, s2, c, network)
                                 .thenCompose(s3 -> reSendAllSharesAndLinksRecursive(pathToFile, s3, c))
                         ));
+    }
+
+    /** Move a file/dir and its subtree into a new writing space, without rotating any keys.
+     *
+     *  Granting write access doesn't compromise any existing key, so the subtree's cryptree nodes
+     *  are re-homed under a new signing key unchanged, rather than being re-encrypted and rewritten.
+     *  Only the subtree root is rewritten, to hold the new signer link and to point at the link node
+     *  which is created in the parent's writing space to restrict rename access.
+     *
+     *  Revoking access is different, and still requires rotateAllKeys.
+     */
+    private CompletableFuture<Snapshot> moveToNewWritingSpace(FileWrapper file,
+                                                              FileWrapper parent,
+                                                              Snapshot initial,
+                                                              Committer c) {
+        PublicKeyHash owner = parent.owner();
+        SigningPrivateKeyAndPublicHash parentSigner = parent.signingPair();
+        WritableAbsoluteCapability parentCap = parent.writableFilePointer();
+        WritableAbsoluteCapability originalCap = file.writableFilePointer();
+        SigningPrivateKeyAndPublicHash originalSigner = file.signingPair();
+        AbsoluteCapability originalChildLink = file.isLink() ?
+                file.getLinkPointer().capability :
+                file.getPointer().capability;
+        FileProperties props = file.getFileProperties();
+
+        byte[] linkMapKey = crypto.random.randomBytes(RelativeCapability.MAP_KEY_LENGTH);
+        Optional<Bat> linkBat = Optional.of(Bat.random(crypto.random));
+        SymmetricKey linkParentKey = SymmetricKey.random();
+        WritableAbsoluteCapability linkCap = new WritableAbsoluteCapability(owner, parentCap.writer,
+                linkMapKey, linkBat, SymmetricKey.random(), SymmetricKey.random());
+        RelativeCapability newParentLink = new RelativeCapability(Optional.of(parentCap.writer),
+                linkMapKey, linkBat, linkParentKey, Optional.empty());
+
+        return CryptreeNode.initAndAuthoriseSigner(owner, parentSigner,
+                        SigningKeyPair.random(crypto.random, crypto.signer), network, initial, c)
+                .thenCompose(p -> {
+                    SigningPrivateKeyAndPublicHash newSigner = p.right;
+                    WritableAbsoluteCapability newCap = originalCap.withSigner(newSigner.publicKeyHash);
+                    SymmetricLinkToSigner signerLink = SymmetricLinkToSigner
+                            .fromPair(originalCap.wBaseKey.get(), newSigner);
+                    CryptreeNode newRoot = file.getPointer().fileAccess
+                            .withWriterLink(originalCap.rBaseKey, signerLink)
+                            .withParentLink(file.getParentKey(), newParentLink);
+                    return IpfsTransaction.call(owner, tid -> network.uploadChunk(p.left, c, newRoot, owner,
+                                            originalCap.getMapKey(), newSigner, tid)
+                                    .thenCompose(v -> FileWrapper.copyAllChunks(false, originalCap, newSigner,
+                                            tid, crypto.hasher, network, v, c)), network.dhtClient)
+                            .thenCompose(v -> CryptreeNode.createAndCommitLink(parent, newCap, props, linkCap,
+                                    linkParentKey, mirrorBatId(), crypto, network, v, c))
+                            .thenCompose(v -> parent.getPointer().fileAccess.updateChildLink(v, c, parentCap,
+                                    parentSigner, originalChildLink,
+                                    new NamedAbsoluteCapability(file.getName(), linkCap,
+                                            Optional.of(props.isDirectory),
+                                            Optional.of(props.mimeType),
+                                            Optional.of(props.created)),
+                                    network, crypto.random, crypto.hasher))
+                            .thenCompose(v -> IpfsTransaction.call(owner,
+                                    tid -> FileWrapper.deleteAllChunks(originalCap, originalSigner,
+                                            tid, crypto.hasher, network, v, c), network.dhtClient));
+                });
     }
 
     public CompletableFuture<Snapshot> sendWriteCapToAll(Path toFile, Set<String> writersToAdd, Snapshot s, Committer c) {
         if (writersToAdd.isEmpty())
             return Futures.of(s);
 
-        System.out.println("Resharing WRITE cap to " + toFile + " with " + writersToAdd);
         return getByPath(toFile.getParent().toString(), s)
                 .thenCompose(parent -> getByPath(toFile.toString(), s)
                         .thenCompose(fileOpt -> fileOpt.map(file -> sendWriteCapToAll(file, parent.get(), toFile, writersToAdd, s, c))

--- a/src/peergos/shared/user/UserContext.java
+++ b/src/peergos/shared/user/UserContext.java
@@ -2407,23 +2407,61 @@ public class UserContext {
                     CryptreeNode newRoot = file.getPointer().fileAccess
                             .withWriterLink(originalCap.rBaseKey, signerLink)
                             .withParentLink(file.getParentKey(), newParentLink);
+                    FileWrapper.MovedSubtree moved = new FileWrapper.MovedSubtree();
                     return IpfsTransaction.call(owner, tid -> network.uploadChunk(p.left, c, newRoot, owner,
                                             originalCap.getMapKey(), newSigner, tid)
                                     .thenCompose(v -> FileWrapper.copyAllChunks(false, originalCap, newSigner,
-                                            tid, crypto.hasher, network, v, c)), network.dhtClient)
-                            .thenCompose(v -> CryptreeNode.createAndCommitLink(parent, newCap, props, linkCap,
-                                    linkParentKey, mirrorBatId(), crypto, network, v, c))
-                            .thenCompose(v -> parent.getPointer().fileAccess.updateChildLink(v, c, parentCap,
-                                    parentSigner, originalChildLink,
-                                    new NamedAbsoluteCapability(file.getName(), linkCap,
-                                            Optional.of(props.isDirectory),
-                                            Optional.of(props.mimeType),
-                                            Optional.of(props.created)),
-                                    network, crypto.random, crypto.hasher))
-                            .thenCompose(v -> IpfsTransaction.call(owner,
-                                    tid -> FileWrapper.deleteAllChunks(originalCap, originalSigner,
-                                            tid, crypto.hasher, network, v, c), network.dhtClient));
+                                            tid, crypto.hasher, network, moved, v, c))
+                                    .thenCompose(v -> reparentNestedWritingSpaces(moved.nestedWritingSpaces, owner,
+                                            originalSigner, newSigner, tid, v, c))
+                                    .thenCompose(v -> CryptreeNode.createAndCommitLink(parent, newCap, props, linkCap,
+                                            linkParentKey, mirrorBatId(), crypto, network, v, c))
+                                    .thenCompose(v -> parent.getPointer().fileAccess.updateChildLink(v, c, parentCap,
+                                            parentSigner, originalChildLink,
+                                            new NamedAbsoluteCapability(file.getName(), linkCap,
+                                                    Optional.of(props.isDirectory),
+                                                    Optional.of(props.mimeType),
+                                                    Optional.of(props.created)),
+                                            network, crypto.random, crypto.hasher))
+                                    .thenCompose(v -> network.deleteAllChunksIfPresent(v, c, owner, originalSigner,
+                                            moved.moved, moved.movedValues, tid)), network.dhtClient);
                 });
+    }
+
+    /** A writing space nested inside the moved subtree keeps all its blocks and its signing key.
+     *  Only its link to its parent, and which key owns it, change.
+     */
+    private CompletableFuture<Snapshot> reparentNestedWritingSpaces(List<AbsoluteCapability> nested,
+                                                                    PublicKeyHash owner,
+                                                                    SigningPrivateKeyAndPublicHash oldParent,
+                                                                    SigningPrivateKeyAndPublicHash newParent,
+                                                                    TransactionId tid,
+                                                                    Snapshot initial,
+                                                                    Committer c) {
+        return Futures.reduceAll(nested, initial,
+                (v, cap) -> v.withWriter(owner, cap.writer, network)
+                        .thenCompose(withChild -> network.getMetadata(withChild.get(cap.writer), cap)
+                                .thenCompose(mOpt -> {
+                                    if (mOpt.isEmpty())
+                                        return Futures.of(withChild);
+                                    CryptreeNode child = mOpt.get();
+                                    SigningPrivateKeyAndPublicHash childSigner = child.getSigner(cap.rBaseKey,
+                                            cap.wBaseKey.get(), Optional.of(oldParent));
+                                    RelativeCapability toParent = child.getParentCapability(cap.rBaseKey)
+                                            .orElseThrow(() -> new IllegalStateException("Nested writing space with no parent link!"))
+                                            .withWritingKey(Optional.of(newParent.publicKeyHash));
+                                    CryptreeNode updated = child.withParentLink(child.getParentKey(cap.rBaseKey), toParent);
+                                    return network.uploadChunk(withChild, c, updated, owner, cap.getMapKey(), childSigner, tid)
+                                            .thenCompose(v2 -> OwnerProof.build(childSigner, newParent.publicKeyHash)
+                                                    .thenCompose(proof -> v2.get(newParent).props.get()
+                                                            .addOwnedKeyAndCommit(owner, newParent, proof,
+                                                                    v2.get(newParent).hash, v2.get(newParent).sequence,
+                                                                    network, c, tid)
+                                                            .thenApply(v2::mergeAndOverwriteWith)))
+                                            .thenCompose(v3 -> CryptreeNode.deAuthoriseSigner(owner, oldParent,
+                                                    childSigner.publicKeyHash, network, v3, c));
+                                })),
+                (a, b) -> b);
     }
 
     public CompletableFuture<Snapshot> sendWriteCapToAll(Path toFile, Set<String> writersToAdd, Snapshot s, Committer c) {

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -2574,7 +2574,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
         network.synchronizer.putEmpty(owner, signer.publicKeyHash);
         return network.synchronizer.applyComplexUpdate(owner, signer, (version, committer) -> IpfsTransaction.call(owner,
                 tid -> network.uploadChunk(version, committer, newFileAccess, owner, getPointer().capability.getMapKey(), signer, tid)
-                        .thenCompose(newVersion -> copyAllChunks(false, cap, signer, hasher, network, newVersion, committer))
+                        .thenCompose(newVersion -> copyAllChunks(false, cap, signer, tid, hasher, network, newVersion, committer))
                         .thenCompose(copiedVersion -> copiedVersion.withWriter(owner, parent.writer(), network))
                         .thenCompose(withParent -> parent.getPointer().fileAccess
                                 .updateChildLink(withParent, committer, parent.writableFilePointer(),
@@ -2597,13 +2597,14 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
      * @param network
      * @return
      */
-    private static CompletableFuture<Snapshot> copyAllChunks(boolean includeFirst,
-                                                             AbsoluteCapability currentCap,
-                                                             SigningPrivateKeyAndPublicHash targetSigner,
-                                                             Hasher hasher,
-                                                             NetworkAccess network,
-                                                             Snapshot initialVersion,
-                                                             Committer committer) {
+    public static CompletableFuture<Snapshot> copyAllChunks(boolean includeFirst,
+                                                            AbsoluteCapability currentCap,
+                                                            SigningPrivateKeyAndPublicHash targetSigner,
+                                                            TransactionId tid,
+                                                            Hasher hasher,
+                                                            NetworkAccess network,
+                                                            Snapshot initialVersion,
+                                                            Committer committer) {
 
         return initialVersion.withWriter(currentCap.owner, currentCap.writer, network)
                 .thenCompose(version -> network.getMetadata(version.get(currentCap.writer), currentCap)
@@ -2611,33 +2612,56 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                             if (! mOpt.isPresent()) {
                                 return CompletableFuture.completedFuture(version);
                             }
-                            return (includeFirst ?
-                                    IpfsTransaction.call(currentCap.owner,
-                                            tid -> network.addPreexistingChunk(mOpt.get(), currentCap.owner, currentCap.getMapKey(),
-                                                    targetSigner, tid, version, committer), network.dhtClient) :
-                                    CompletableFuture.completedFuture(version))
-                                    .thenCompose(updated -> {
-                                        CryptreeNode chunk = mOpt.get();
-                                        Optional<byte[]> streamSecret = chunk.getProperties(chunk
-                                                .getParentKey(currentCap.rBaseKey)).streamSecret;
-                                        return chunk.getNextChunkLocation(currentCap.rBaseKey,
-                                                streamSecret, currentCap.getMapKey(), currentCap.bat, hasher)
-                                                .thenCompose(nextChunkMapKeyAndBat ->
-                                                        copyAllChunks(true, currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right),
-                                                                targetSigner, hasher, network, updated, committer));
-                                    })
-                                    .thenCompose(updatedVersion -> {
-                                        if (! mOpt.get().isDirectory())
-                                            return CompletableFuture.completedFuture(updatedVersion);
-                                        return mOpt.get().getDirectChildrenCapabilities(currentCap, updatedVersion, network)
-                                                .thenCompose(childCaps ->
-                                                        Futures.reduceAll(childCaps,
-                                                                updatedVersion,
-                                                                (v, cap) -> copyAllChunks(true, cap.cap,
-                                                                        targetSigner, hasher, network, v, committer),
-                                                                (x, y) -> y));
-                                    });
+                            return copyAllChunks(includeFirst, currentCap, mOpt.get(), targetSigner, tid, hasher,
+                                    network, version, committer);
                         }));
+    }
+
+    private static CompletableFuture<Snapshot> copyAllChunks(boolean includeFirst,
+                                                             AbsoluteCapability currentCap,
+                                                             CryptreeNode chunk,
+                                                             SigningPrivateKeyAndPublicHash targetSigner,
+                                                             TransactionId tid,
+                                                             Hasher hasher,
+                                                             NetworkAccess network,
+                                                             Snapshot version,
+                                                             Committer committer) {
+        FileProperties props = chunk.getProperties(chunk.getParentKey(currentCap.rBaseKey));
+        Optional<byte[]> streamSecret = props.streamSecret;
+        boolean normalFile = ! chunk.isDirectory() && streamSecret.isPresent();
+        return (includeFirst ?
+                network.addPreexistingChunk(chunk, currentCap.owner, currentCap.getMapKey(),
+                        targetSigner, tid, version, committer) :
+                CompletableFuture.completedFuture(version))
+                .thenCompose(updated -> {
+                    if (normalFile) {
+                        // the chunk count tells us the locations, so there is no need to probe for them
+                        if (props.chunkCount() <= 1)
+                            return CompletableFuture.completedFuture(updated);
+                        return getAllChunkLocations(currentCap.getMapKey(), currentCap.bat, streamSecret.get(),
+                                props.chunkCount(), hasher)
+                                .thenCompose(labels -> copyChunks(labels.subList(1, labels.size()), currentCap,
+                                        targetSigner, tid, network, updated, committer));
+                    }
+                    return chunk.getNextChunkLocation(currentCap.rBaseKey,
+                            streamSecret, currentCap.getMapKey(), currentCap.bat, hasher)
+                            .thenCompose(nextChunkMapKeyAndBat ->
+                                    copyAllChunks(true, currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right),
+                                            targetSigner, tid, hasher, network, updated, committer));
+                })
+                .thenCompose(updatedVersion -> {
+                    if (! chunk.isDirectory())
+                        return CompletableFuture.completedFuture(updatedVersion);
+                    return chunk.getDirectChildrenCapabilities(currentCap, updatedVersion, network)
+                            .thenCompose(childCaps -> network.retrieveAllMetadata(childCaps.stream()
+                                            .map(c -> c.cap)
+                                            .collect(Collectors.toList()), updatedVersion)
+                                    .thenCompose(retrieved -> Futures.reduceAll(retrieved.left,
+                                            updatedVersion,
+                                            (v, child) -> copyAllChunks(true, child.capability, child.fileAccess,
+                                                    targetSigner, tid, hasher, network, v, committer),
+                                            (x, y) -> y)));
+                });
     }
 
     public static CompletableFuture<Snapshot> deleteAllChunks(WritableAbsoluteCapability currentCap,
@@ -2764,6 +2788,23 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                                 Committer c) {
         return getAllChunkLocations(startCap.getMapKey(), startCap.bat, streamSecret, nChunks, hasher)
                 .thenCompose(labels -> network.deleteAllChunksIfPresent(current, c, startCap.owner, ourSigner, labels, tid));
+    }
+
+    private static CompletableFuture<Snapshot> copyChunks(List<Pair<byte[], Optional<Bat>>> labels,
+                                                          AbsoluteCapability firstCap,
+                                                          SigningPrivateKeyAndPublicHash targetSigner,
+                                                          TransactionId tid,
+                                                          NetworkAccess network,
+                                                          Snapshot version,
+                                                          Committer committer) {
+        List<AbsoluteCapability> caps = labels.stream()
+                .map(l -> firstCap.withMapKey(l.left, l.right))
+                .collect(Collectors.toList());
+        return network.retrieveAllMetadata(caps, version)
+                .thenCompose(retrieved -> Futures.reduceAll(retrieved.left, version,
+                        (v, c) -> network.addPreexistingChunk(c.fileAccess, firstCap.owner,
+                                c.capability.getMapKey(), targetSigner, tid, v, committer),
+                        (x, y) -> y));
     }
 
     private static CompletableFuture<List<Pair<byte[], Optional<Bat>>>> getAllChunkLocations(byte[] first,

--- a/src/peergos/shared/user/fs/FileWrapper.java
+++ b/src/peergos/shared/user/fs/FileWrapper.java
@@ -2574,7 +2574,8 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
         network.synchronizer.putEmpty(owner, signer.publicKeyHash);
         return network.synchronizer.applyComplexUpdate(owner, signer, (version, committer) -> IpfsTransaction.call(owner,
                 tid -> network.uploadChunk(version, committer, newFileAccess, owner, getPointer().capability.getMapKey(), signer, tid)
-                        .thenCompose(newVersion -> copyAllChunks(false, cap, signer, tid, hasher, network, newVersion, committer))
+                        .thenCompose(newVersion -> copyAllChunks(false, cap, signer, tid, hasher, network,
+                                new MovedSubtree(), newVersion, committer))
                         .thenCompose(copiedVersion -> copiedVersion.withWriter(owner, parent.writer(), network))
                         .thenCompose(withParent -> parent.getPointer().fileAccess
                                 .updateChildLink(withParent, committer, parent.writableFilePointer(),
@@ -2589,7 +2590,26 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                 .thenApply(updatedUs -> new Pair<>(updatedUs.get(), updatedParent))));
     }
 
-    /** This copies all the cryptree nodes from one signing key to another for a file or subtree
+    /** The result of moving a subtree to a new signing key: the source locations that were moved,
+     *  along with their values in the source CHAMP, and the roots of any nested writing spaces,
+     *  which are left untouched and must be re-parented onto the new signing key by the caller.
+     */
+    public static class MovedSubtree {
+        public final List<Pair<byte[], Optional<Bat>>> moved = new ArrayList<>();
+        public final Map<ByteArrayWrapper, MaybeMultihash> movedValues = new HashMap<>();
+        public final List<AbsoluteCapability> nestedWritingSpaces = new ArrayList<>();
+
+        private void record(AbsoluteCapability cap, CryptreeNode chunk) {
+            moved.add(new Pair<>(cap.getMapKey(), cap.bat));
+            MaybeMultihash existing = chunk.committedHash();
+            if (existing.isPresent())
+                movedValues.put(new ByteArrayWrapper(cap.getMapKey()), existing);
+        }
+    }
+
+    /** This copies all the cryptree nodes from one signing key to another for a file or subtree.
+     *  The traversal stops at a nested writing space, whose blocks belong to a different signing
+     *  key and must not be moved.
      *
      * @param includeFirst
      * @param currentCap
@@ -2603,6 +2623,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                             TransactionId tid,
                                                             Hasher hasher,
                                                             NetworkAccess network,
+                                                            MovedSubtree res,
                                                             Snapshot initialVersion,
                                                             Committer committer) {
 
@@ -2613,7 +2634,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                 return CompletableFuture.completedFuture(version);
                             }
                             return copyAllChunks(includeFirst, currentCap, mOpt.get(), targetSigner, tid, hasher,
-                                    network, version, committer);
+                                    network, res, version, committer);
                         }));
     }
 
@@ -2624,11 +2645,13 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                              TransactionId tid,
                                                              Hasher hasher,
                                                              NetworkAccess network,
+                                                             MovedSubtree res,
                                                              Snapshot version,
                                                              Committer committer) {
         FileProperties props = chunk.getProperties(chunk.getParentKey(currentCap.rBaseKey));
         Optional<byte[]> streamSecret = props.streamSecret;
         boolean normalFile = ! chunk.isDirectory() && streamSecret.isPresent();
+        res.record(currentCap, chunk);
         return (includeFirst ?
                 network.addPreexistingChunk(chunk, currentCap.owner, currentCap.getMapKey(),
                         targetSigner, tid, version, committer) :
@@ -2641,26 +2664,33 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                         return getAllChunkLocations(currentCap.getMapKey(), currentCap.bat, streamSecret.get(),
                                 props.chunkCount(), hasher)
                                 .thenCompose(labels -> copyChunks(labels.subList(1, labels.size()), currentCap,
-                                        targetSigner, tid, network, updated, committer));
+                                        targetSigner, tid, network, res, updated, committer));
                     }
                     return chunk.getNextChunkLocation(currentCap.rBaseKey,
                             streamSecret, currentCap.getMapKey(), currentCap.bat, hasher)
                             .thenCompose(nextChunkMapKeyAndBat ->
                                     copyAllChunks(true, currentCap.withMapKey(nextChunkMapKeyAndBat.left, nextChunkMapKeyAndBat.right),
-                                            targetSigner, tid, hasher, network, updated, committer));
+                                            targetSigner, tid, hasher, network, res, updated, committer));
                 })
                 .thenCompose(updatedVersion -> {
                     if (! chunk.isDirectory())
                         return CompletableFuture.completedFuture(updatedVersion);
                     return chunk.getDirectChildrenCapabilities(currentCap, updatedVersion, network)
-                            .thenCompose(childCaps -> network.retrieveAllMetadata(childCaps.stream()
-                                            .map(c -> c.cap)
-                                            .collect(Collectors.toList()), updatedVersion)
-                                    .thenCompose(retrieved -> Futures.reduceAll(retrieved.left,
-                                            updatedVersion,
-                                            (v, child) -> copyAllChunks(true, child.capability, child.fileAccess,
-                                                    targetSigner, tid, hasher, network, v, committer),
-                                            (x, y) -> y)));
+                            .thenCompose(childCaps -> {
+                                List<AbsoluteCapability> sameSpace = new ArrayList<>();
+                                for (NamedAbsoluteCapability child : childCaps) {
+                                    if (child.cap.writer.equals(currentCap.writer))
+                                        sameSpace.add(child.cap);
+                                    else
+                                        res.nestedWritingSpaces.add(child.cap);
+                                }
+                                return network.retrieveAllMetadata(sameSpace, updatedVersion)
+                                        .thenCompose(retrieved -> Futures.reduceAll(retrieved.left,
+                                                updatedVersion,
+                                                (v, child) -> copyAllChunks(true, child.capability, child.fileAccess,
+                                                        targetSigner, tid, hasher, network, res, v, committer),
+                                                (x, y) -> y));
+                            });
                 });
     }
 
@@ -2795,6 +2825,7 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                                                           SigningPrivateKeyAndPublicHash targetSigner,
                                                           TransactionId tid,
                                                           NetworkAccess network,
+                                                          MovedSubtree res,
                                                           Snapshot version,
                                                           Committer committer) {
         List<AbsoluteCapability> caps = labels.stream()
@@ -2802,8 +2833,11 @@ public CompletableFuture<Boolean> copyTo(FileWrapper target, UserContext context
                 .collect(Collectors.toList());
         return network.retrieveAllMetadata(caps, version)
                 .thenCompose(retrieved -> Futures.reduceAll(retrieved.left, version,
-                        (v, c) -> network.addPreexistingChunk(c.fileAccess, firstCap.owner,
-                                c.capability.getMapKey(), targetSigner, tid, v, committer),
+                        (v, c) -> {
+                            res.record(c.capability, c.fileAccess);
+                            return network.addPreexistingChunk(c.fileAccess, firstCap.owner,
+                                    c.capability.getMapKey(), targetSigner, tid, v, committer);
+                        },
                         (x, y) -> y));
     }
 


### PR DESCRIPTION
Grant write access by moving the subtree to a new signing key instead of rotating all its keys. The rotation meant downloading, decrypting, changing all keys, re-encrypting and uploading all metadata for the entire subtree. 
Now we just move the champ metadata to the new writer. 