### PR TITLE
Fix a failed write leaving the async lock queue permanently incomplete

### DIFF
--- a/src/peergos/server/tests/AsyncLockTests.java
+++ b/src/peergos/server/tests/AsyncLockTests.java
@@ -5,6 +5,7 @@ import peergos.shared.util.*;
 
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.*;
 
@@ -141,6 +142,96 @@ public class AsyncLockTests {
     }
 
 
+
+    @Test
+    public void aFailedWriteDoesntPoisonTheWriteQueue() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(7));
+
+        CompletableFuture<Integer> failed = lock.runWithLock(x -> Futures.errored(new RuntimeException("boom")));
+        assertTrue(failed.isCompletedExceptionally());
+
+        CompletableFuture<Integer> next = lock.runWithLock(x -> Futures.of(x + 1));
+        assertTrue("the write queue is still usable after a failed write", next.isDone());
+        assertEquals(8, (int) next.join());
+    }
+
+    @Test
+    public void aFailedInitialValueDoesntHangTheWriteQueue() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.errored(new RuntimeException("boom")));
+
+        CompletableFuture<Integer> failed = lock.runWithLock(x -> Futures.of(x));
+        assertTrue(failed.isCompletedExceptionally());
+
+        // with no updater there is no fresh value to recover, but the queue must still terminate
+        // rather than be left permanently incomplete
+        CompletableFuture<Integer> next = lock.runWithLock(x -> Futures.of(x));
+        assertTrue("the write queue terminates rather than hanging", next.isDone());
+        assertTrue("and terminates with the failure, not a null value", next.isCompletedExceptionally());
+    }
+
+    @Test
+    public void anUpdaterThatFailsDoesntHangTheWriteQueue() {
+        for (Supplier<CompletableFuture<Integer>> broken : List.<Supplier<CompletableFuture<Integer>>>of(
+                () -> Futures.errored(new RuntimeException("updater failed")),
+                () -> { throw new RuntimeException("updater threw"); },
+                () -> null)) {
+            AsyncLock<Integer> lock = new AsyncLock<>(Futures.of(7));
+
+            CompletableFuture<Integer> failed = lock.runWithLock(x -> Futures.errored(new RuntimeException("boom")), broken);
+            assertTrue(failed.isCompletedExceptionally());
+
+            CompletableFuture<Integer> next = lock.runWithLock(x -> Futures.of(x + 1), broken);
+            assertTrue("the write queue is still usable", next.isDone());
+        }
+    }
+
+    @Test
+    public void anUpdaterThatFailsDoesntHangAQueuedWrite() {
+        for (Supplier<CompletableFuture<Integer>> broken : List.<Supplier<CompletableFuture<Integer>>>of(
+                () -> Futures.errored(new RuntimeException("updater failed")),
+                () -> { throw new RuntimeException("updater threw"); },
+                () -> null)) {
+            AsyncLock<Integer> lock = new AsyncLock<>(Futures.errored(new RuntimeException("boom")));
+
+            CompletableFuture<Integer> failed = lock.runWithLock(x -> Futures.of(x), broken);
+            assertTrue(failed.isCompletedExceptionally());
+
+            CompletableFuture<Integer> next = lock.runWithLock(x -> Futures.of(x), broken);
+            assertTrue("the write queue is still usable", next.isDone());
+        }
+    }
+
+    @Test
+    public void aFailedInitialValueIsRecoveredForWrites() {
+        AsyncLock<Integer> lock = new AsyncLock<>(Futures.errored(new RuntimeException("boom")));
+
+        CompletableFuture<Integer> failed = lock.runWithLock(x -> Futures.of(x), () -> Futures.of(5));
+        assertTrue(failed.isCompletedExceptionally());
+
+        List<Integer> startedFrom = new ArrayList<>();
+        CompletableFuture<Integer> next = lock.runWithLock(x -> {
+            startedFrom.add(x);
+            return Futures.of(x);
+        }, () -> Futures.of(5));
+        assertEquals(Arrays.asList(5), startedFrom);
+        assertEquals(5, (int) next.join());
+    }
+
+    @Test
+    public void anUpdaterThatFailsDoesntHangTheReadQueue() {
+        for (Supplier<CompletableFuture<Integer>> broken : List.<Supplier<CompletableFuture<Integer>>>of(
+                () -> Futures.errored(new RuntimeException("updater failed")),
+                () -> { throw new RuntimeException("updater threw"); },
+                () -> null)) {
+            AsyncLock<Integer> lock = new AsyncLock<>(Futures.errored(new RuntimeException("boom")));
+
+            CompletableFuture<Integer> failed = lock.runWithReadLock(x -> Futures.of(x), broken);
+            assertTrue(failed.isCompletedExceptionally());
+
+            CompletableFuture<Integer> next = lock.runWithReadLock(x -> Futures.of(x), broken);
+            assertTrue("the read queue is still usable", next.isDone());
+        }
+    }
 
     @Test
     public void writesAreStillSerialised() {

--- a/src/peergos/shared/user/WriteSynchronizer.java
+++ b/src/peergos/shared/user/WriteSynchronizer.java
@@ -201,7 +201,8 @@ public class WriteSynchronizer {
         return pending.computeIfAbsent(
                         new Pair<>(owner, writer),
                         p -> new AsyncLock<>(getWriterData(owner, p.right))
-                ).runWithLock(v -> CompletableFuture.completedFuture(v.withVersion(writer, value.get(writer))))
+                ).runWithLock(v -> CompletableFuture.completedFuture(v.withVersion(writer, value.get(writer))),
+                        () -> getWriterData(owner, writer))
                 .thenApply(x -> true);
     }
 

--- a/src/peergos/shared/util/AsyncLock.java
+++ b/src/peergos/shared/util/AsyncLock.java
@@ -25,14 +25,23 @@ public class AsyncLock<T> {
         return queueHead.isDone();
     }
 
+    /** Recovers from a failure by retaining the previous value, so this is only usable where that is
+     *  still correct afterwards. Anything backed by the network should supply an updater that
+     *  re-retrieves the value instead.
+     */
     public synchronized CompletableFuture<T> runWithLock(Function<T, CompletionStage<T>> processor) {
-        return runWithLock(processor, () -> queueHead);
+        // capture the previous head: a supplier reading the field would return this call's head, or a
+        // later one that depends on it, and a future can't be completed from a callback on itself
+        CompletableFuture<T> previous = queueHead;
+        return runWithLock(processor, () -> previous);
     }
 
-    /**
+    /** The head installed here is always completed, however the update fails, because every later
+     *  operation on this lock queues behind it.
      *
      * @param processor
-     * @param updater a method to get a fresh value which is called if updater completes exceptionally
+     * @param updater a method to get a fresh value, called if the processor fails, or if the operation
+     *                this one queued behind did
      * @return A future completed with the result from a computation, or exceptionally completed on error
      */
     public synchronized CompletableFuture<T> runWithLock(Function<T, CompletionStage<T>> processor,
@@ -49,7 +58,7 @@ public class AsyncLock<T> {
                     return result.complete(res);
                 })
                 .exceptionally(t -> {
-                    updater.get()
+                    fresh(updater)
                             .thenApply(res -> {
                                 newHead.complete(res);
                                 return result.completeExceptionally(t);
@@ -65,13 +74,25 @@ public class AsyncLock<T> {
                     // The previous queueHead failed - use updater to recover
                     // so subsequent operations aren't permanently poisoned
                     result.completeExceptionally(t);
-                    updater.get()
+                    fresh(updater)
                             .thenApply(newHead::complete)
                             .exceptionally(e -> newHead.completeExceptionally(e));
                     return true;
                 });
 
         return result;
+    }
+
+    /** An updater that throws, or hands back nothing, is a failed recovery rather than a reason to
+     *  leave the queue head incomplete.
+     */
+    private CompletableFuture<T> fresh(Supplier<CompletableFuture<T>> updater) {
+        try {
+            CompletableFuture<T> value = updater.get();
+            return value != null ? value : Futures.errored(new IllegalStateException("No value from updater"));
+        } catch (Throwable t) {
+            return Futures.errored(t);
+        }
     }
 
     /** Run a read only task which never waits for an in-flight write. Read only tasks are still
@@ -101,7 +122,7 @@ public class AsyncLock<T> {
                 .exceptionally(t -> {
                     // The previous readHead failed - use updater to recover
                     result.completeExceptionally(t);
-                    updater.get()
+                    fresh(updater)
                             .thenApply(newHead::complete)
                             .exceptionally(e -> newHead.completeExceptionally(e));
                     return true;


### PR DESCRIPTION
## Summary
`AsyncLock.runWithLock(processor)` defaulted its recovery supplier to `() -> queueHead`. The field is read when the supplier *runs*, by which point it is the head this call just installed - so the failure path registered a callback on the very future it was trying to complete. It never fired, the head was left incomplete, and every later write for that `(owner, writer)` waited on it forever with no timeout.

Reads use a separate queue and keep working, so the symptom is one folder silently no longer saving while browsing looks fine, until a restart.

- `WriteSynchronizer.updateWriterState` now passes a real `() -> getWriterData(owner, writer)` updater, matching its six sibling call sites - it was the only production caller of the single-arg form.
- The single-arg overload captures the previous head, so its supplier can no longer return the head being installed.
- `updater.get()` is now called through a guard, so an updater that throws or returns null is a failed recovery rather than a reason to leave the head incomplete. Applied to the read path too, which had the identical shape.
- Corrected the `@param updater` javadoc, which described itself ("called if updater completes exceptionally") and plausibly licensed the original default.

## Testing
Six new tests in `AsyncLockTests`, covering a failed write, a failed initial value, and an updater that fails, throws or returns null, on both the write and read queues. Each was confirmed to fail before the fix and pass after. `AsyncLockTests` already contained `aFailedInitialValueIsRecoveredForReads` - the exact read-side mirror of this bug - which passes only because it supplies a real updater; there was no write-side equivalent.

Full suite green: 781 tests, 0 failures, 0 errors.