### PR TITLE
Report transfer progress once per MiB

### DIFF
--- a/src/peergos/server/sync/LocalFileSystem.java
+++ b/src/peergos/server/sync/LocalFileSystem.java
@@ -7,6 +7,7 @@ import peergos.server.simulation.FileAsyncReader;
 import peergos.shared.crypto.hash.Hasher;
 import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.user.fs.*;
+import peergos.shared.util.ProgressConsumer;
 import peergos.shared.util.PathUtil;
 import peergos.shared.util.Triple;
 
@@ -170,6 +171,7 @@ public class LocalFileSystem implements SyncFilesystem {
             raf.seek(fileOffset);
             byte[] buf = new byte[4096];
             long done = 0;
+            ProgressConsumer<Long> reporter = SyncFilesystem.perMiB("Downloaded", size, p.toString(), progress);
             while (done < size) {
                 // a paused or removed pair must stop here too, not just on upload
                 if (isCancelled.get())
@@ -177,8 +179,7 @@ public class LocalFileSystem implements SyncFilesystem {
                 int read = fin.readIntoArray(buf, 0, (int) Math.min(buf.length, size - done)).join();
                 raf.write(buf, 0, read);
                 done += read;
-                if (done >= 1024*1024)
-                    progress.accept("Downloaded " + (done/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + p.toString());
+                reporter.accept((long) read);
             }
             if (modificationTime.isPresent()) {
                 long time = modificationTime.get().toInstant(ZoneOffset.UTC).toEpochMilli() / 1000 * 1000;

--- a/src/peergos/server/sync/PairStatus.java
+++ b/src/peergos/server/sync/PairStatus.java
@@ -64,12 +64,19 @@ public class PairStatus {
         persist();
     }
 
+    // A pass clears the error before each folder and sets the state twice, so most of these
+    // calls change nothing. Rewriting the file for them is pure cost.
     public synchronized void setError(String err) {
-        error = err == null || err.isEmpty() ? Optional.empty() : Optional.of(err);
+        Optional<String> newError = err == null || err.isEmpty() ? Optional.empty() : Optional.of(err);
+        if (newError.equals(error))
+            return;
+        error = newError;
         persist();
     }
 
     public synchronized void setStatus(SyncStatus newState) {
+        if (newState == state)
+            return;
         state = newState;
         persist();
     }

--- a/src/peergos/server/sync/PeergosSyncFS.java
+++ b/src/peergos/server/sync/PeergosSyncFS.java
@@ -7,6 +7,7 @@ import peergos.shared.storage.auth.Bat;
 import peergos.shared.storage.auth.BatId;
 import peergos.shared.user.UserContext;
 import peergos.shared.user.fs.*;
+import peergos.shared.util.ProgressConsumer;
 import peergos.shared.user.fs.cryptree.CryptreeNode;
 import peergos.shared.util.Futures;
 import peergos.shared.util.Pair;
@@ -219,14 +220,10 @@ public class PeergosSyncFS implements SyncFilesystem {
                 parentOpt = context.getByPath(root.resolve(p).getParent()).join();
             }
             FileWrapper parent = parentOpt.get();
-            AtomicLong done = new AtomicLong(0);
             parent.uploadFileWithHash(filename, data, size, hash, modificationTime, thumbnail,
                     Optional.of(props),
-                    context.network, context.crypto, isCancelled, x -> {
-                        long total = done.addAndGet(x);
-                        if (total >= 1024*1024)
-                            progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + relPath);
-                    }).join();
+                    context.network, context.crypto, isCancelled,
+                    SyncFilesystem.perMiB("Uploaded", size, relPath, progress)).join();
         } else {
             FileWrapper f = existing.get();
             if (f.isDirty()) {
@@ -237,15 +234,13 @@ public class PeergosSyncFS implements SyncFilesystem {
             }
 
             long end = fileOffset + size;
-            AtomicLong done = new AtomicLong(0);
+            ProgressConsumer<Long> reporter = SyncFilesystem.perMiB("Uploaded", size, relPath, progress);
             f.overwriteSectionJS(data, (int) (fileOffset >>> 32), (int) fileOffset, (int) (end >>> 32), (int) end, modificationTime, context.network, context.crypto, x -> {
                 // this path carries no cancel check of its own, so a resumed upload would
                 // otherwise run to the end after a pause
                 if (isCancelled.get())
                     throw new IllegalStateException("Upload cancelled!");
-                long total = done.addAndGet(x);
-                if (total >= 1024*1024)
-                    progress.accept("Uploaded " + (total/1024/1024) + " / " + (size / 1024/1024) + " MiB of " + relPath);
+                reporter.accept(x);
             }).join();
         }
         return modificationTime;

--- a/src/peergos/server/sync/SyncFilesystem.java
+++ b/src/peergos/server/sync/SyncFilesystem.java
@@ -2,6 +2,7 @@ package peergos.server.sync;
 
 import peergos.shared.crypto.hash.PublicKeyHash;
 import peergos.shared.user.fs.*;
+import peergos.shared.util.ProgressConsumer;
 import peergos.shared.util.Triple;
 
 import java.io.IOException;
@@ -10,11 +11,25 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public interface SyncFilesystem {
+
+    /** Progress for a transfer, reported once per MiB. Callers are called per chunk or per
+     *  read, and a repeated figure costs a log line and a status file write for nothing. */
+    static ProgressConsumer<Long> perMiB(String verb, long size, String path, Consumer<String> progress) {
+        AtomicLong done = new AtomicLong(0);
+        AtomicLong reported = new AtomicLong(0);
+        long total = size / 1024 / 1024;
+        return delta -> {
+            long mib = done.addAndGet(delta) / 1024 / 1024;
+            if (mib > 0 && reported.getAndSet(mib) != mib)
+                progress.accept(verb + " " + mib + " / " + total + " MiB of " + path);
+        };
+    }
 
     long totalSpace() throws IOException;
 

--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -13,9 +13,11 @@ import peergos.shared.io.ipfs.Cid;
 import peergos.shared.io.ipfs.Multihash;
 import peergos.shared.user.CommittedWriterData;
 import peergos.shared.user.Snapshot;
+import peergos.shared.user.fs.AsyncReader;
 import peergos.shared.user.fs.Chunk;
 import peergos.shared.user.fs.ChunkHashList;
 import peergos.shared.user.fs.HashTree;
+import peergos.shared.user.fs.ResumeUploadProps;
 import peergos.shared.user.fs.RootHash;
 import peergos.shared.util.Pair;
 import peergos.shared.util.PathUtil;
@@ -989,5 +991,61 @@ public class SyncTests {
         PairStatus old = new PairStatus(peergosDir, hash);
         Assert.assertEquals(SyncStatus.SYNCED, old.getStatus());
         Assert.assertEquals("Dir sync took 3s", old.getMessage());
+    }
+
+    @Test
+    public void progressIsReportedOncePerMiB() throws Exception {
+        // The local filesystem reads in 4 KiB, and each read used to report progress: a message
+        // every 4 KiB says the same thing 255 times out of 256, and every one of them is logged
+        // and written to the pair's status file.
+        int fileSize = 5 * 1024 * 1024;
+        byte[] data = new byte[fileSize];
+        new Random(42).nextBytes(data);
+        Path base = Files.createTempDirectory("peergos-sync");
+        LocalFileSystem fs = new LocalFileSystem(base, Main.initCrypto().hasher);
+
+        List<String> reported = new ArrayList<>();
+        fs.setBytes(PathUtil.get("big.bin"), 0, AsyncReader.build(data), fileSize, Optional.empty(),
+                Optional.of(LocalDateTime.now()), Optional.empty(), ResumeUploadProps.random(crypto), () -> false, reported::add);
+
+        Assert.assertEquals(fileSize, Files.size(base.resolve("big.bin")));
+        Assert.assertEquals("one message per MiB", 5, reported.size());
+        Assert.assertEquals("no message repeats the previous one",
+                reported.size(), new LinkedHashSet<>(reported).size());
+        Assert.assertTrue(reported.get(0), reported.get(0).startsWith("Downloaded 1 / 5 MiB of "));
+        Assert.assertTrue(reported.get(4), reported.get(4).startsWith("Downloaded 5 / 5 MiB of "));
+    }
+
+    @Test
+    public void redundantStatusWritesAreSkipped() throws Exception {
+        // A pass clears the error before each folder and sets the state twice, so most of those
+        // calls say what the file already says. Each one used to rewrite it.
+        Path dir = Files.createTempDirectory("peergos-sync");
+        Files.createDirectories(PairLogger.logDir(dir));
+        PairStatus status = new PairStatus(dir, "testpair");
+        Path file = PairStatus.statusPath(dir, "testpair");
+
+        status.setStatus("Checking files on this device");
+        status.setStatus(SyncStatus.SYNCING);
+        // the file is replaced by a rename, so a write shows up as a new file rather than as
+        // different content: a redundant one would write the same bytes back
+        Object beforeWrites = fileKey(file);
+
+        status.setError(null);
+        status.setStatus(SyncStatus.SYNCING);
+        Assert.assertEquals("nothing changed, so nothing was written", beforeWrites, fileKey(file));
+
+        status.setStatus(SyncStatus.SYNCED);
+        Assert.assertNotEquals("a real change still reaches the file", beforeWrites, fileKey(file));
+
+        // the message carries the clock the view shows, so repeating it is still worth writing
+        Object beforeRepeat = fileKey(file);
+        status.setStatus("Dir sync took 2s");
+        status.setStatus("Dir sync took 2s");
+        Assert.assertNotEquals("the same message still restamps the time", beforeRepeat, fileKey(file));
+    }
+
+    private static Object fileKey(Path p) throws IOException {
+        return Files.readAttributes(p, java.nio.file.attribute.BasicFileAttributes.class).fileKey();
     }
 }


### PR DESCRIPTION
`LocalFileSystem.setBytes` reads in 4 KiB and reported progress on every read past the
first MiB, so a 5 MiB download emitted 1025 messages where 5 carry information. The upload
paths in `PeergosSyncFS` do the same per chunk, at about two messages per MiB.

Every one of those messages is appended to the pair log and written to the pair's status
file, which is a write plus an atomic rename. Measured on an Android device, one status
write costs ~3.7 ms, so a 100 MiB download spends ~95 s writing status alone, on the
download loop's critical path, and churns the 1 MiB pair log hard enough to lose its
history.

- one `SyncFilesystem.perMiB(verb, size, path, progress)` now decides when a figure is
  worth reporting, replacing three copies of the rule and of the message string
- `PairStatus.setError` and `setStatus(SyncStatus)` skip the write when the value is
  unchanged; a pass clears an already-clear error and re-sets the same state each time
  round. The message setter still writes every call, because the timestamp it stamps is
  what the view shows as "at <time>"

Tests: `progressIsReportedOncePerMiB` fails on master with 1025 messages for a 5 MiB file;
`redundantStatusWritesAreSkipped` compares the status file's inode, since a redundant write
writes back identical bytes. SyncTests, SyncRunnerTests and SyncWatcherTests pass.

Verified end to end on desktop: a 6 MiB file through a real sync pair logs exactly six
progress lines, and a 12 MiB upload on Android logs twelve, against 2.05 per MiB before.