### PR TITLE
Stop writing sync pair secret links world readable

### DIFF
--- a/src/peergos/server/net/SyncConfigHandler.java
+++ b/src/peergos/server/net/SyncConfigHandler.java
@@ -77,17 +77,30 @@ public class SyncConfigHandler implements HttpHandler {
     }
 
     private synchronized void saveConfigToFile(SyncConfig config) {
-        byte[] bytes = org.peergos.util.JSONParser.toString(config.toJson()).getBytes(StandardCharsets.UTF_8);
         try {
-            // this file holds every sync pair, and a crash part way through writing it would
-            // leave it truncated, so write beside it and swap it in
-            Path target = peergosDir.resolve(SYNC_CONFIG_FILENAME);
-            Path tmp = target.resolveSibling(SYNC_CONFIG_FILENAME + ".tmp");
-            Files.write(tmp, bytes);
-            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            writeConfig(peergosDir, org.peergos.util.JSONParser.toString(config.toJson())
+                    .getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /** Every pair's secret link is a capability, so this goes through a temp file, which createTempFile
+     *  creates readable only by its owner, rather than writing the target under the umask. Swapping it
+     *  in is atomic, so a crash part way through can't truncate the config that is already there.
+     */
+    public static void writeConfig(Path peergosDir, byte[] bytes) throws IOException {
+        Path tmp = Files.createTempFile(peergosDir, SYNC_CONFIG_FILENAME, ".tmp");
+        try {
+            Files.write(tmp, bytes);
+            Files.move(tmp, peergosDir.resolve(SYNC_CONFIG_FILENAME),
+                    StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } finally {
+            // a failed swap must not leave the links in a file nothing ever cleans up
+            Files.deleteIfExists(tmp);
+        }
+        // the superseded pre-json config holds the same links, and was written under the umask
+        Files.deleteIfExists(peergosDir.resolve(OLD_SYNC_CONFIG_FILENAME));
     }
 
     private synchronized SyncConfig getUpdatedArgs() {

--- a/src/peergos/server/tests/SyncConfigWriteTests.java
+++ b/src/peergos/server/tests/SyncConfigWriteTests.java
@@ -1,0 +1,60 @@
+package peergos.server.tests;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import peergos.server.net.SyncConfigHandler;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** The sync config holds a secret link per pair, so it must never be written readable by anyone else. */
+public class SyncConfigWriteTests {
+
+    private static boolean posix(Path dir) {
+        return dir.getFileSystem().supportedFileAttributeViews().contains("posix");
+    }
+
+    private static List<String> contents(Path dir) throws Exception {
+        try (Stream<Path> kids = Files.list(dir)) {
+            return kids.map(p -> p.getFileName().toString()).sorted().collect(Collectors.toList());
+        }
+    }
+
+    @Test
+    public void configIsOwnerOnlyAndLeavesNothingBehind() throws Exception {
+        Path dir = Files.createTempDirectory("peergos-sync-config");
+        Assume.assumeTrue(posix(dir));
+        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxr-xr-x"));
+        // a config from before this was fixed, to pin the repair on upgrade
+        Path target = dir.resolve(SyncConfigHandler.SYNC_CONFIG_FILENAME);
+        Files.write(target, "{}".getBytes(StandardCharsets.UTF_8));
+        Files.setPosixFilePermissions(target, PosixFilePermissions.fromString("rw-r--r--"));
+
+        byte[] payload = "{\"pairs\":[]}".getBytes(StandardCharsets.UTF_8);
+        SyncConfigHandler.writeConfig(dir, payload);
+
+        Assert.assertEquals("rw-------", PosixFilePermissions.toString(Files.getPosixFilePermissions(target)));
+        Assert.assertArrayEquals("the config survives the swap", payload, Files.readAllBytes(target));
+        Assert.assertEquals("no temp file is left behind",
+                List.of(SyncConfigHandler.SYNC_CONFIG_FILENAME), contents(dir));
+    }
+
+    /** The pre-json config was written under the umask and holds the same links, so it can't be left there. */
+    @Test
+    public void theSupersededConfigIsRemoved() throws Exception {
+        Path dir = Files.createTempDirectory("peergos-sync-config");
+        Path old = dir.resolve(SyncConfigHandler.OLD_SYNC_CONFIG_FILENAME);
+        Files.write(old, "links = secretlink\n".getBytes(StandardCharsets.UTF_8));
+
+        SyncConfigHandler.writeConfig(dir, "{\"pairs\":[]}".getBytes(StandardCharsets.UTF_8));
+
+        Assert.assertFalse(Files.exists(old));
+        Assert.assertEquals(List.of(SyncConfigHandler.SYNC_CONFIG_FILENAME), contents(dir));
+    }
+}


### PR DESCRIPTION
## Summary
`~/.peergos/sync-config.json` holds one secret link per sync pair - a capability including the AES base key, and the write key for a writable pair. It was written with `Files.write` under the umask, landing as `rw-r--r--`, so any local user could read read/write capabilities to every synced folder.

- The config is now written through `Files.createTempFile`, which creates it readable only by its owner, and swapped in atomically as before. `ATOMIC_MOVE` keeps the temp file's permissions, so an existing exposed config is repaired on the next start - the handler's constructor rewrites it unconditionally, so no user action is needed.
- The superseded pre-json `sync-config` is deleted. It holds the same links and was also written under the umask, so leaving it behind kept the exposure open on upgraded installs.
- The temp file is removed in a `finally`, matching the sibling `MountConfigHandler`. Previously a failed swap left the links in a file nothing ever cleans up.
- Using a unique temp name also fixes a real corruption hazard: with the old fixed `sync-config.json.tmp`, two processes could interleave writes into the same temp path and then atomically install a mixed-content config.

`MountConfigHandler` is untouched - `Files.createTempFile` already applies owner-only permissions on POSIX, so no shared helper was needed.

## Testing
Two new tests in `SyncConfigWriteTests`, asserting the written config is `rw-------`, that its contents survive the swap, that no temp file is left behind, and that the superseded config is removed. Both fail against the previous behaviour.

Full suite green: 781 tests, 0 failures, 0 errors.