### PR TITLE
Show calendar entries shared with the user over CalDAV, read-only

### DIFF
--- a/src/peergos/server/tests/CalDavTests.java
+++ b/src/peergos/server/tests/CalDavTests.java
@@ -414,6 +414,65 @@ public class CalDavTests {
         return client.send(request.build(), HttpResponse.BodyHandlers.ofString());
     }
 
+    /** An entry another user owns reaches the phone, and stays theirs to change. */
+    @Test
+    public void showsEntriesSharedWithTheUserAndRefusesToChangeThem() throws Exception {
+        String username = "caldav-shared" + Math.abs(random.nextInt() % 1_000_000);
+        String password = "testpassword";
+        UserContext context = PeergosNetworkUtils.ensureSignedUp(username, password, network, crypto);
+
+        App calendar = App.init(context, "calendar").join();
+        write(calendar, "App.config",
+                "{\"calendars\":[{\"name\":\"Work\",\"directory\":\"work\",\"color\":\"#ff0000\"}]}");
+        write(calendar, "work/calendar.inf", "{\"name\":\"Work\",\"color\":\"#ff0000\"}");
+        // What the web app keeps when somebody shares one entry: their event, with a pointer
+        // back to the file it came from.
+        String pointer = "X-PEERGOS-SRC-OWNER:alice\r\n"
+                + "X-PEERGOS-SRC-DIR:default\r\n"
+                + "X-PEERGOS-SRC-UID:evt-shared\r\n"
+                + "X-PEERGOS-SRC-PATH:2024/9\r\n"
+                + "X-PEERGOS-SRC-MODIFIED:2024-09-15T09:00\r\n";
+        String snapshot = event("evt-shared", "20240915T090000Z", "20240915T100000Z", pointer);
+        write(calendar, "work/shared/alice-evt-shared.ics", snapshot);
+
+        int port = TestPorts.getPort();
+        Server server = WebdavServer.startNonBlocking(port, WEBDAV_USER, WEBDAV_PASSWORD,
+                username, password, "http://localhost:" + args.getInt("port"), "basic", MountConfig.disabled());
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            String base = "http://localhost:" + port;
+            String auth = "Basic " + Base64.getEncoder()
+                    .encodeToString((WEBDAV_USER + ":" + WEBDAV_PASSWORD).getBytes());
+            String work = base + "/dav/calendars/" + username + "/work/";
+
+            HttpResponse<String> listing = propfind(client, auth, work, "1",
+                    "<?xml version=\"1.0\"?><D:propfind xmlns:D=\"DAV:\"><D:prop>"
+                            + "<D:getetag/></D:prop></D:propfind>");
+            Assert.assertEquals(207, listing.statusCode());
+            Assert.assertTrue("an entry shared with the user belongs in the listing",
+                    listing.body().contains("alice-evt-shared.ics"));
+
+            HttpResponse<String> fetched = send(client, auth, "GET",
+                    work + "alice-evt-shared.ics", null, null);
+            Assert.assertEquals(200, fetched.statusCode());
+            Assert.assertTrue("and reads back as the owner's event",
+                    fetched.body().contains("UID:evt-shared"));
+
+            // Changing it here would either move it out of shared/, losing the link to its
+            // owner, or keep an edit they never see. Refused, and its file left alone.
+            HttpResponse<String> refused = put(client, auth, work + "alice-evt-shared.ics",
+                    event("evt-shared", "20241015T090000Z", "20241015T100000Z", pointer), null);
+            Assert.assertEquals(403, refused.statusCode());
+            UserContext verifier = verifier(username, password);
+            Assert.assertTrue("the snapshot must still be where it was",
+                    exists(verifier, username, "work/shared/alice-evt-shared.ics"));
+            Assert.assertFalse("and must not have been filed as the user's own",
+                    exists(verifier, username, "work/2024/10/alice-evt-shared.ics"));
+        } finally {
+            server.stop();
+        }
+    }
+
     @Test
     public void syncCollectionReportsOnlyWhatChanged() throws Exception {
         String username = "caldav-sync" + Math.abs(random.nextInt() % 1_000_000);

--- a/src/peergos/server/webdav/caldav/CalendarStore.java
+++ b/src/peergos/server/webdav/caldav/CalendarStore.java
@@ -32,6 +32,13 @@ public class CalendarStore extends AppDataStore {
     public static final String CALENDAR_INFO_FILENAME = "calendar.inf";
     public static final String RECURRING_DIR = "recurring";
     public static final String TASKS_DIR = "tasks";
+    /** Entries another user owns, kept by the web app as a snapshot of their file beside a
+     *  pointer back to it. Listed like any other, so they reach a phone the same way the
+     *  user's own entries do. */
+    public static final String SHARED_DIR = "shared";
+    /** The first line of that pointer, which is what tells one of those snapshots apart
+     *  from an entry of the user's own. */
+    private static final String SHARED_MARKER = "X-PEERGOS-SRC-OWNER:";
     public static final String ICS_SUFFIX = ".ics";
     public static final String TASK_COMPONENT = "VTODO";
 
@@ -46,7 +53,8 @@ public class CalendarStore extends AppDataStore {
         for (FileWrapper shard : children(collectionPath(directory))) {
             if (! shard.isDirectory())
                 continue;
-            if (shard.getName().equals(RECURRING_DIR) || shard.getName().equals(TASKS_DIR)) {
+            if (shard.getName().equals(RECURRING_DIR) || shard.getName().equals(TASKS_DIR)
+                || shard.getName().equals(SHARED_DIR)) {
                 collect(shard, shard.getName(), objects);
             } else if (isYear(shard.getName())) {
                 for (FileWrapper month : children(shard)) {
@@ -60,7 +68,15 @@ public class CalendarStore extends AppDataStore {
 
     @Override
     protected Optional<String> shardFor(byte[] content) {
-        return shardFor(ICal.summarise(new String(content, StandardCharsets.UTF_8)));
+        String ics = new String(content, StandardCharsets.UTF_8);
+        // An entry another user owns is theirs to change, and nothing here can reach them.
+        // Filing it by its date would move it out of shared/, losing the pointer to their
+        // file and leaving a copy that quietly stops matching it; keeping it where it is
+        // would store an edit they never see and the app replaces the next time it looks.
+        // So it is listed and readable, and a write of one is refused.
+        if (ics.contains(SHARED_MARKER))
+            return Optional.empty();
+        return shardFor(ICal.summarise(ics));
     }
 
     /**


### PR DESCRIPTION
The web calendar is gaining live shared entries: when somebody shares a single
event with you, your calendar keeps a snapshot of their file beside a pointer
back to it, under `<calendar>/shared/`, so their later changes reach you instead
of your copy quietly drifting. The pointer is written into the entry as
`X-PEERGOS-SRC-*` properties, which the rest of the iCalendar world ignores.

This teaches the CalDAV bridge about that directory, so those entries reach a
phone or any CalDAV client the same way the user's own entries do. Without it
they exist only in the web app.

They are listed and readable, and a write of one is refused with 403
`valid-calendar-data`.

Refusing is the point rather than an omission. `putObject` files an object by
what its content says and removes the old file when the shard changes, so a
client editing one of these would delete the snapshot, write an ordinary copy
into the user's own month directory, and tell the owner nothing - recreating
exactly the silent divergence the snapshot exists to prevent. Keeping it in
place instead would store an edit the owner never sees and the web app replaces
the next time it looks. The bridge has no route to the owner, so the honest
answer to a client is no.

Deleting one still works: that is CalDAV's version of no longer following it,
and it only ever removes the user's own snapshot.

- `readObjects` collects `shared/` alongside `recurring/` and `tasks/`
- `shardFor` returns empty for content carrying the pointer, which `DavServlet`
  already turns into a 403 with a `valid-calendar-data` precondition

Tested with a new case in `CalDavTests`: the snapshot appears in a PROPFIND,
reads back as the owner's event, a PUT returns 403, and afterwards the file is
still in `shared/` with no copy filed under the user's own month.
`CalDavTests` 4/4, `CardDavTests` 2/2, `WebdavTests` 2/2 - the three suites that
exercise `AppDataStore`.