### PR TITLE
Only let a verified second factor satisfy a login challenge

### DIFF
--- a/src/peergos/server/login/JdbcAccount.java
+++ b/src/peergos/server/login/JdbcAccount.java
@@ -327,6 +327,12 @@ public class JdbcAccount implements LoginCache {
         }
         MultiFactorAuthResponse mfaAuth = mfa.get();
         byte[] credentialId = mfaAuth.credentialId;
+        // only an enabled factor can satisfy a challenge - an enrolment that was never verified isn't
+        // listed in 2fa settings, so it can't be seen or revoked there either. Same wording as an
+        // unknown credential, both so they can't be told apart, and because a revoked mount factor is
+        // recognised by this message
+        if (enabled.stream().noneMatch(m -> Arrays.equals(m.credentialId, credentialId)))
+            throw new IllegalStateException("Unknown credential id for user " + username);
         if (mfaAuth.response.isB()) {
             MultiFactorAuthMethod.Type type = getType(username, credentialId);
             if (type != MultiFactorAuthMethod.Type.WEBAUTHN)

--- a/src/peergos/server/tests/JdbcAccountTests.java
+++ b/src/peergos/server/tests/JdbcAccountTests.java
@@ -1,5 +1,6 @@
 package peergos.server.tests;
 
+import com.eatthepath.otp.*;
 import com.webauthn4j.data.client.*;
 import org.junit.*;
 import peergos.server.*;
@@ -12,9 +13,13 @@ import peergos.shared.crypto.asymmetric.*;
 import peergos.shared.crypto.hash.*;
 import peergos.shared.io.ipfs.*;
 import peergos.shared.crypto.symmetric.*;
+import peergos.shared.login.mfa.*;
 import peergos.shared.user.*;
+import peergos.shared.util.*;
 
+import javax.crypto.spec.*;
 import java.sql.*;
+import java.time.*;
 import java.util.*;
 
 /** The login table has to stay usable through a password change that is interrupted at any point,
@@ -159,5 +164,62 @@ public class JdbcAccountTests {
         stage(username, reader());
 
         Assert.assertFalse(canLogin(username, reader()));
+    }
+
+    private static String code(TimeBasedOneTimePasswordGenerator totp, TotpKey key) throws Exception {
+        return totp.generateOneTimePasswordString(new SecretKeySpec(key.key, TotpKey.ALGORITHM), Instant.now());
+    }
+
+    /** An enrolment that was started and abandoned is hidden from 2fa settings, so it can be neither
+     *  seen nor revoked. It must not be usable to satisfy a login challenge either.
+     */
+    @Test
+    public void anUnverifiedSecondFactorCantSatisfyMfa() throws Exception {
+        String username = "alice";
+        PublicSigningKey reader = reader();
+        db.setLoginData(loginFor(username, reader)).join();
+        TimeBasedOneTimePasswordGenerator totp =
+                new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30L), 6, TotpKey.ALGORITHM);
+
+        // a verified factor, so that logging in requires a second factor at all
+        TotpKey active = db.addTotpFactor(username).join();
+        db.enableTotpFactor(username, active.credentialId, code(totp, active)).join();
+
+        // a second enrolment whose QR was displayed but never verified
+        TotpKey abandoned = db.addTotpFactor(username).join();
+        Assert.assertTrue("an unverified factor isn't listed", db.getSecondAuthMethods(username).join().stream()
+                .noneMatch(m -> Arrays.equals(m.credentialId, abandoned.credentialId)));
+
+        try {
+            db.getEntryData(username, reader, Optional.of(new MultiFactorAuthResponse(abandoned.credentialId,
+                    Either.a(code(totp, abandoned))))).join();
+            Assert.fail("an unverified second factor satisfied the login challenge");
+        } catch (IllegalStateException e) {
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("Unknown credential id"));
+        }
+
+        // the verified one still works
+        Assert.assertTrue(db.getEntryData(username, reader, Optional.of(new MultiFactorAuthResponse(active.credentialId,
+                Either.a(code(totp, active))))).join().isA());
+    }
+
+    /** A mount's credential is never offered in a challenge, because it isn't interactive, but it
+     *  still has to be able to satisfy one.
+     */
+    @Test
+    public void anEnabledMountFactorCanSatisfyMfa() throws Exception {
+        String username = "alice";
+        PublicSigningKey reader = reader();
+        db.setLoginData(loginFor(username, reader)).join();
+        TimeBasedOneTimePasswordGenerator totp =
+                new TimeBasedOneTimePasswordGenerator(Duration.ofSeconds(30L), 6, TotpKey.ALGORITHM);
+
+        TotpKey user = db.addTotpFactor(username).join();
+        db.enableTotpFactor(username, user.credentialId, code(totp, user)).join();
+        TotpKey mount = db.addMountFactor(username, "a device").join();
+        db.enableMountFactor(username, mount.credentialId, code(totp, mount)).join();
+
+        Assert.assertTrue(db.getEntryData(username, reader, Optional.of(new MultiFactorAuthResponse(mount.credentialId,
+                Either.a(code(totp, mount))))).join().isA());
     }
 }


### PR DESCRIPTION
## Summary
The login path looked a supplied second factor up with `GET_TYPE`/`GET_AUTH`, which key on `(username, credid)` and ignore the `enabled` column, while `getSecondAuthMethods` hides unverified TOTP and MOUNT rows. So an enrolment that was started and abandoned - its QR displayed but never verified - was a working second factor that the user could neither see in 2FA settings nor revoke.

`getEntryData` now rejects any response whose credential is not among the enabled methods it has already computed, so no extra query is needed.

The gate is deliberately in the login path rather than in `getType`, which is shared with `enableCodeFactor` - enrolment operates on a not-yet-enabled row by definition, so filtering there would break it.

It reuses the existing `"Unknown credential id"` wording on purpose: `MountConfigHandler.isCredentialFailure` matches that string to tell a revoked mount factor from a transient network error, and it also means an unknown credential and an unverified one can't be told apart.

## Testing
Two new tests in `JdbcAccountTests`. The first enrols a verified factor plus an abandoned one and supplies a genuinely correct TOTP code for the abandoned factor, so it would pass for the wrong reason if the code were simply invalid - it fails without the fix with "an unverified second factor satisfied the login challenge". The second pins that an enabled MOUNT credential still satisfies a challenge, which it must, even though non-interactive factors are never offered in one.

Also re-ran the MFA integration tests covering ordinary TOTP, mount factors, backup codes and revocation. Full suite green: 781 tests, 0 failures, 0 errors.

## Note
This closes the security half. The user still can't see or revoke an abandoned enrolment, since `getSecondAuthMethods` continues to hide those rows - and such rows still count toward `MAX_MFA`, so it's possible to hit "Too many multi factor auth methods" over rows that aren't listed. Happy to follow up separately if you'd like that surfaced in settings instead.