### PR TITLE
Make the status-write test portable

### DIFF
--- a/src/peergos/server/tests/SyncTests.java
+++ b/src/peergos/server/tests/SyncTests.java
@@ -1027,25 +1027,24 @@ public class SyncTests {
 
         status.setStatus("Checking files on this device");
         status.setStatus(SyncStatus.SYNCING);
-        // the file is replaced by a rename, so a write shows up as a new file rather than as
-        // different content: a redundant one would write the same bytes back
-        Object beforeWrites = fileKey(file);
+        Assert.assertTrue(Files.exists(file));
 
+        // a write recreates the file, so whether it comes back is the check: a redundant one
+        // would write the same bytes, and file times and keys are not portable enough to tell
+        Files.delete(file);
         status.setError(null);
         status.setStatus(SyncStatus.SYNCING);
-        Assert.assertEquals("nothing changed, so nothing was written", beforeWrites, fileKey(file));
+        Assert.assertFalse("nothing changed, so nothing was written", Files.exists(file));
 
         status.setStatus(SyncStatus.SYNCED);
-        Assert.assertNotEquals("a real change still reaches the file", beforeWrites, fileKey(file));
+        Assert.assertTrue("a real change still reaches the file", Files.exists(file));
 
-        // the message carries the clock the view shows, so repeating it is still worth writing
-        Object beforeRepeat = fileKey(file);
+        // the message carries the clock the view shows next to it, so repeating it is still
+        // worth a write even though the text has not changed
+        Files.delete(file);
         status.setStatus("Dir sync took 2s");
+        Files.delete(file);
         status.setStatus("Dir sync took 2s");
-        Assert.assertNotEquals("the same message still restamps the time", beforeRepeat, fileKey(file));
-    }
-
-    private static Object fileKey(Path p) throws IOException {
-        return Files.readAttributes(p, java.nio.file.attribute.BasicFileAttributes.class).fileKey();
+        Assert.assertTrue("the same message still restamps the time", Files.exists(file));
     }
 }


### PR DESCRIPTION
redundantStatusWritesAreSkipped detected a rewrite by comparing the status file's
fileKey. That is null on Windows, so asserting a real change did reach the file
compared null with null and failed. On the ubuntu runner the write-then-rename got
the same inode back, so the same style of check saw no change after a real write.

Delete the file and check whether the call brings it back instead: a write recreates
it, a skipped one does not. No file times or identity involved, so it reads the same
on every platform.